### PR TITLE
docs(skills): enable OpenClaw/MoltBook install via ClawHub + GitHub fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ OpenClaw / MoltBook via ClawHub:
 
 ```bash
 npm install -g clawhub
-claw login
-claw add starknet-wallet
+clawhub login
+clawhub install starknet-wallet
 ```
 
 ## Examples

--- a/skills/README.md
+++ b/skills/README.md
@@ -64,17 +64,20 @@ ClawHub is the primary distribution channel for OpenClaw and MoltBook users.
 npm install -g clawhub
 
 # Login
-claw login
+clawhub login
 
 # Discover
-claw search starknet
+clawhub search starknet
+
+# Tip: sort results
+clawhub search starknet --sort trending
 
 # Install
-claw add starknet-wallet
+clawhub install starknet-wallet
 ```
 
 Maintainer publishing should follow the official ClawHub upload workflow:
-`https://github.com/RhysLad/clawhub`.
+`https://github.com/openclaw/clawhub`.
 
 If ClawHub distribution is unavailable for your environment, use Option 5.
 
@@ -219,7 +222,7 @@ See the main [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 - [Agent Skills Specification](https://agentskills.io/)
 - [OpenClaw Skill Format](https://docs.openclaw.ai/guide/skills)
 - [ClawHub User Guide](https://docs.openclaw.ai/guide/clawhub)
-- [ClawHub Repository](https://github.com/RhysLad/clawhub)
+- [ClawHub Repository](https://github.com/openclaw/clawhub)
 - [Starknet Documentation](https://docs.starknet.io/)
 - [avnu SDK](https://docs.avnu.fi/)
 - [ERC-8004 Standard](https://eips.ethereum.org/EIPS/eip-8004)


### PR DESCRIPTION
## Summary
- Add OpenClaw/MoltBook install instructions to the top-level README
- Update `skills/README.md` with verified ClawHub CLI flow (`claw login`, `claw search`, `claw add`)
- Add stable GitHub fallback install path for `starknet-wallet` (download `SKILL.md` into `~/.openclaw/skills/starknet-wallet/`)
- Add explicit security note: install from trusted publishers and review skill scripts before enabling autonomous execution
- Add OpenClaw/ClawHub reference links for maintainers

## Validation
- `python3 scripts/quick_validate_skill.py skills/*/`
- `python3 -m json.tool .claude-plugin/marketplace.json > /dev/null`
- Verified plugin manifest skill directory references with local CI-equivalent script

Closes #160
