### PR TITLE
fix(vercel): allow website install without lockfile

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "pnpm build",
-  "installCommand": "npm i -g pnpm@10.28.2 && pnpm install --frozen-lockfile",
+  "installCommand": "npm i -g pnpm@10.28.2 && pnpm install --no-frozen-lockfile",
   "outputDirectory": ".next",
   "framework": "nextjs"
 }


### PR DESCRIPTION
Summary: avoid frozen-lockfile failures when Vercel root directory is website by allowing pnpm to generate a lockfile there. Tests: not run (config change only).
