### PR TITLE
fix(security): do not print generated private key by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ target/
 deployed_addresses*.json
 .env.local
 .mcp.json
+examples/onboard-agent/onboarding_secrets.json
 
 # Claude Code
 .claude/settings.local.json

--- a/examples/onboard-agent/README.md
+++ b/examples/onboard-agent/README.md
@@ -7,7 +7,7 @@ One-command path to deploy a Starknet agent account with ERC-8004 identity regis
 1. **Preflight** -- validates env, RPC, chain ID, deployer balance
 2. **Deploy** -- generates a new Stark keypair locally, calls `AgentAccountFactory.deploy_account()` which atomically deploys an account contract and registers an ERC-8004 identity
 3. **Verify** -- reads the new account's balances; optionally sends a 0-value self-transfer to prove tx plumbing
-4. **Receipt** -- emits `onboarding_receipt.json` with all addresses, tx hashes, and credentials
+4. **Receipt** -- emits `onboarding_receipt.json` (public info) + `onboarding_secrets.json` (private key)
 
 ## Prerequisites
 
@@ -45,11 +45,16 @@ npx tsx run.ts --network sepolia --token-uri "ipfs://QmYourMetadata" --gasfree
 
 # Custom salt (deterministic address)
 npx tsx run.ts --token-uri "ipfs://QmYourMetadata" --salt 0x1234
+
+# If you really need to print the private key once (not recommended):
+npx tsx run.ts --network sepolia --token-uri "ipfs://QmYourMetadata" --print-private-key
 ```
 
 ## Output
 
-The script prints credentials to stdout and saves `onboarding_receipt.json`:
+The script saves:
+- `onboarding_receipt.json` (safe to share: addresses + tx hashes)
+- `onboarding_secrets.json` (DO NOT SHARE: contains the private key)
 
 ```json
 {
@@ -69,7 +74,7 @@ The script prints credentials to stdout and saves `onboarding_receipt.json`:
 }
 ```
 
-**Save the private key securely!** It is printed once and not stored anywhere.
+`onboarding_secrets.json` is written with best-effort `0600` permissions on POSIX systems.
 
 ## Next steps
 


### PR DESCRIPTION
Depends on PR #175.

This changes the onboard-agent example to be safe-by-default:
- Save the generated private key to `examples/onboard-agent/onboarding_secrets.json` (gitignored, best-effort chmod 0600).
- Stop printing the private key to stdout by default.
- Add `--print-private-key` escape hatch for one-time printing (with warning).
- Update the example README accordingly.

Tests:
- `pnpm --dir examples/onboard-agent smoke`
- `pnpm -r test`