### PR TITLE
fix(onboarding): wire Sepolia addresses and ByteArray deploy payload

### DIFF
--- a/examples/onboard-agent/config.ts
+++ b/examples/onboard-agent/config.ts
@@ -14,9 +14,9 @@ export interface NetworkConfig {
 
 export const NETWORKS: Record<string, NetworkConfig> = {
   sepolia: {
-    factory: "", // TODO: fill after deploying AgentAccountFactory to Sepolia
-    registry: "", // TODO: fill after deploying IdentityRegistry to Sepolia
-    rpc: "https://starknet-sepolia.public.blastapi.io",
+    factory: "0x358301e1c530a6100ae2391e43b2dd4dd0593156e59adab7501ff6f4fe8720e",
+    registry: "0x7856876f4c8e1880bc0a2e4c15f4de3085bc2bad5c7b0ae472740f8f558e417",
+    rpc: "https://starknet-sepolia-rpc.publicnode.com",
     explorer: "https://sepolia.voyager.online",
   },
   mainnet: {


### PR DESCRIPTION
## Summary
- Sets live Sepolia addresses in `examples/onboard-agent/config.ts`
  - IdentityRegistry: `0x7856876f4c8e1880bc0a2e4c15f4de3085bc2bad5c7b0ae472740f8f558e417`
  - AgentAccountFactory: `0x358301e1c530a6100ae2391e43b2dd4dd0593156e59adab7501ff6f4fe8720e`
- Updates Sepolia RPC default to a live endpoint (`https://starknet-sepolia-rpc.publicnode.com`) since Blast endpoint is deprecated
- Fixes onboarding deploy step to encode `token_uri` as Cairo `ByteArray`
- Fixes account/agent parsing from factory event data shape

## Why
The v1 onboarding flow failed at runtime because `token_uri` was sent as a plain string and calldata encoding expected Cairo `ByteArray`. This patch makes the flow executable against Sepolia.

## Validation (live Sepolia)
- ERC-8004 deployed
- AgentAccountFactory deployed
- Onboarding flow executed successfully:
  - Deploy tx: `0x7ae749299eb046325bdd4c672d94090b372f06f6a39fed1c6ad281785365ab1`
  - New account: `0x6c876f3f05e44fbe836a577c32c05640e4e3c4745c6cdac35c2b64253370071`
  - Agent ID: `2`

Part of #96
