### PR TITLE
fix(huginn-registry): fail closed until proof verifier is integrated

### DIFF
--- a/contracts/huginn-registry/src/lib.cairo
+++ b/contracts/huginn-registry/src/lib.cairo
@@ -93,23 +93,9 @@ pub mod HuginnRegistry {
             let profile = self.agents.read(caller);
             assert(profile.name != '', 'Agent not registered');
 
-            // TODO: Integrate STWO verifier contract
-            // For now, store proof hash
-            let proof_hash = self._hash_proof(proof);
-            
-            let proof_record = Proof {
-                thought_hash,
-                proof_hash,
-                verified: true, // TODO: actual verification
-                agent_id: caller,
-            };
-            self.thought_proofs.write(thought_hash, proof_record);
-
-            self.emit(Event::MimirWisdom(MimirWisdom { 
-                agent_id: caller, 
-                thought_hash, 
-                proof_verified: true 
-            }));
+            // Fail-closed until real verifier integration lands.
+            // Never record or emit verified=true from a stub path.
+            assert(false, 'Verification not implemented');
         }
 
         fn get_agent(self: @ContractState, agent_id: ContractAddress) -> (felt252, ByteArray) {

--- a/contracts/huginn-registry/tests/test_contract.cairo
+++ b/contracts/huginn-registry/tests/test_contract.cairo
@@ -53,7 +53,8 @@ fn test_log_thought_unregistered() {
 }
 
 #[test]
-fn test_prove_thought() {
+#[should_panic(expected: 'Verification not implemented')]
+fn test_prove_thought_reverts_until_verifier_is_integrated() {
     let contract_address = deploy_contract();
     let dispatcher = IHuginnRegistryDispatcher { contract_address };
 


### PR DESCRIPTION
## Summary
- make `prove_thought()` fail closed with `Verification not implemented`
- remove stub path that previously recorded/emitted successful verification
- update integration test to assert revert until real verifier integration exists

## Why
`prove_thought()` previously stored `verified: true` from a TODO/stub path, which can create false trust signals. This PR enforces the new guardrail: no stubbed security success.

## Validation
- `contracts/huginn-registry`: `snforge test` -> 6 passed

Closes #86
