### PR TITLE
fix(security): remove hardcoded deploy secrets; add ERC-8004 register tool

### DIFF
--- a/contracts/erc8004-cairo/scripts/deploy_sepolia.sh
+++ b/contracts/erc8004-cairo/scripts/deploy_sepolia.sh
@@ -6,14 +6,26 @@
 echo "🚀 Deploying ERC-8004 to Sepolia Testnet..."
 echo ""
 
-# Sepolia Configuration with Alchemy RPC (v0.9)
-RPC_URL="https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_9/r93j7Eo1Oub9N6Gs3p7fC"
-ACCOUNT_ADDRESS="0x04a6b1f403E879B54Ba3e68072FE4C3aAf8Eb3617a51d8fea59b769432AbBF50"
-PRIVATE_KEY="0x0038ea6d7f8df0f1d3d29004deb72390028c1d15be04f1b089f9841d235a7d33"
-ACCOUNT_NAME="sepolia_deployer"
+# ==================== Configuration ====================
+# SECURITY: do NOT hardcode private keys or paid RPC keys in repo scripts.
+# Provide these via environment variables (or a local .env you source manually).
+#
+# Required:
+#   STARKNET_RPC_URL
+#   DEPLOYER_ADDRESS
+#   DEPLOYER_PRIVATE_KEY
+#
+# Optional:
+#   DEPLOYER_ACCOUNT_NAME (default: sepolia_deployer)
+#   OWNER_ADDRESS (default: DEPLOYER_ADDRESS)
+
+RPC_URL="${STARKNET_RPC_URL:?STARKNET_RPC_URL is required}"
+ACCOUNT_ADDRESS="${DEPLOYER_ADDRESS:?DEPLOYER_ADDRESS is required}"
+PRIVATE_KEY="${DEPLOYER_PRIVATE_KEY:?DEPLOYER_PRIVATE_KEY is required}"
+ACCOUNT_NAME="${DEPLOYER_ACCOUNT_NAME:-sepolia_deployer}"
 
 # Owner address for the contracts (deployer is the owner)
-OWNER_ADDRESS="$ACCOUNT_ADDRESS"
+OWNER_ADDRESS="${OWNER_ADDRESS:-$ACCOUNT_ADDRESS}"
 
 echo "📡 RPC URL: $RPC_URL"
 echo "👤 Account: $ACCOUNT_ADDRESS"

--- a/contracts/erc8004-cairo/src/identity_registry.cairo
+++ b/contracts/erc8004-cairo/src/identity_registry.cairo
@@ -19,6 +19,7 @@
 #[starknet::contract]
 pub mod IdentityRegistry {
     use core::poseidon::poseidon_hash_span;
+    use core::num::traits::Zero;
     use core::to_byte_array::AppendFormattedToByteArray;
     use erc8004::interfaces::account::IAccountDispatcher;
     use erc8004::interfaces::account::IAccountDispatcherTrait;
@@ -163,6 +164,7 @@ pub mod IdentityRegistry {
     // ============ Constructor ============
     #[constructor]
     fn constructor(ref self: ContractState, owner: ContractAddress) {
+        assert(!owner.is_zero(), 'Invalid owner');
         // Initialize ERC721 with name "ERC-8004 Trustless Agent" and symbol "AGENT"
         self.erc721.initializer("ERC-8004 Trustless Agent", "AGENT", "");
 

--- a/contracts/erc8004-cairo/src/reputation_registry.cairo
+++ b/contracts/erc8004-cairo/src/reputation_registry.cairo
@@ -103,6 +103,7 @@ pub mod ReputationRegistry {
     fn constructor(
         ref self: ContractState, owner: ContractAddress, identity_registry_address: ContractAddress,
     ) {
+        assert(!owner.is_zero(), 'Invalid owner');
         // Validate address is not zero
         assert(!identity_registry_address.is_zero(), 'bad identity');
 


### PR DESCRIPTION
## Summary
- Removes hardcoded Sepolia deployer private key + RPC URL from `contracts/erc8004-cairo/scripts/deploy_sepolia.sh` (env-driven instead).
- Adds `owner != 0` constructor guards in `IdentityRegistry` and `ReputationRegistry` (prevents accidentally deploying an ownerless/undegradable contract).
- Implements the previously-advertised MCP tool `starknet_register_agent` (gated by `ERC8004_IDENTITY_REGISTRY_ADDRESS`).

## Notes
- The previously hardcoded Sepolia key is now removed from the script, but it is still present in git history. Treat it as permanently burned/testnet-only.

## Test Plan
- `cd contracts/erc8004-cairo && snforge test`
- `pnpm --filter @starknet-agentic/x402-starknet build` (needed for MCP tests)
- `pnpm --filter @starknet-agentic/mcp-server test`
