### PR TITLE
fix: repair pnpm lockfile for Vercel

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,7 +148,7 @@ importers:
         version: 9.39.2(jiti@1.21.7)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(typescript@5.9.3)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.0
         version: 5.9.3


### PR DESCRIPTION
Fixes pnpm lockfile entry so Vercel pnpm install no longer fails with ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY. This was surfaced in the Vercel preview logs on PR #37 and tracked in #36.

Changes:
- Regenerate pnpm lockfile with pnpm 10 to add the missing tsup peer set entry.

Refs: #36
