### PR TITLE
Add hello-agent E2E demo + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Something is broken
+labels: bug
+---
+
+## What happened
+
+## Expected
+
+## Repro steps
+
+## Environment
+- OS:
+- node:
+- pnpm:
+
+## Logs / output

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions / discussion
+    url: https://t.me/
+    about: Use Telegram for fast iteration, then open an issue with an acceptance test.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Propose a new capability
+labels: enhancement
+---
+
+## Problem
+
+## Proposed solution
+
+## Acceptance test
+
+## Notes / links

--- a/examples/hello-agent/README.md
+++ b/examples/hello-agent/README.md
@@ -1,0 +1,40 @@
+# Hello Agent (E2E demo)
+
+Goal: one reproducible end-to-end path that proves a Starknet agent can:
+- connect to an RPC
+- read state (balance)
+- send a transaction (0-value self-transfer)
+
+This is intentionally minimal and meant to be the target that contributors can improve.
+
+## Setup
+
+```bash
+pnpm install
+pnpm approve-builds
+```
+
+## Configure
+
+Create `examples/hello-agent/.env`:
+
+```env
+STARKNET_RPC_URL=https://starknet-sepolia.public.blastapi.io
+STARKNET_ACCOUNT_ADDRESS=0x...
+STARKNET_PRIVATE_KEY=0x...
+```
+
+Notes:
+- Use Sepolia for safety.
+- The demo sends a 0-value STRK self-transfer, it should be harmless but still proves tx plumbing.
+
+## Run
+
+```bash
+pnpm demo:hello-agent
+```
+
+## Expected output
+- prints address
+- prints STRK balance
+- prints tx hash and waits for acceptance

--- a/examples/hello-agent/index.mjs
+++ b/examples/hello-agent/index.mjs
@@ -1,0 +1,85 @@
+import 'dotenv/config';
+import { Account, RpcProvider, Contract, CallData, cairo, uint256 } from 'starknet';
+
+const env = {
+  STARKNET_RPC_URL: process.env.STARKNET_RPC_URL,
+  STARKNET_ACCOUNT_ADDRESS: process.env.STARKNET_ACCOUNT_ADDRESS,
+  STARKNET_PRIVATE_KEY: process.env.STARKNET_PRIVATE_KEY,
+};
+
+for (const k of Object.keys(env)) {
+  if (!env[k]) throw new Error(`Missing env var: ${k}`);
+}
+
+const provider = new RpcProvider({ nodeUrl: env.STARKNET_RPC_URL });
+const account = new Account({ provider, address: env.STARKNET_ACCOUNT_ADDRESS, signer: env.STARKNET_PRIVATE_KEY });
+
+// STRK (mainnet address). For Sepolia, STRK may differ; but 0-value transfer is used only as a tx exercise.
+// If STRK is not deployed on your network, set TOKEN_ADDRESS explicitly.
+const TOKEN_ADDRESS = process.env.TOKEN_ADDRESS || '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+
+const ERC20_ABI = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    inputs: [{ name: 'account', type: 'felt' }],
+    outputs: [{ name: 'balance', type: 'Uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'decimals',
+    type: 'function',
+    inputs: [],
+    outputs: [{ name: 'decimals', type: 'felt' }],
+    stateMutability: 'view',
+  },
+  {
+    name: 'transfer',
+    type: 'function',
+    inputs: [
+      { name: 'recipient', type: 'felt' },
+      { name: 'amount', type: 'Uint256' },
+    ],
+    outputs: [{ name: 'success', type: 'felt' }],
+  },
+];
+
+function formatAmount(raw, decimals) {
+  const s = raw.toString();
+  if (decimals === 0) return s;
+  const pad = s.padStart(decimals + 1, '0');
+  const whole = pad.slice(0, -decimals);
+  const frac = pad.slice(-decimals).replace(/0+$/, '');
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+async function main() {
+  console.log('hello-agent demo');
+  console.log('address:', account.address);
+  console.log('rpc:', env.STARKNET_RPC_URL);
+
+  const token = new Contract({ abi: ERC20_ABI, address: TOKEN_ADDRESS, providerOrAccount: provider });
+  const decimals = Number(await token.decimals());
+  const bal = await token.balanceOf(account.address);
+  const balBn = uint256.uint256ToBN(bal);
+  console.log('token:', TOKEN_ADDRESS);
+  console.log('balance:', formatAmount(balBn, decimals));
+
+  // 0-value self-transfer, used only to prove tx path.
+  const call = {
+    contractAddress: TOKEN_ADDRESS,
+    entrypoint: 'transfer',
+    calldata: CallData.compile({ recipient: account.address, amount: cairo.uint256(0) }),
+  };
+
+  console.log('sending 0-value self-transfer tx...');
+  const res = await account.execute(call);
+  console.log('tx:', res.transaction_hash);
+  await provider.waitForTransaction(res.transaction_hash);
+  console.log('done');
+}
+
+main().catch((err) => {
+  console.error(String(err));
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "demo:hello-agent": "node examples/hello-agent/index.mjs"
   },
   "devDependencies": {
     "typescript": "^5.9.0",

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --format esm --watch",
-    "test": "vitest"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "starknet": "^6.24.1",

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --format esm --watch",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
Adds a minimal end-to-end demo (RPC -> read balance -> send tx) under examples/hello-agent and a root script `pnpm demo:hello-agent`.

Also adds GitHub issue templates to push contributors toward acceptance tests.

Includes a small CI hygiene fix: package test scripts now run once (no watch) and a2a passes with no tests.