### PR TITLE
fix(mcp): validate felt range for deploy-agent inputs

### DIFF
--- a/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
+++ b/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
@@ -894,6 +894,31 @@ describe("MCP Tool Handlers", () => {
 
       delete process.env.AVNU_PAYMASTER_API_KEY;
     });
+
+    it("returns clear error for out-of-range public key", async () => {
+      const tooLarge = (1n << 251n).toString(); // 2^251, one above max allowed
+      const response = await callTool("starknet_deploy_agent_account", {
+        public_key: tooLarge,
+        token_uri: "ipfs://demo",
+      });
+
+      expect(response.isError).toBe(true);
+      const result = parseResponse(response);
+      expect(result.message).toContain("public_key must fit in 251 bits");
+    });
+
+    it("returns clear error for out-of-range salt", async () => {
+      const tooLarge = (1n << 251n).toString();
+      const response = await callTool("starknet_deploy_agent_account", {
+        public_key: "1",
+        token_uri: "ipfs://demo",
+        salt: tooLarge,
+      });
+
+      expect(response.isError).toBe(true);
+      const result = parseResponse(response);
+      expect(result.message).toContain("salt must fit in 251 bits");
+    });
   });
 
   describe("unknown tool", () => {

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -118,6 +118,12 @@ function parseFelt(name: string, value: string): bigint {
   if (parsed < 0n) {
     throw new Error(`${name} must be non-negative`);
   }
+  // Starknet felts are field elements; in practice most calldata values should fit in 251 bits.
+  // Enforce 251-bit bound to fail fast with a clear error instead of a provider/encoding failure.
+  const max251 = (1n << 251n) - 1n;
+  if (parsed > max251) {
+    throw new Error(`${name} must fit in 251 bits`);
+  }
   return parsed;
 }
 


### PR DESCRIPTION
## Summary
- Adds a strict 251-bit bound check for felt inputs (fails fast with a clear error instead of provider/encoding failures).
- Covers `starknet_deploy_agent_account` inputs (`public_key`, `salt`) with tests.

## Test Plan
- `pnpm --filter @starknet-agentic/x402-starknet build`
- `pnpm --filter @starknet-agentic/mcp-server test`
