### PR TITLE
feat(onboarding): enable AVNU-sponsored gasfree deploy path

### DIFF
--- a/examples/onboard-agent/.env.example
+++ b/examples/onboard-agent/.env.example
@@ -24,3 +24,16 @@ STARKNET_RPC_URL=https://starknet-sepolia.public.blastapi.io
 
 DEPLOYER_ADDRESS=0xYOUR_EXISTING_ACCOUNT_ADDRESS
 DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+
+# =============================================================================
+# OPTIONAL: AVNU PAYMASTER (GASFREE DEPLOY)
+# =============================================================================
+# Enable this only if you run onboarding with --gasfree.
+#
+# Example:
+#   npx tsx run.ts --network sepolia --token-uri "ipfs://..." --gasfree
+#
+# Sepolia endpoint:
+AVNU_PAYMASTER_URL=https://sepolia.paymaster.avnu.fi
+# API key from https://portal.avnu.fi
+AVNU_PAYMASTER_API_KEY=

--- a/examples/onboard-agent/README.md
+++ b/examples/onboard-agent/README.md
@@ -14,6 +14,7 @@ One-command path to deploy a Starknet agent account with ERC-8004 identity regis
 - Node.js 20+
 - An existing Starknet account with funds (to pay gas for the deploy)
 - Contracts deployed (AgentAccountFactory + IdentityRegistry). See `contracts/agent-account/scripts/deploy.js`
+- Optional for gasfree deploy: AVNU paymaster key (`AVNU_PAYMASTER_API_KEY`)
 
 ## Get funds on Starknet
 
@@ -38,6 +39,9 @@ pnpm onboard
 
 # With options
 npx tsx run.ts --network sepolia --token-uri "ipfs://QmYourMetadata" --verify-tx
+
+# Gasfree deploy (sponsored paymaster)
+npx tsx run.ts --network sepolia --token-uri "ipfs://QmYourMetadata" --gasfree
 
 # Custom salt (deterministic address)
 npx tsx run.ts --token-uri "ipfs://QmYourMetadata" --salt 0x1234

--- a/examples/onboard-agent/package.json
+++ b/examples/onboard-agent/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "onboard": "npx tsx run.ts",
     "onboard:sepolia": "npx tsx run.ts --network sepolia",
+    "onboard:gasfree": "npx tsx run.ts --network sepolia --gasfree",
     "onboard:verify": "npx tsx run.ts --network sepolia --verify-tx",
     "smoke": "npx tsx smoke.ts"
   },

--- a/examples/onboard-agent/run.ts
+++ b/examples/onboard-agent/run.ts
@@ -9,7 +9,7 @@
  *   4. Receipt  — emit onboarding_receipt.json
  *
  * Usage:
- *   npx tsx run.ts [--network sepolia] [--token-uri "ipfs://..."] [--verify-tx]
+ *   npx tsx run.ts [--network sepolia] [--token-uri "ipfs://..."] [--verify-tx] [--gasfree]
  *
  * Requires:
  *   - .env file with STARKNET_RPC_URL, DEPLOYER_ADDRESS, DEPLOYER_PRIVATE_KEY
@@ -32,12 +32,14 @@ function parseArgs(): {
   network: string;
   tokenUri: string;
   verifyTx: boolean;
+  gasfree: boolean;
   salt?: string;
 } {
   const args = process.argv.slice(2);
   let network = "sepolia";
   let tokenUri = "";
   let verifyTx = false;
+  let gasfree = false;
   let salt: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -50,6 +52,9 @@ function parseArgs(): {
         break;
       case "--verify-tx":
         verifyTx = true;
+        break;
+      case "--gasfree":
+        gasfree = true;
         break;
       case "--salt":
         salt = args[++i];
@@ -68,16 +73,17 @@ function parseArgs(): {
     );
   }
 
-  return { network, tokenUri, verifyTx, salt };
+  return { network, tokenUri, verifyTx, gasfree, salt };
 }
 
 async function main() {
-  const { network, tokenUri, verifyTx, salt } = parseArgs();
+  const { network, tokenUri, verifyTx, gasfree, salt } = parseArgs();
 
   console.log("=== Starknet Agent Onboarding ===\n");
   console.log(`Network: ${network}`);
   console.log(`Token URI: ${tokenUri}`);
   console.log(`Verify TX: ${verifyTx}`);
+  console.log(`Gasfree: ${gasfree}`);
   console.log("");
 
   // ==================== STEP 1: PREFLIGHT ====================
@@ -112,7 +118,11 @@ async function main() {
     provider: pre.provider,
     deployerAccount: pre.account,
     networkConfig: pre.networkConfig,
+    network,
     tokenUri,
+    gasfree,
+    paymasterUrl: process.env.AVNU_PAYMASTER_URL,
+    paymasterApiKey: process.env.AVNU_PAYMASTER_API_KEY,
     salt,
   });
 


### PR DESCRIPTION
## Summary
- Adds `--gasfree` to `examples/onboard-agent` and wires deploy step to AVNU paymaster sponsored mode.
- Switches MCP gasfree execution to paymaster `account.execute(..., { paymaster })` style validated on Sepolia.
- Adds/updates smoke and handler tests for sponsored deploy path.
- Uses sepolia-aware defaults for AVNU API/paymaster URLs based on RPC context.

## Validation
- `pnpm --dir examples/onboard-agent smoke` passes
- `pnpm --dir packages/starknet-mcp-server test` passes (152/152)
- Live Sepolia gasfree onboarding tx succeeded
  - tx: `0x2460cf2409dd3b9c1c88089286dc0758c425a8d43164c8a8381fc485909b14f`
  - account: `0x34286942ce552a3635c8f08d3d2f44e067be68c54440fbdfa1779c4e17a2ef0`
  - agent ID: `5`

## Notes
- Rotate AVNU key(s) if exposed in logs/chats.
