### PR TITLE
docs(readme): rewrite root README to reflect current repo state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Starknet Agentic
 
-Infrastructure for building AI agents that can act on Starknet.
+Open-source stack for giving AI agents wallets, identity, reputation, and execution rails on Starknet.
 
 ## What This Repo Is
 


### PR DESCRIPTION
## Summary

Rewrites the top-level README to be factual, concise, and operator-focused.

- Removes pitch-deck style sections and stale claims
- Adds a clear "what this repo contains" section
- Adds a status table with current component coverage snapshots
- Adds practical quick-start commands that match current CI/tooling
- Fixes repository layout to current paths (contracts/erc8004-cairo, contracts/huginn-registry, etc.)
- Keeps contract-specific deployment/address details delegated to contract READMEs

## Why

The previous README mixed aspirational architecture with outdated paths/status, which made first-use onboarding harder and introduced ambiguity. This rewrite is intended to let contributors understand the repo and run checks quickly.

## Scope

- Docs-only: README.md
- No code or CI behavior changes
