### PR TITLE
fix(ci): align health-check with pnpm v10 and --if-present usage

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@53751a9789c7351e4924f01fe68370252a4f1f18 # v2
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -38,12 +38,12 @@ jobs:
 
       - name: JS build
         id: js_build
-        run: pnpm -r build --if-present
+        run: pnpm -r --if-present build
         continue-on-error: true
 
       - name: JS tests
         id: js_test
-        run: pnpm -r test --if-present
+        run: pnpm -r --if-present test
         continue-on-error: true
 
       - name: Setup Scarb


### PR DESCRIPTION
## Summary
- bump health-check workflow from pnpm 8 to pnpm 10
- fix workspace command syntax so `--if-present` is parsed by pnpm (not passed to underlying scripts)

## Why
- lockfile and `packageManager` are pinned to pnpm 10; using pnpm 8 causes incompatible lockfile behavior
- `pnpm -r build --if-present` / `pnpm -r test --if-present` passes the flag to script tools; correct form is `pnpm -r --if-present build|test`

## Scope
- only `.github/workflows/health-check.yml`

Closes #107
