### PR TITLE
fix(mcp): x402 signing uses only server env key

### DIFF
--- a/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
+++ b/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
@@ -804,28 +804,25 @@ describe("MCP Tool Handlers", () => {
       });
     });
 
-    it("uses provided params over env defaults", async () => {
+    it("ignores extra params and always signs with env-configured account", async () => {
       mockCreateStarknetPaymentSignatureHeader.mockResolvedValue({
         headerValue: "sig",
         payload: {},
       });
 
-      const customRpc = "https://custom.rpc.url";
-      const customAddress = "0xcustom";
-      const customKey = "0xprivate";
-
       await callTool("x402_starknet_sign_payment_required", {
         paymentRequiredHeader: "test",
-        rpcUrl: customRpc,
-        accountAddress: customAddress,
-        privateKey: customKey,
+        // These are intentionally ignored to avoid signing arbitrary key material.
+        rpcUrl: "https://custom.rpc.url",
+        accountAddress: "0xcustom",
+        privateKey: "0xprivate",
       });
 
       expect(mockCreateStarknetPaymentSignatureHeader).toHaveBeenCalledWith({
         paymentRequiredHeader: "test",
-        rpcUrl: customRpc,
-        accountAddress: customAddress,
-        privateKey: customKey,
+        rpcUrl: mockEnv.STARKNET_RPC_URL,
+        accountAddress: mockEnv.STARKNET_ACCOUNT_ADDRESS,
+        privateKey: mockEnv.STARKNET_PRIVATE_KEY,
       });
     });
   });

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -464,19 +464,6 @@ const tools: Tool[] = [
           type: "string",
           description: "Base64 JSON from PAYMENT-REQUIRED header",
         },
-        rpcUrl: {
-          type: "string",
-          description: "Starknet RPC URL (defaults to STARKNET_RPC_URL env var)",
-        },
-        accountAddress: {
-          type: "string",
-          description:
-            "Starknet account address (defaults to STARKNET_ACCOUNT_ADDRESS env var)",
-        },
-        privateKey: {
-          type: "string",
-          description: "Starknet private key (defaults to STARKNET_PRIVATE_KEY env var)",
-        },
       },
       required: ["paymentRequiredHeader"],
     },
@@ -914,23 +901,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "x402_starknet_sign_payment_required": {
-        const {
-          paymentRequiredHeader,
-          rpcUrl = env.STARKNET_RPC_URL,
-          accountAddress = env.STARKNET_ACCOUNT_ADDRESS,
-          privateKey = env.STARKNET_PRIVATE_KEY,
-        } = args as {
+        const { paymentRequiredHeader } = args as {
           paymentRequiredHeader: string;
-          rpcUrl?: string;
-          accountAddress?: string;
-          privateKey?: string;
         };
+
+        if (!env.STARKNET_RPC_URL || !env.STARKNET_ACCOUNT_ADDRESS || !env.STARKNET_PRIVATE_KEY) {
+          throw new Error(
+            "Missing required env vars for x402 signing (STARKNET_RPC_URL, STARKNET_ACCOUNT_ADDRESS, STARKNET_PRIVATE_KEY)",
+          );
+        }
 
         const { headerValue, payload } = await createStarknetPaymentSignatureHeader({
           paymentRequiredHeader,
-          rpcUrl,
-          accountAddress,
-          privateKey,
+          rpcUrl: env.STARKNET_RPC_URL,
+          accountAddress: env.STARKNET_ACCOUNT_ADDRESS,
+          privateKey: env.STARKNET_PRIVATE_KEY,
         });
 
         return {


### PR DESCRIPTION
## Summary
- Tighten `x402_starknet_sign_payment_required` so it **always** signs using the MCP server’s configured Starknet account (`STARKNET_RPC_URL`, `STARKNET_ACCOUNT_ADDRESS`, `STARKNET_PRIVATE_KEY`).
- Removes the ability for callers to pass arbitrary `rpcUrl` / `accountAddress` / `privateKey` overrides.

## Why
If the MCP server is exposed beyond a single trusted user, accepting caller-supplied key material is an unsafe default. This change makes the tool behavior deterministic and prevents “sign with someone else’s key” style footguns.

## Test plan
- `pnpm --filter @starknet-agentic/mcp-server test`
