### PR TITLE
docs(huginn): document verifier mutability and proof invariants

### DIFF
--- a/contracts/huginn-registry/src/lib.cairo
+++ b/contracts/huginn-registry/src/lib.cairo
@@ -40,6 +40,8 @@ pub mod HuginnRegistry {
     pub struct Proof {
         thought_hash: u256,
         proof_hash: u256,
+        // Invariant: when a record is submitted, `verified` is always true.
+        // Invalid proofs revert and are never persisted.
         verified: bool,
         agent_id: ContractAddress,
         submitted: bool,
@@ -77,6 +79,8 @@ pub mod HuginnRegistry {
 
     #[constructor]
     fn constructor(ref self: ContractState, verifier_address: ContractAddress) {
+        // Verifier address is intentionally immutable for v1.
+        // Changing verifier implementation requires registry redeploy.
         assert(!verifier_address.is_zero(), 'Invalid verifier');
         self.verifier.write(verifier_address);
     }

--- a/contracts/huginn-registry/tests/test_contract.cairo
+++ b/contracts/huginn-registry/tests/test_contract.cairo
@@ -16,6 +16,14 @@ fn deploy_contract(verifier_address: ContractAddress) -> ContractAddress {
 }
 
 #[test]
+fn test_get_verifier_returns_constructor_value() {
+    let verifier = test_address();
+    let contract_address = deploy_contract(verifier);
+    let dispatcher = IHuginnRegistryDispatcher { contract_address };
+    assert(dispatcher.get_verifier() == verifier, 'wrong verifier');
+}
+
+#[test]
 fn test_register_agent() {
     let contract_address = deploy_contract(test_address());
     let dispatcher = IHuginnRegistryDispatcher { contract_address };

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -228,6 +228,25 @@ Recommended convention for cross-chain portability:
 4. Deploy AgentAccount class (template for new agent wallets)
 5. Create factory for deploying new AgentAccount instances linked to the registry
 
+### 3.8 Huginn Registry Semantics (v1)
+
+This section clarifies v1 invariants for `contracts/huginn-registry/`:
+
+- Verifier mutability:
+  - The verifier address is constructor-set and immutable in v1.
+  - If verifier logic must change, deploy a new registry instance and migrate clients.
+
+- Proof record invariant:
+  - Invalid proofs revert and are not stored.
+  - Therefore stored records satisfy: `submitted => verified = true`.
+  - `verified = false` is not a persisted runtime state in v1.
+
+- Ownership and replay:
+  - First logger of a `thought_hash` becomes canonical thought owner.
+  - Same owner may re-log idempotently; different owner is rejected.
+  - Only thought owner can submit proof for that hash.
+  - One submitted proof per `thought_hash` (replay blocked).
+
 ## 4. MCP Server
 
 **Status:** Production-ready at `packages/starknet-mcp-server/` (1,600+ lines, 9 tools implemented).


### PR DESCRIPTION
## Summary
Low-severity follow-up from #127 after the security fix in #125.

This PR does not change runtime security behavior. It clarifies and documents v1 semantics:

- documents verifier immutability (constructor-set, no rotation path in v1)
- documents proof invariant: persisted records satisfy `submitted => verified=true`
- adds one explicit test for constructor verifier wiring (`get_verifier`)

## Changes
- `contracts/huginn-registry/src/lib.cairo`
  - added explicit invariant comment on `Proof.verified`
  - added explicit immutability comment in constructor
- `docs/SPECIFICATION.md`
  - added "Huginn Registry Semantics (v1)" section with:
    - verifier mutability policy
    - proof record invariant
    - ownership + replay semantics
- `contracts/huginn-registry/tests/test_contract.cairo`
  - added `test_get_verifier_returns_constructor_value`

## Validation
- `cd contracts/huginn-registry && snforge test` (15/15 passing)
- `cd contracts/huginn-registry && scarb build` (passes)

Related: #127
Depends on: #125
