### PR TITLE
chore: add CodeRabbit advisory config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: false


### PR DESCRIPTION
## Summary
- add `.coderabbit.yaml` with a low-noise review profile
- keep CodeRabbit in advisory mode (`request_changes_workflow: false`)
- disable draft auto-reviews to reduce noise

## Why
- get AI review signal without turning it into a merge blocker
- keep velocity while improving review quality

## Scope
- config only; no CI gate or branch protection changes
