### PR TITLE
fix(arb-scanner): reject inverted bid/ask in spread and mid

### DIFF
--- a/packages/prediction-arb-scanner/__tests__/scanner.test.ts
+++ b/packages/prediction-arb-scanner/__tests__/scanner.test.ts
@@ -223,6 +223,10 @@ describe("computeMid", () => {
   it("returns undefined when ask is missing", () => {
     expect(computeMid(0.4, undefined)).toBeUndefined();
   });
+
+  it("returns undefined for inverted bid/ask", () => {
+    expect(computeMid(0.6, 0.4)).toBeUndefined();
+  });
 });
 
 describe("computeSpreadBps", () => {
@@ -238,6 +242,10 @@ describe("computeSpreadBps", () => {
   it("returns undefined for zero bid/ask", () => {
     expect(computeSpreadBps(0, 0.5)).toBeUndefined();
     expect(computeSpreadBps(0.5, 0)).toBeUndefined();
+  });
+
+  it("returns undefined for inverted bid/ask", () => {
+    expect(computeSpreadBps(0.6, 0.4)).toBeUndefined();
   });
 });
 

--- a/packages/prediction-arb-scanner/src/score.ts
+++ b/packages/prediction-arb-scanner/src/score.ts
@@ -1,6 +1,7 @@
 export function computeSpreadBps(bestBid?: number, bestAsk?: number): number | undefined {
   if (bestBid == null || bestAsk == null) return undefined;
   if (bestBid <= 0 || bestAsk <= 0) return undefined;
+  if (bestBid > bestAsk) return undefined;
   const mid = (bestBid + bestAsk) / 2;
   if (mid === 0) return undefined;
   return ((bestAsk - bestBid) / mid) * 10000;
@@ -8,6 +9,7 @@ export function computeSpreadBps(bestBid?: number, bestAsk?: number): number | u
 
 export function computeMid(bestBid?: number, bestAsk?: number): number | undefined {
   if (bestBid == null || bestAsk == null) return undefined;
+  if (bestBid > bestAsk) return undefined;
   return (bestBid + bestAsk) / 2;
 }
 


### PR DESCRIPTION
## Summary

Closes #145.

- `computeSpreadBps()` and `computeMid()` now return `undefined` when `bestBid > bestAsk`
- Previously an inverted book produced a negative spread, which failed `VenueBookSnapshotSchema`'s `nonnegative()` constraint and crashed `scanArbs()` at runtime
- Added test coverage for the inverted case in both functions

## Test plan

- [ ] `pnpm --dir packages/prediction-arb-scanner test` passes (35/35)
- [ ] `computeSpreadBps(0.6, 0.4)` returns `undefined` instead of `-4000`
- [ ] `computeMid(0.6, 0.4)` returns `undefined` instead of `0.5`

Generated with [Claude Code](https://claude.com/claude-code)