### PR TITLE
feat(erc8004): add paginated bounded summary APIs

### DIFF
--- a/contracts/erc8004-cairo/src/interfaces/reputation_registry.cairo
+++ b/contracts/erc8004-cairo/src/interfaces/reputation_registry.cairo
@@ -102,6 +102,23 @@ pub trait IReputationRegistry<TState> {
         tag2: ByteArray,
     ) -> (u64, i128, u8);
 
+    /// Get aggregated summary of feedback over a bounded window.
+    /// Returns (count, summaryValue, summaryValueDecimals, truncated)
+    /// - client_offset/client_limit paginate the client list
+    /// - feedback_offset/feedback_limit paginate feedback entries per client
+    /// - truncated=true means additional matching data exists outside this window
+    fn get_summary_paginated(
+        self: @TState,
+        agent_id: u256,
+        client_addresses: Span<ContractAddress>,
+        tag1: ByteArray,
+        tag2: ByteArray,
+        client_offset: u32,
+        client_limit: u32,
+        feedback_offset: u64,
+        feedback_limit: u64,
+    ) -> (u64, i128, u8, bool);
+
     /// Read a single feedback entry
     /// Returns (value, valueDecimals, tag1, tag2, isRevoked)
     fn read_feedback(

--- a/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
+++ b/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
@@ -104,6 +104,20 @@ pub trait IValidationRegistry<TState> {
         tag: ByteArray,
     ) -> (u64, u8);
 
+    /// @notice Get aggregated validation statistics for an agent using request pagination
+    /// @param request_offset Starting request index in the agent validation list
+    /// @param request_limit Maximum number of requests to scan
+    /// @return (count, avg_response, truncated)
+    /// - truncated=true means there are additional requests after this page
+    fn get_summary_paginated(
+        self: @TState,
+        agent_id: u256,
+        validator_addresses: Span<ContractAddress>,
+        tag: ByteArray,
+        request_offset: u64,
+        request_limit: u64,
+    ) -> (u64, u8, bool);
+
     /// @notice Get all validation request hashes for an agent
     fn get_agent_validations(self: @TState, agent_id: u256) -> Array<u256>;
 


### PR DESCRIPTION
## Summary
Adds additive, non-breaking paginated summary APIs to reduce unbounded read risk on large datasets while preserving existing interface behavior.

### New APIs
- ReputationRegistry:
  - `get_summary_paginated(...) -> (count, summary_value, summary_value_decimals, truncated)`
- ValidationRegistry:
  - `get_summary_paginated(...) -> (count, avg_response, truncated)`

### Semantics
- Existing `get_summary(...)` methods are unchanged.
- New paginated methods use explicit windows (`offset`/`limit`) and return `truncated=true` when additional data remains outside the scanned window.

## TDD-first changes
Added tests for both contracts before finalizing implementation:
- `test_get_summary_paginated_client_window`
- `test_get_summary_paginated_full_window_not_truncated`
- `test_get_summary_paginated_window`
- `test_get_summary_paginated_full_window_not_truncated`

## Validation
- `contracts/erc8004-cairo`: `snforge test` -> **122 passed, 0 failed**
- `contracts/agent-account`: `snforge test` -> **96 passed, 0 failed**

## Scope notes
This PR addresses bounded/paginated summary APIs specifically.
Unbounded `read_all_feedback` and `get_response_count` can be handled in a dedicated follow-up PR to keep this review focused.
