### PR TITLE
Scaffold-Stark reference app plan (Agent Console) + test script hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ starknet-agentic/
 ├── packages/
 │   ├── starknet-mcp-server/      # MCP server for Starknet tools
 │   └── starknet-a2a/             # A2A protocol adapter for Starknet agents
+├── examples/
+│   └── scaffold-stark-agentic/   # Reference app plan: Scaffold-Stark frontend for Agentic primitives
 ├── skills/                       # Starknet Skills Marketplace
 │   ├── starknet-wallet/          # Wallet management skill
 │   ├── starknet-defi/            # DeFi operations skill

--- a/examples/scaffold-stark-agentic/README.md
+++ b/examples/scaffold-stark-agentic/README.md
@@ -1,0 +1,50 @@
+# Scaffold-Stark x Starknet Agentic (reference app plan)
+
+Goal: use Scaffold-Stark as the fastest frontend chassis for Starknet Agentic primitives.
+
+This is a starter blueprint you can fork to ship an agent-facing dapp quickly.
+
+## Why Scaffold-Stark is useful for Starknet Agentic
+
+- Burner wallet + mainnetFork support (v2.1.0) makes it safe to test realistic flows.
+- Built-in write UX (now shows tx receipts) reduces debugging friction.
+- Hooks/components accelerate on-chain read/write and event history.
+
+## What we should ship as the first reference app (MVP)
+
+A minimal "Agent Console" that proves the full agent stack:
+1) Register identity (ERC-8004 IdentityRegistry)
+2) Show reputation/validation summary
+3) Execute a swap via avnu (optional paymaster)
+4) Show tx receipt + events
+
+## Minimal integration outline
+
+### Contracts
+- Use `packages/starknet-identity/erc8004-cairo` (already production-grade).
+- Deploy to Sepolia for demo.
+
+### Frontend
+- Use Scaffold-Stark 2 (Next.js app) and configure:
+  - network: Sepolia or mainnetFork
+  - RPC URLs in env
+  - externalContracts: ERC-8004 registry addresses + ABIs
+
+### Data model
+- Read identity metadata keys (agentName, agentType, capabilities, a2aEndpoint, etc).
+- Display feedback summary from ReputationRegistry.
+
+### Acceptance test
+- Fresh clone + 3 terminal workflow:
+  - `yarn chain` (or fork)
+  - `yarn deploy` (deploy ERC-8004 demo addresses)
+  - `yarn start`
+- In UI:
+  - register agent
+  - perform a swap quote + swap
+  - receipt appears, events visible
+
+## References
+- Scaffold-Stark repo: https://github.com/Scaffold-Stark/scaffold-stark-2
+- Release v2.1.0 notes: notes/starknet/scaffold-stark-release-log.md
+- AVNU docs digest: notes/avnu/avnu-docs-digest.md

--- a/examples/scaffold-stark-agentic/issue-template.md
+++ b/examples/scaffold-stark-agentic/issue-template.md
@@ -1,0 +1,27 @@
+## [Type]: Scaffold-Stark Agent Console (reference app)
+
+**Complexity:** M
+**Component:** TypeScript + Docs
+
+### Problem
+We need a Starknet-native, forkable reference app that demonstrates the Starknet Agentic stack end-to-end.
+
+### Context
+- Scaffold-Stark provides the fastest Next.js Starknet UX baseline, now with mainnetFork + burner wallet support and receipt UX fixed.
+- Starknet Agentic already has production ERC-8004 Cairo contracts.
+
+### Implementation Plan
+1) Create a minimal scaffold-stark based app under `examples/scaffold-stark-agentic/app/` (or a separate repo) using create-stark.
+2) Add ERC-8004 externalContracts wiring (identity/reputation/validation).
+3) Add one page: register agent + display metadata.
+4) Add one page: avnu quote + swap + receipt display.
+5) Document a deterministic Sepolia demo path.
+
+### Acceptance Criteria
+- [ ] New contributor can run the app and complete the two flows in <15 minutes
+- [ ] Receipts/events shown for register + swap tx
+- [ ] Code stays minimal, no custom wallet infra
+
+### Out of Scope
+- Execution bots, strategy logic, perps
+- Production deployment

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --format esm --watch",
-    "test": "vitest"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "starknet": "^6.24.1",

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "tsup src/index.ts --format esm --watch",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
Adds an examples/scaffold-stark-agentic blueprint for using Scaffold-Stark as the fastest frontend chassis for Starknet Agentic primitives (ERC-8004 identity/reputation + avnu swap + receipts).

Also fixes TS package test scripts to run once in CI:
- starknet-a2a: vitest run --passWithNoTests
- starknet-mcp-server: vitest run

Context: Scaffold-Stark v2.1.0 now supports mainnetFork with burner wallets and shows receipts on the write tab, ideal for realistic agent-console testing.