### PR TITLE
ci: add lint, audit, and parallel Cairo test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
       - name: Type check
         run: pnpm run build
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm -r --if-present --filter './packages/*' lint
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -49,6 +72,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=high
+        continue-on-error: true
 
       - name: Build packages
         run: pnpm run build
@@ -84,8 +111,8 @@ jobs:
         working-directory: contracts/huginn-registry
         run: scarb build
 
-  cairo-test:
-    name: Cairo Tests
+  cairo-test-erc8004:
+    name: Cairo Tests (erc8004)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -109,9 +136,51 @@ jobs:
         working-directory: contracts/erc8004-cairo
         run: snforge test
 
+  cairo-test-agent-account:
+    name: Cairo Tests (agent-account)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.14.0"
+
+      - name: Setup Starknet Foundry
+        uses: foundry-rs/setup-snfoundry@v4
+        with:
+          starknet-foundry-version: "0.54.1"
+
       - name: Run Cairo tests (agent-account)
         working-directory: contracts/agent-account
         run: snforge test
+
+  cairo-test-huginn:
+    name: Cairo Tests (huginn-registry)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.14.0"
+
+      - name: Setup Starknet Foundry
+        uses: foundry-rs/setup-snfoundry@v4
+        with:
+          starknet-foundry-version: "0.54.1"
 
       - name: Run Cairo tests (huginn-registry)
         working-directory: contracts/huginn-registry
@@ -144,7 +213,7 @@ jobs:
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [typecheck, test, cairo-check, cairo-test, website-build]
+    needs: [typecheck, lint, test, cairo-check, cairo-test-erc8004, cairo-test-agent-account, cairo-test-huginn, website-build]
     steps:
       - name: Success
         run: echo "All CI checks passed!"

--- a/packages/x402-starknet/eslint.config.js
+++ b/packages/x402-starknet/eslint.config.js
@@ -1,6 +1,7 @@
 import js from "@eslint/js"
 
 export default [
+  { ignores: ["dist/**"] },
   js.configs.recommended,
   {
     languageOptions: {


### PR DESCRIPTION
## Summary
- Adds a **lint** CI job that auto-discovers packages with lint scripts (`--if-present`). Currently runs on `x402-starknet`; new packages get picked up as they add lint scripts.
- Adds **`pnpm audit --audit-level=high`** to the test job. Runs as `continue-on-error` so it surfaces vulnerabilities (currently reports a high-severity CVE in `@modelcontextprotocol/sdk`) without blocking merges.
- Splits the single `cairo-test` job into **3 parallel jobs** (`erc8004`, `agent-account`, `huginn-registry`) so failures are isolated and visible independently.
- Fixes `x402-starknet` eslint config to ignore `dist/` (was linting build output).
- Updates `all-checks` gate to require all 8 jobs.

## Test plan
- [x] `pnpm -r --if-present --filter './packages/*' lint` passes locally
- [x] `pnpm audit --audit-level=high` runs and reports known CVEs
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes

Closes #107 (partially — CI hardening follow-up)
