### PR TITLE
docs(governance): add practical security guardrails for PR review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,18 @@
 - Backward compatibility impact:
 - Rollback plan:
 
+## Security Notes
+- Security-sensitive files touched? (`contracts/**`, auth/verification/signature/session-key logic)
+- Trust assumptions introduced or changed:
+- Failure mode if a check is bypassed:
+- If a security feature is not fully implemented, behavior is:
+  - [ ] Explicitly disabled (`panic`/revert)
+  - [ ] Explicitly unverified (`verified = false`)
+  - [ ] N/A
+
 ## Checklist
 - [ ] Scope is focused and reviewable
 - [ ] Tests were added or updated when behavior changed
 - [ ] Docs were updated if needed
+- [ ] No "stubbed security success" (`TODO` paths must not default to success/verified=true)
+- [ ] If auth/verification logic changed, tests were added or updated to cover allow + deny paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,14 @@ Common prefixes: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`.
 
 - Never commit real private keys or secrets.
 - Use `.env.example` only.
+
+## Security Guardrails
+
+- Do not ship "stubbed security success". If verification or authorization is not implemented yet:
+  - revert/panic explicitly, or
+  - store/emit explicit unverified state (`verified = false`).
+  Never default to success (`verified = true`) behind a TODO.
+- If you change auth/signature/verification/session-key logic, include tests for both:
+  - expected allow path, and
+  - expected deny/reject path.
+- Keep security claims in docs/readmes aligned with current code behavior.


### PR DESCRIPTION
## Summary
- add a `Security Notes` section to the PR template
- add explicit checklist items to block TODO-based security success paths
- add lightweight security guardrails to `CONTRIBUTING.md`

## Why
This repo is moving quickly and needs low-overhead safety rails that scale with a small team:
- no stubbed security success (`verified=true` behind TODO)
- clearer reviewer prompts on trust assumptions and failure modes
- test expectations for auth/verification changes

## Scope
- `.github/pull_request_template.md`
- `CONTRIBUTING.md`

## Validation
- docs-only change
