### PR TITLE
fix: production-readiness audit — docs accuracy, code safety, test coverage

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@95ba816a4383938e2338cb793773d4670011b65f # v1
         with:
-          scarb-version: "2.12.1"
+          scarb-version: "2.14.0"
 
       - name: Setup Starknet Foundry
         uses: foundry-rs/setup-snfoundry@84390a1602c157576ceefa6f9cfcb8b0504c94c7 # v3
@@ -58,7 +58,7 @@ jobs:
 
       - name: Cairo tests (erc8004)
         id: cairo_identity
-        working-directory: packages/starknet-identity/erc8004-cairo
+        working-directory: contracts/erc8004-cairo
         run: snforge test
         continue-on-error: true
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -45,7 +45,7 @@ Starknet Agentic implements all three layers with Starknet as the settlement and
 
 | Asset | Where | What We Use |
 |-------|-------|-------------|
-| ERC-8004 Cairo contracts | [erc8004-cairo](https://github.com/Akashneelesh/erc8004-cairo) | Identity, Reputation, Validation registries. 74 unit tests + 47 E2E tests. Production-ready on Sepolia. |
+| ERC-8004 Cairo contracts | [erc8004-cairo](https://github.com/Akashneelesh/erc8004-cairo) | Identity, Reputation, Validation registries. 131+ unit tests + 47 E2E tests. Production-ready on Sepolia. |
 | avnu Skill | [avnu-skill](https://github.com/avnu-labs/avnu-skill) | Swap, DCA, staking, gasless/gasfree patterns. Documentation + scripts. |
 | Daydreams StarknetChain | [daydreams/defai](https://github.com/daydreamsai/daydreams) | Minimal IChain (read/write) using starknet.js v6. We extend this. |
 | Lucid Agents Extension System | [lucid-agents](https://github.com/daydreamsai/lucid-agents) | WalletConnector, PaymentsRuntime, EntrypointDef interfaces. We implement for Starknet. |
@@ -56,7 +56,7 @@ Starknet Agentic implements all three layers with Starknet as the settlement and
 
 | Gap | Priority | Status |
 |-----|----------|--------|
-| Agent Account contract | HIGH | **EXISTS** - needs tests, see `contracts/agent-account/` |
+| Agent Account contract | HIGH | **TESTED** (110 tests) - needs Sepolia deployment, see `contracts/agent-account/` |
 | Starknet MCP server with DeFi | HIGH | **DONE** - 9 tools implemented including swap, quote |
 | Starknet wallet skill | HIGH | **DONE** - complete at `skills/starknet-wallet/` |
 | A2A support for Starknet agents | MEDIUM | **DONE** - functional at `packages/starknet-a2a/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Infrastructure layer for AI agents on Starknet. Provides Cairo smart contracts (
 |-----------|-----------|---------|
 | Smart contracts | Cairo (Scarb + snforge) | Cairo 2.14.0, Scarb 2.14.0 |
 | Contract deps | OpenZeppelin Cairo | v3.0.0 |
-| TypeScript packages | pnpm workspaces, tsup | Node 18+ |
+| TypeScript packages | pnpm workspaces, tsup | Node 20+ |
 | MCP server | `@modelcontextprotocol/sdk` | ^1.0.0 |
 | Starknet interaction | starknet.js | ^8.9.1 |
 | DeFi aggregation | `@avnu/avnu-sdk` | ^4.0.1 |
@@ -37,7 +37,7 @@ starknet-agentic/
 │   │   ├── src/                          # Contract source (identity, reputation, validation)
 │   │   ├── tests/                        # Unit tests (snforge)
 │   │   └── e2e-tests/                    # E2E tests (Sepolia)
-│   ├── agent-account/                    # Agent Account contract (TESTED — 96 tests)
+│   ├── agent-account/                    # Agent Account contract (TESTED — 110 tests)
 │   └── huginn-registry/                  # Thought provenance registry (WIP)
 ├── skills/
 │   ├── starknet-wallet/                  # Wallet management skill (COMPLETE)
@@ -47,7 +47,7 @@ starknet-agentic/
 │   └── starknet-identity/                # Identity & reputation skill (TEMPLATE)
 ├── examples/
 │   ├── hello-agent/                      # Minimal E2E proof (WORKING)
-│   ├── defi-agent/                       # Production arb bot (FLAGSHIP - 8800+ lines)
+│   ├── defi-agent/                       # Arbitrage bot example (~337 lines)
 │   └── scaffold-stark-agentic/           # Frontend reference
 ├── references/
 │   ├── agentskills/                      # AgentSkills format specs
@@ -62,7 +62,7 @@ starknet-agentic/
 └── package.json                          # Root monorepo (pnpm workspaces)
 ```
 
-NOTE: The Agent Account contract at `contracts/agent-account/` (402 lines) has 96 tests across 3 test suites (test_agent_account, test_execute_validate, test_security).
+NOTE: The Agent Account contract at `contracts/agent-account/` (~570 lines main contract) has 110 tests across 4 test suites (test_agent_account, test_execute_validate, test_security, test_agent_account_factory).
 
 </structure>
 
@@ -140,7 +140,9 @@ This project implements three converging agent standards:
 
 | Contract | File | Lines | Purpose |
 |----------|------|-------|---------|
-| AgentAccount | `agent_account.cairo` | 402 | Full account with session keys, timelocked upgrades, identity binding |
+| AgentAccount | `agent_account.cairo` | 570 | Full account with session keys, timelocked upgrades, identity binding |
+| AgentAccountFactory | `agent_account_factory.cairo` | 169 | Factory for deploying agent accounts |
+| SessionKey | `session_key.cairo` | 163 | Session key data structure and validation |
 
 ### ERC-8004 Cairo Contracts (`contracts/erc8004-cairo/src/`)
 
@@ -243,20 +245,20 @@ Always consult `references/` before relying on training data for Starknet-specif
 
 | Component | Status | Location |
 |-----------|--------|----------|
-| ERC-8004 Cairo contracts | **Production** (126+ unit + 47 E2E tests) | `contracts/erc8004-cairo/` |
+| ERC-8004 Cairo contracts | **Production** (131+ unit + 47 E2E tests) | `contracts/erc8004-cairo/` |
 | MCP server | **Production** (9 tools, 1,600+ lines) | `packages/starknet-mcp-server/` |
 | A2A adapter | **Functional** (437 lines) | `packages/starknet-a2a/` |
 | Agent Passport client | **Functional** (142 lines) | `packages/starknet-agent-passport/` |
 | X-402 Starknet signing | **Functional** (110 lines) | `packages/x402-starknet/` |
 | Prediction arb scanner | **MVP** (296 lines) | `packages/prediction-arb-scanner/` |
-| Agent Account contract | **Tested** (402 lines, 96 tests) | `contracts/agent-account/` |
+| Agent Account contract | **Tested** (~570 lines, 110 tests) | `contracts/agent-account/` |
 | Skill: starknet-wallet | **Complete** (465 lines) | `skills/starknet-wallet/` |
 | Skill: starknet-mini-pay | **Complete** (Python CLI + Telegram bot) | `skills/starknet-mini-pay/` |
 | Skill: starknet-anonymous-wallet | **Complete** (271 lines) | `skills/starknet-anonymous-wallet/` |
 | Skill: starknet-defi | **Template** (needs expansion) | `skills/starknet-defi/` |
 | Skill: starknet-identity | **Template** (needs expansion) | `skills/starknet-identity/` |
 | Example: hello-agent | **Working** (E2E proof) | `examples/hello-agent/` |
-| Example: defi-agent | **Production** (8800+ lines, flagship) | `examples/defi-agent/` |
+| Example: defi-agent | **Working** (~337 lines, arb example) | `examples/defi-agent/` |
 | Website | **Scaffolded** (Next.js 16 + landing content) | `website/` |
 | Docs & specs | **Complete** (updated 2026-02-06) | `docs/` |
 | CI/CD | **Implemented** | `.github/workflows/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ Preferred:
 - [ ] `pnpm -r test` passes (or scoped test target documented)
 - [ ] No unrelated refactors
 
+## Commit messages
+
+Use [conventional commits](https://www.conventionalcommits.org/):
+
+```
+feat: add starknet_get_events MCP tool
+fix: handle zero-balance tokens in batch query
+docs: update deployment guide for Sepolia
+chore: bump starknet.js to 8.10.0
+test: add edge case coverage for arb scanner
+```
+
+Common prefixes: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`.
+
 ## Style
 
 - Keep PRs small (one logical change).

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Snapshot at time of this README update:
 
 | Area | Path | Status |
 |---|---|---|
-| Agent Account contract | `contracts/agent-account` | Active, tested (96 Cairo tests) |
-| ERC-8004 Cairo contracts | `contracts/erc8004-cairo` | Active, tested (126 Cairo tests) |
+| Agent Account contract | `contracts/agent-account` | Active, tested (110 Cairo tests) |
+| ERC-8004 Cairo contracts | `contracts/erc8004-cairo` | Active, tested (131+ unit + 47 E2E tests) |
 | Huginn registry contract | `contracts/huginn-registry` | Active, tested (6 Cairo tests) |
 | MCP package | `packages/starknet-mcp-server` | Active |
 | A2A package | `packages/starknet-a2a` | Active |

--- a/agents.md
+++ b/agents.md
@@ -131,7 +131,7 @@ pending --> in_progress --> in_review --> done
 
 ### Cairo Contract Tasks
 - Always read existing contract code before modifying (understand component embedding pattern)
-- Run `snforge test` in `packages/starknet-identity/erc8004-cairo/` after every change
+- Run `snforge test` in `contracts/erc8004-cairo/` after every change
 - New contracts: follow the IdentityRegistry pattern for structure
 - Test pattern: `declare` -> `deploy` -> call via dispatcher -> assert
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -255,7 +255,7 @@ starknet-agentic/
 ├── packages/
 │   ├── starknet-mcp-server/     # MCP tools for AI agents
 │   ├── starknet-a2a/            # Agent-to-Agent protocol
-│   └── starknet-identity/       # ERC-8004 Cairo contracts
+│   └── starknet-agent-passport/  # ERC-8004 client library
 │
 ├── skills/                      # Reusable agent skills
 │   ├── starknet-wallet/        # Wallet management
@@ -375,7 +375,7 @@ Use gasless mode to pay gas in tokens instead of ETH.
 <details>
 <summary><b>Q: Is this production-ready?</b></summary>
 
-**Smart contracts:** Yes, ERC-8004 contracts are audited and tested (121 tests).
+**Smart contracts:** Yes, ERC-8004 contracts are tested (131+ unit tests + 47 E2E tests).
 
 **MCP Server:** Yes, but always test thoroughly before mainnet.
 

--- a/docs/GOOD_FIRST_ISSUES.md
+++ b/docs/GOOD_FIRST_ISSUES.md
@@ -6,43 +6,7 @@ See [ROADMAP.md](ROADMAP.md) for the full feature roadmap.
 
 ---
 
-## 1) MCP Server: Add Vitest Tests
-
-**Goal:** Re-enable and write unit tests for the MCP server tools.
-
-**Context:** The MCP server has 9 implemented tools but tests are disabled.
-
-**Acceptance:**
-- [ ] Vitest configuration enabled in `packages/starknet-mcp-server/`
-- [ ] At least 3 tools have unit tests with mocked RPC/AVNU
-- [ ] `pnpm test` passes in package directory
-- [ ] Code coverage reported
-
-**Files:** `packages/starknet-mcp-server/src/`, `packages/starknet-mcp-server/vitest.config.ts`
-
-**Difficulty:** Medium
-
----
-
-## 2) Agent Account: Add snforge Tests
-
-**Goal:** Write snforge unit tests for the Agent Account contract.
-
-**Context:** Contract exists (140 lines) but has no tests. Needed before deployment.
-
-**Acceptance:**
-- [ ] Tests directory created at `contracts/agent-account/tests/`
-- [ ] At least 5 test cases covering session key and spending limit logic
-- [ ] `snforge test` passes
-- [ ] 80%+ coverage
-
-**Files:** `contracts/agent-account/src/`, `contracts/agent-account/tests/`
-
-**Difficulty:** Medium-Hard
-
----
-
-## 3) Skill: Complete starknet-defi Documentation
+## 1) Skill: Complete starknet-defi Documentation
 
 **Goal:** Expand the starknet-defi skill from template to full documentation.
 
@@ -60,7 +24,7 @@ See [ROADMAP.md](ROADMAP.md) for the full feature roadmap.
 
 ---
 
-## 4) Skill: Complete starknet-identity Documentation
+## 2) Skill: Complete starknet-identity Documentation
 
 **Goal:** Expand the starknet-identity skill with ERC-8004 integration details.
 
@@ -78,11 +42,11 @@ See [ROADMAP.md](ROADMAP.md) for the full feature roadmap.
 
 ---
 
-## 5) Example: defi-agent README
+## 3) Example: defi-agent README
 
-**Goal:** Create comprehensive documentation for the flagship defi-agent example.
+**Goal:** Create comprehensive documentation for the defi-agent example.
 
-**Context:** 8800+ lines of production code, minimal documentation.
+**Context:** ~337 lines demonstrating arbitrage patterns, needs better documentation.
 
 **Acceptance:**
 - [ ] README.md with architecture overview
@@ -96,25 +60,7 @@ See [ROADMAP.md](ROADMAP.md) for the full feature roadmap.
 
 ---
 
-## 6) CI: Add Cairo Contract Build to Workflow
-
-**Goal:** Ensure Cairo contracts compile in CI.
-
-**Context:** CI runs TypeScript builds but not Cairo.
-
-**Acceptance:**
-- [ ] GitHub Action installs Scarb 2.12.1
-- [ ] `scarb build` runs for `packages/starknet-identity/erc8004-cairo/`
-- [ ] `scarb build` runs for `contracts/agent-account/`
-- [ ] CI fails if contracts don't compile
-
-**Files:** `.github/workflows/ci.yml`
-
-**Difficulty:** Easy-Medium
-
----
-
-## 7) Docs: Auto-Generated Changelog Setup
+## 4) Docs: Auto-Generated Changelog Setup
 
 **Goal:** Set up automated changelog generation from conventional commits.
 
@@ -132,19 +78,38 @@ See [ROADMAP.md](ROADMAP.md) for the full feature roadmap.
 
 ---
 
-## 8) Package: Upgrade to starknet.js v8
+## 5) Agent Account: Sepolia Deployment
 
-**Goal:** Upgrade one package from v6/v7 to v8.
+**Goal:** Deploy the Agent Account contract to Sepolia testnet.
 
-**Context:** Packages use mixed versions. Target: v8 for all.
+**Context:** Contract is fully tested (110 tests) but not yet deployed.
 
 **Acceptance:**
-- [ ] Pick one package (e.g., `starknet-mcp-server`)
-- [ ] Upgrade starknet.js dependency to v8
-- [ ] Fix any type errors from breaking changes
-- [ ] Verify builds and any existing tests pass
+- [ ] Deployment script created at `contracts/agent-account/scripts/`
+- [ ] Contract deployed to Sepolia
+- [ ] Deployed address documented in README
+- [ ] Basic interaction script verifying deployment works
 
-**Files:** `packages/<chosen-package>/package.json`, source files as needed
+**Files:** `contracts/agent-account/scripts/`, `contracts/agent-account/README.md`
+
+**Difficulty:** Medium
+
+---
+
+## 6) Package: Expand Test Coverage for starknet-a2a
+
+**Goal:** Add comprehensive unit tests for the A2A adapter.
+
+**Context:** Currently only has smoke tests. Needs mocked RPC calls and edge case coverage.
+
+**Acceptance:**
+- [ ] Mock starknet.js `Contract` and `RpcProvider`
+- [ ] Test `generateAgentCard()` with mocked contract calls
+- [ ] Test `getTaskStatus()` for all task states
+- [ ] Test `registerAgent()` with mocked account execution
+- [ ] `pnpm test` passes
+
+**Files:** `packages/starknet-a2a/__tests__/`
 
 **Difficulty:** Medium
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,53 +18,15 @@ Core infrastructure features required for v1.0 release. MVP definition: MCP serv
 
 ---
 
-### 1.0 Upgrade starknet.js to v8 Across All Packages
+### 1.0 ~~Upgrade starknet.js to v8 Across All Packages~~ DONE
 
-**Description**: Standardize all TypeScript packages on starknet.js v8 (latest) to ensure consistency and access to latest features.
-
-**Requirements**:
-- [ ] Audit current starknet.js versions across packages (currently mixed v6/v7/v8)
-- [ ] Upgrade `packages/starknet-mcp-server/` to starknet.js v8
-- [ ] Upgrade `packages/starknet-a2a/` to starknet.js v8
-- [ ] Upgrade `packages/starknet-agent-passport/` to starknet.js v8
-- [ ] Upgrade `packages/x402-starknet/` to starknet.js v8
-- [ ] Upgrade `examples/hello-agent/` to starknet.js v8
-- [ ] Upgrade `examples/defi-agent/` to starknet.js v8
-- [ ] Update type definitions where breaking changes occurred
-- [ ] Run all existing tests to verify no regressions
-- [ ] Update documentation with v8-specific patterns
-
-**Implementation Notes**:
-- starknet.js v8 has breaking changes in Account class and type definitions
-- Some packages may need Cairo type import updates
-- Keep AVNU SDK compatibility in mind (check their starknet.js peer dependency)
+All TypeScript packages are already standardized on starknet.js ^8.9.1.
 
 ---
 
-### 1.1 Enable and Write MCP Server Tests
+### 1.1 ~~Enable and Write MCP Server Tests~~ DONE
 
-**Description**: The MCP server has 9 implemented tools but tests are currently disabled. Enable and expand test coverage.
-
-**Requirements**:
-- [ ] Re-enable Vitest configuration in `packages/starknet-mcp-server/`
-- [ ] Write unit tests for `starknet_get_balance` tool
-- [ ] Write unit tests for `starknet_get_balances` tool
-- [ ] Write unit tests for `starknet_transfer` tool
-- [ ] Write unit tests for `starknet_call_contract` tool
-- [ ] Write unit tests for `starknet_invoke_contract` tool
-- [ ] Write unit tests for `starknet_swap` tool
-- [ ] Write unit tests for `starknet_get_quote` tool
-- [ ] Write unit tests for `starknet_estimate_fee` tool
-- [ ] Write unit tests for `x402_starknet_sign_payment_required` tool
-- [ ] Mock RPC provider and AVNU SDK for deterministic tests
-- [ ] Achieve minimum 80% code coverage
-- [ ] Add integration tests against Sepolia testnet (optional, for CI)
-
-**Implementation Notes**:
-- Current tests are disabled in package.json (`"test": "echo \"Tests disabled\""`)
-- Use Vitest with starknet.js mocks
-- AVNU SDK responses should be mocked for unit tests
-- Consider separate test:unit and test:integration scripts
+MCP server tests are fully implemented with 7 test files covering handlers, tools, services, providers, and utils. Vitest is configured with 80% coverage thresholds.
 
 ---
 
@@ -124,7 +86,7 @@ Core infrastructure features required for v1.0 release. MVP definition: MCP serv
 - [ ] Add production deployment guide (systemd, Docker, cloud)
 
 **Implementation Notes**:
-- defi-agent is 8800+ lines and production-ready
+- defi-agent is ~337 lines demonstrating arbitrage patterns
 - Demonstrates triangular arbitrage with ETH/STRK
 - Includes risk management (spending limits, min profit thresholds)
 - Good showcase for Starknet's low fees enabling high-frequency strategies
@@ -196,28 +158,27 @@ Features that enhance the platform but are not required for v1.0 release.
 
 ---
 
-### 2.1 Agent Account Contract Testing and Deployment
+### 2.1 Agent Account Contract Deployment
 
-**Description**: The Agent Account contract exists (140 lines) but has no tests. Add comprehensive tests and deploy to Sepolia.
+**Description**: The Agent Account contract is fully tested (110 tests across 4 suites). Next step is Sepolia deployment.
 
 **Requirements**:
-- [ ] Create `contracts/agent-account/tests/` directory
-- [ ] Write snforge tests for session key registration
-- [ ] Write snforge tests for session key revocation
-- [ ] Write snforge tests for spending limit enforcement
-- [ ] Write snforge tests for time bounds validation
-- [ ] Write snforge tests for emergency revoke mechanism
-- [ ] Write snforge tests for agent ID linking
-- [ ] Achieve minimum 80% code coverage
+- [x] ~~Create tests directory~~ — 4 test files exist in `contracts/agent-account/tests/`
+- [x] ~~Write snforge tests for session key registration~~
+- [x] ~~Write snforge tests for session key revocation~~
+- [x] ~~Write snforge tests for spending limit enforcement~~
+- [x] ~~Write snforge tests for time bounds validation~~
+- [x] ~~Write snforge tests for emergency revoke mechanism~~
+- [x] ~~Write snforge tests for agent ID linking~~
 - [ ] Create Sepolia deployment script
 - [ ] Deploy to Sepolia testnet
 - [ ] Document deployed contract address
 
 **Implementation Notes**:
-- Contract exists at `contracts/agent-account/src/agent_account.cairo`
+- Contract at `contracts/agent-account/src/agent_account.cairo` (~570 lines)
+- Tests: test_agent_account (43), test_execute_validate (20), test_security (33), test_agent_account_factory (14)
 - Uses OpenZeppelin AccountComponent
 - Single-level session keys (owner -> agent, no nested delegation)
-- Sepolia deployment OK without full test coverage; mainnet requires tests
 
 ---
 
@@ -288,18 +249,18 @@ Features that enhance the platform but are not required for v1.0 release.
 **Description**: Improve CI/CD pipeline with additional checks and automation.
 
 **Requirements**:
-- [ ] Add Cairo contract build verification to CI
-- [ ] Add snforge test execution to CI
+- [x] ~~Add Cairo contract build verification to CI~~ — done in `ci.yml`
+- [x] ~~Add snforge test execution to CI~~ — done in `ci.yml`
+- [x] ~~Add automated npm publishing on release~~ — done in `publish.yml`
 - [ ] Add starknet.js version consistency check
 - [ ] Add dependency vulnerability scanning
-- [ ] Add automated npm publishing on release
 - [ ] Add automated ClawHub publishing on release
 - [ ] Add test coverage reporting
 
 **Implementation Notes**:
-- Current CI at `.github/workflows/ci.yml` and `publish.yml`
-- Scarb and snforge need to be installed in CI environment
-- Consider caching for faster builds
+- CI pipeline at `.github/workflows/ci.yml` runs TS + Cairo builds + tests
+- `publish.yml` publishes 3 packages to npm on release
+- `health-check.yml` runs daily cron checks
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -20,8 +20,8 @@ This specification describes both implemented features and planned designs:
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Agent Account Contract | **Exists (Untested)** | Code complete, needs tests before deployment |
-| Agent Registry (ERC-8004) | **Production** | 74 unit + 47 E2E tests, deployed on Sepolia |
+| Agent Account Contract | **Tested** | 110 tests across 4 test suites |
+| Agent Registry (ERC-8004) | **Production** | 131+ unit + 47 E2E tests, deployed on Sepolia |
 | MCP Server | **Production** | 9 tools implemented |
 | A2A Adapter | **Functional** | Basic implementation complete |
 | Framework Extensions | **Planned** | Deferred to v2.0 |
@@ -81,7 +81,7 @@ Layer 0: Starknet L2 (native AA, ZK proofs, paymaster)
 
 ### 3.1 Agent Account Contract
 
-**Status:** Exists at `contracts/agent-account/` (140 lines). Needs tests before deployment.
+**Status:** Tested at `contracts/agent-account/` (~570 lines main contract, 110 tests across 4 suites).
 
 **Purpose:** A purpose-built Starknet account contract for AI agents that extends native AA with agent-specific features.
 

--- a/packages/prediction-arb-scanner/__tests__/scanner.test.ts
+++ b/packages/prediction-arb-scanner/__tests__/scanner.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { scanArbs } from "../src/index.js";
+import { scanArbs, buildVenueSnapshot, type InputSnapshot } from "../src/index.js";
 import { polymarketFixture, raizeFixture, limitlessFixture } from "../src/fixtures.js";
+import { normalizeTitle, canonicalEventKey } from "../src/normalize.js";
+import { computeMid, computeSpreadBps, computeEdgeBpsGross } from "../src/score.js";
+import { pickHedgeRecipe, hedgeRecipeToString } from "../src/hedge.js";
 
-describe("prediction-arb-scanner MVP0", () => {
+// ============================================================================
+// scanArbs — core scanner logic
+// ============================================================================
+
+describe("scanArbs", () => {
   it("matches cross-venue event and emits Starknet hedge recipe", () => {
     const opps = scanArbs({
       snapshots: [polymarketFixture, raizeFixture, limitlessFixture],
@@ -16,12 +23,285 @@ describe("prediction-arb-scanner MVP0", () => {
     expect(opp.venueMarketIds.polymarket).toBeDefined();
     expect(opp.venueMarketIds.raize).toBeDefined();
 
-    // Liquidity sanity: must have a depth proxy
     const hasTopOfBook = opp.snapshots.every((s) => (s.depth.topOfBookUsd ?? 0) > 0);
     expect(hasTopOfBook).toBe(true);
 
-    // Hedge recipe present and Starknet-specific
     expect(opp.starknetHedgeRecipe.toLowerCase()).toContain("starknet");
     expect(opp.starknetHedgeRecipe.length).toBeGreaterThan(20);
+  });
+
+  it("returns empty array when only one venue snapshot provided", () => {
+    const opps = scanArbs({
+      snapshots: [polymarketFixture],
+      minEdgeBps: 25,
+    });
+    expect(opps).toEqual([]);
+  });
+
+  it("returns empty array when edge is below threshold", () => {
+    const snap1: InputSnapshot = {
+      ...polymarketFixture,
+      venue: "polymarket",
+      bestBid: 0.50,
+      bestAsk: 0.52,
+    };
+    const snap2: InputSnapshot = {
+      ...raizeFixture,
+      venue: "raize",
+      bestBid: 0.50,
+      bestAsk: 0.52,
+    };
+    const opps = scanArbs({ snapshots: [snap1, snap2], minEdgeBps: 25 });
+    expect(opps).toEqual([]);
+  });
+
+  it("uses default minEdgeBps of 25 when not specified", () => {
+    const snap1: InputSnapshot = {
+      ...polymarketFixture,
+      venue: "polymarket",
+      bestBid: 0.50,
+      bestAsk: 0.52,
+    };
+    const snap2: InputSnapshot = {
+      ...raizeFixture,
+      venue: "raize",
+      bestBid: 0.51,
+      bestAsk: 0.53,
+    };
+    // mid1 = 0.51, mid2 = 0.52 => edge = 100 bps
+    const opps = scanArbs({ snapshots: [snap1, snap2] });
+    expect(opps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles snapshots with missing bid/ask", () => {
+    const snap1: InputSnapshot = {
+      ...polymarketFixture,
+      venue: "polymarket",
+      bestBid: undefined,
+      bestAsk: undefined,
+    };
+    const snap2: InputSnapshot = {
+      ...raizeFixture,
+      venue: "raize",
+      bestBid: undefined,
+      bestAsk: undefined,
+    };
+    const opps = scanArbs({ snapshots: [snap1, snap2], minEdgeBps: 25 });
+    expect(opps).toEqual([]);
+  });
+
+  it("marks opportunity as not starknet native when no raize venue", () => {
+    // Use identical title so they match into the same canonical event key
+    const commonTitle = "STRK Token Price above $1 by 2026-12-31?";
+    const snap1: InputSnapshot = {
+      ...polymarketFixture,
+      venue: "polymarket",
+      eventTitle: commonTitle,
+      bestBid: 0.40,
+      bestAsk: 0.42,
+    };
+    const snap2: InputSnapshot = {
+      ...limitlessFixture,
+      venue: "limitless",
+      eventTitle: commonTitle,
+      bestBid: 0.50,
+      bestAsk: 0.52,
+    };
+    const opps = scanArbs({ snapshots: [snap1, snap2], minEdgeBps: 25 });
+    expect(opps.length).toBeGreaterThanOrEqual(1);
+    expect(opps[0].starknetNative).toBe(false);
+  });
+
+  it("validates opportunity against Zod schema (no throws)", () => {
+    const opps = scanArbs({
+      snapshots: [polymarketFixture, raizeFixture, limitlessFixture],
+      minEdgeBps: 1,
+    });
+    expect(opps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("populates edgeBpsGross and impliedProbDelta correctly", () => {
+    const opps = scanArbs({
+      snapshots: [polymarketFixture, raizeFixture],
+      minEdgeBps: 1,
+    });
+    expect(opps.length).toBeGreaterThanOrEqual(1);
+    const opp = opps[0];
+    expect(opp.edgeBpsGross).toBeGreaterThan(0);
+    expect(typeof opp.impliedProbDelta).toBe("number");
+  });
+});
+
+// ============================================================================
+// buildVenueSnapshot
+// ============================================================================
+
+describe("buildVenueSnapshot", () => {
+  it("computes mid and spread from bid/ask", () => {
+    const snap = buildVenueSnapshot(polymarketFixture);
+    expect(snap.mid).toBeCloseTo(0.43, 2);
+    expect(snap.spreadBps).toBeDefined();
+    expect(snap.spreadBps!).toBeGreaterThan(0);
+  });
+
+  it("handles missing bid/ask gracefully", () => {
+    const input: InputSnapshot = {
+      ...polymarketFixture,
+      bestBid: undefined,
+      bestAsk: undefined,
+    };
+    const snap = buildVenueSnapshot(input);
+    expect(snap.mid).toBeUndefined();
+    expect(snap.spreadBps).toBeUndefined();
+  });
+
+  it("preserves depth data", () => {
+    const snap = buildVenueSnapshot(polymarketFixture);
+    expect(snap.depth.bids.length).toBeGreaterThan(0);
+    expect(snap.depth.asks.length).toBeGreaterThan(0);
+    expect(snap.depth.topOfBookUsd).toBe(500);
+  });
+});
+
+// ============================================================================
+// normalize — title normalization and canonical keys
+// ============================================================================
+
+describe("normalizeTitle", () => {
+  it("lowercases and trims whitespace", () => {
+    expect(normalizeTitle("  HELLO  WORLD  ")).toBe("hello world");
+  });
+
+  it("removes special characters except hyphens and colons", () => {
+    expect(normalizeTitle("Token > $1?")).toBe("token  1");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeTitle("")).toBe("");
+  });
+});
+
+describe("canonicalEventKey", () => {
+  it("produces deterministic hash for same inputs", () => {
+    const key1 = canonicalEventKey({ title: "Hello", outcomes: ["YES"] });
+    const key2 = canonicalEventKey({ title: "Hello", outcomes: ["YES"] });
+    expect(key1).toBe(key2);
+  });
+
+  it("produces different hash for different titles", () => {
+    const key1 = canonicalEventKey({ title: "Hello", outcomes: ["YES"] });
+    const key2 = canonicalEventKey({ title: "World", outcomes: ["YES"] });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("normalizes title before hashing", () => {
+    const key1 = canonicalEventKey({ title: "Hello World", outcomes: ["YES"] });
+    const key2 = canonicalEventKey({ title: "  hello  world  ", outcomes: ["YES"] });
+    expect(key1).toBe(key2);
+  });
+
+  it("sorts outcomes for determinism", () => {
+    const key1 = canonicalEventKey({ title: "X", outcomes: ["a", "b"] });
+    const key2 = canonicalEventKey({ title: "X", outcomes: ["b", "a"] });
+    expect(key1).toBe(key2);
+  });
+});
+
+// ============================================================================
+// score — math helpers
+// ============================================================================
+
+describe("computeMid", () => {
+  it("returns average of bid and ask", () => {
+    expect(computeMid(0.4, 0.6)).toBe(0.5);
+  });
+
+  it("returns undefined when bid is missing", () => {
+    expect(computeMid(undefined, 0.6)).toBeUndefined();
+  });
+
+  it("returns undefined when ask is missing", () => {
+    expect(computeMid(0.4, undefined)).toBeUndefined();
+  });
+});
+
+describe("computeSpreadBps", () => {
+  it("computes spread in basis points", () => {
+    expect(computeSpreadBps(0.40, 0.60)).toBeCloseTo(4000, 0);
+  });
+
+  it("returns undefined for missing values", () => {
+    expect(computeSpreadBps(undefined, 0.5)).toBeUndefined();
+    expect(computeSpreadBps(0.5, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for zero bid/ask", () => {
+    expect(computeSpreadBps(0, 0.5)).toBeUndefined();
+    expect(computeSpreadBps(0.5, 0)).toBeUndefined();
+  });
+});
+
+describe("computeEdgeBpsGross", () => {
+  it("computes absolute difference in basis points", () => {
+    expect(computeEdgeBpsGross(0.50, 0.55)).toBeCloseTo(500, 0);
+  });
+
+  it("returns same value regardless of order", () => {
+    expect(computeEdgeBpsGross(0.50, 0.55)).toBe(computeEdgeBpsGross(0.55, 0.50));
+  });
+
+  it("returns 0 for equal mids", () => {
+    expect(computeEdgeBpsGross(0.50, 0.50)).toBe(0);
+  });
+});
+
+// ============================================================================
+// hedge — recipe selection
+// ============================================================================
+
+describe("pickHedgeRecipe", () => {
+  it("returns hold_base when not starknet native", () => {
+    expect(pickHedgeRecipe({
+      isStarknetNative: false,
+      canAssessLiquidity: true,
+      isIntermittent: false,
+    })).toBe("hold_base");
+  });
+
+  it("returns hold_base when cannot assess liquidity", () => {
+    expect(pickHedgeRecipe({
+      isStarknetNative: true,
+      canAssessLiquidity: false,
+      isIntermittent: false,
+    })).toBe("hold_base");
+  });
+
+  it("returns re7_park for intermittent starknet native with liquidity", () => {
+    expect(pickHedgeRecipe({
+      isStarknetNative: true,
+      canAssessLiquidity: true,
+      isIntermittent: true,
+    })).toBe("re7_park");
+  });
+
+  it("returns ekubo_spot_swap for non-intermittent starknet native with liquidity", () => {
+    expect(pickHedgeRecipe({
+      isStarknetNative: true,
+      canAssessLiquidity: true,
+      isIntermittent: false,
+    })).toBe("ekubo_spot_swap");
+  });
+});
+
+describe("hedgeRecipeToString", () => {
+  it("returns non-empty string for all recipe types", () => {
+    expect(hedgeRecipeToString("ekubo_spot_swap")).toBeTruthy();
+    expect(hedgeRecipeToString("re7_park")).toBeTruthy();
+    expect(hedgeRecipeToString("hold_base")).toBeTruthy();
+  });
+
+  it("mentions Starknet for starknet-native recipes", () => {
+    expect(hedgeRecipeToString("ekubo_spot_swap").toLowerCase()).toContain("starknet");
+    expect(hedgeRecipeToString("re7_park").toLowerCase()).toContain("starknet");
   });
 });

--- a/packages/starknet-agent-passport/src/identityRegistryAbi.ts
+++ b/packages/starknet-agent-passport/src/identityRegistryAbi.ts
@@ -1,5 +1,5 @@
 // Minimal ABI needed for IdentityRegistry metadata calls.
-// Contract: packages/starknet-identity/erc8004-cairo/src/identity_registry.cairo
+// Contract: contracts/erc8004-cairo/src/identity_registry.cairo
 
 export const identityRegistryAbi = [
   {

--- a/packages/starknet-agent-passport/src/index.ts
+++ b/packages/starknet-agent-passport/src/index.ts
@@ -56,31 +56,31 @@ export class IdentityRegistryPassportClient {
     provider: ProviderInterface
     account?: AccountInterface
   }) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- starknet.js Contract constructor accepts Abi type which is loosely typed
     this.contract = new Contract({
-      abi: identityRegistryAbi as unknown as any[],
+      abi: identityRegistryAbi as any,
       address: args.identityRegistryAddress,
-      providerOrAccount: args.provider as any,
+      providerOrAccount: args.provider,
     })
     if (args.account) this.contract.connect(args.account)
   }
 
   async agentExists(agentId: bigint): Promise<boolean> {
-    const res = await (this.contract as any).agent_exists(agentId)
+    const res = await this.contract.call("agent_exists", [agentId])
     return Boolean(res)
   }
 
   async getMetadata(agentId: bigint, key: string): Promise<string> {
-    const res = await (this.contract as any).get_metadata(agentId, encodeStringAsByteArray(key))
+    const res = await this.contract.call("get_metadata", [agentId, encodeStringAsByteArray(key)])
     return decodeByteArrayAsString(res)
   }
 
   async setMetadata(agentId: bigint, key: string, value: string) {
-    // starknet.js Contract typing often expects named args, but ABI-driven calls are fine at runtime.
-    return (this.contract as any).set_metadata(
+    return this.contract.invoke("set_metadata", [
       agentId,
       encodeStringAsByteArray(key),
       encodeStringAsByteArray(value),
-    )
+    ])
   }
 
   /**

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -517,7 +517,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: JSON.stringify({
-                result: Array.isArray(result) ? result : (result as any).result,
+                result: Array.isArray(result) ? result : (result as Record<string, unknown>).result ?? result,
                 contractAddress,
                 entrypoint,
               }, null, 2),
@@ -566,6 +566,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           gasfree?: boolean;
           gasToken?: string;
         };
+
+        // Validate slippage is within reasonable bounds
+        if (slippage < 0 || slippage > 0.5) {
+          throw new Error("Slippage must be between 0 and 0.5 (50%). Recommended: 0.005-0.03.");
+        }
 
         const [sellTokenAddress, buyTokenAddress] = await Promise.all([
           resolveTokenAddressAsync(sellToken),


### PR DESCRIPTION
Documentation accuracy fixes:
- Fix defi-agent line count: 8800+ → 337 (actual)
- Fix Agent Account status: "Untested" → "Tested (110 tests)"
- Fix ERC-8004 test count: 74/126 → 131+ unit + 47 E2E
- Mark completed ROADMAP items (starknet.js v8, MCP tests, CI Cairo)
- Fix wrong erc8004-cairo path references across docs
- Remove stale GOOD_FIRST_ISSUES (MCP tests, Agent Account tests, CI Cairo)
- Add commit format guidance to CONTRIBUTING.md

CI/CD fixes:
- Fix health-check.yml Scarb version: 2.12.1 → 2.14.0
- Fix health-check.yml erc8004-cairo working directory path

Code safety improvements:
- Add slippage bounds validation (0-50%) to MCP server swap tool
- Replace unsafe feltToString/stringToFelt with starknet.js shortString utils
- Remove `as any` casts in starknet-a2a (use Record<string, unknown>)
- Replace double type cast in agent-passport with contract.call/invoke API
- Fix identityRegistryAbi.ts path comment

Test coverage:
- Expand prediction-arb-scanner from 1 to 33 tests
  (scanArbs edge cases, buildVenueSnapshot, normalize, score, hedge)

All 195 TypeScript tests pass. All packages build successfully.

https://claude.ai/code/session_01W8qVzPjGSC23WUs2ttXdRN