### PR TITLE
fix(identity): require token existence in token_uri

### DIFF
--- a/contracts/erc8004-cairo/src/identity_registry.cairo
+++ b/contracts/erc8004-cairo/src/identity_registry.cairo
@@ -523,6 +523,7 @@ pub mod IdentityRegistry {
         }
 
         fn token_uri(self: @ContractState, token_id: u256) -> ByteArray {
+            assert(self.erc721.exists(token_id), 'Token does not exist');
             // Return our custom stored URI
             self.token_uris.entry(token_id).read()
         }

--- a/contracts/erc8004-cairo/tests/test_identity_registry.cairo
+++ b/contracts/erc8004-cairo/tests/test_identity_registry.cairo
@@ -482,6 +482,14 @@ fn test_set_agent_uri_unauthorized() {
     stop_cheat_caller_address(registry_address);
 }
 
+#[test]
+#[should_panic(expected: 'Token does not exist')]
+fn test_token_uri_nonexistent_token_reverts() {
+    let (_, _, registry_address) = deploy_registry();
+    let metadata_dispatcher = IERC721MetadataDispatcher { contract_address: registry_address };
+    metadata_dispatcher.token_uri(999);
+}
+
 // ============ Agent Wallet Tests ============
 
 #[test]


### PR DESCRIPTION
## Summary
- Harden `IdentityRegistry` metadata behavior by making `token_uri` revert for non-existent tokens.
- Aligns behavior with expected ERC721 metadata semantics (avoid silent empty URI on missing token).

## TDD Flow
1. Added failing test first:
   - `test_token_uri_nonexistent_token_reverts`
2. Implemented fix in `token_uri`:
   - `assert(self.erc721.exists(token_id), 'Token does not exist');`
3. Re-ran targeted + full contract tests.

## Validation
- `snforge test test_token_uri_nonexistent_token_reverts` -> pass
- `contracts/erc8004-cairo`: `snforge test` -> **119 passed, 0 failed**

## Files
- `contracts/erc8004-cairo/src/identity_registry.cairo`
- `contracts/erc8004-cairo/tests/test_identity_registry.cairo`
