### PR TITLE
feat(huginn): cap proof size and add proof_exists API

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -240,12 +240,15 @@ This section clarifies v1 invariants for `contracts/huginn-registry/`:
   - Invalid proofs revert and are not stored.
   - Therefore stored records satisfy: `submitted => verified = true`.
   - `verified = false` is not a persisted runtime state in v1.
+  - `proof_exists(thought_hash)` should be used by clients for explicit existence checks.
+  - Proof payloads are bounded (`MAX_PROOF_WORDS`) to avoid oversized calldata/hash/verifier griefing.
 
 - Ownership and replay:
   - First logger of a `thought_hash` becomes canonical thought owner.
   - Same owner may re-log idempotently; different owner is rejected.
   - Only thought owner can submit proof for that hash.
   - One submitted proof per `thought_hash` (replay blocked).
+  - Tradeoff: first-logger semantics can be front-run if `thought_hash` is predictable. Clients should include caller-specific salting/domain separation in hash construction.
 
 ## 4. MCP Server
 


### PR DESCRIPTION
## Summary
Implements issue #129 as a focused hardening + DX slice for `huginn-registry`:

- adds bounded proof-size guard in `prove_thought`
- adds explicit `proof_exists(thought_hash) -> bool` API
- documents first-logger ownership tradeoff and proof-state semantics in spec

## Contract changes
### `contracts/huginn-registry/src/lib.cairo`
- new `MAX_PROOF_WORDS: usize = 1024`
- new guard in `prove_thought`:
  - `assert(proof.len() <= MAX_PROOF_WORDS, 'Proof too large')`
- new interface/view method:
  - `proof_exists(self, thought_hash) -> bool`

## Tests
### `contracts/huginn-registry/tests/test_contract.cairo`
Added:
- `test_prove_thought_rejects_oversized_proof`
- `test_proof_exists_false_before_and_true_after_submit`

Updated existing positive path to assert `proof_exists` after successful submit.

## Docs
### `docs/SPECIFICATION.md`
- clarifies `proof_exists` usage for clients
- documents proof-size cap rationale
- documents first-logger/front-run tradeoff and recommendation to use caller-specific salting/domain separation

## Validation
- `cd contracts/huginn-registry && snforge test` -> 17/17 passing
- `cd contracts/huginn-registry && scarb build` -> pass

Closes #129
