### PR TITLE
fix(agent-account): enforce minimum upgrade delay

### DIFF
--- a/contracts/agent-account/src/agent_account.cairo
+++ b/contracts/agent-account/src/agent_account.cairo
@@ -14,6 +14,7 @@ pub mod AgentAccount {
     const QUERY_OFFSET: u256 = 0x100000000000000000000000000000000;
     /// Default timelock delay for upgrades (5 minutes).
     const DEFAULT_UPGRADE_DELAY: u64 = 300;
+    const MIN_UPGRADE_DELAY: u64 = 60;
 
     fn execute_calls(mut calls: Span<Call>) -> Array<Span<felt252>> {
         let mut res = array![];
@@ -561,6 +562,7 @@ pub mod AgentAccount {
 
         fn set_upgrade_delay(ref self: ContractState, new_delay: u64) {
             self.account.assert_only_self();
+            assert(new_delay >= MIN_UPGRADE_DELAY, 'Upgrade delay too small');
             let old_delay = self.upgrade_delay.read();
             self.upgrade_delay.write(new_delay);
 

--- a/contracts/agent-account/tests/lib.cairo
+++ b/contracts/agent-account/tests/lib.cairo
@@ -2,3 +2,4 @@ mod test_agent_account;
 mod test_agent_account_factory;
 mod test_execute_validate;
 mod test_security;
+mod test_upgrade_delay;

--- a/contracts/agent-account/tests/test_upgrade_delay.cairo
+++ b/contracts/agent-account/tests/test_upgrade_delay.cairo
@@ -1,0 +1,47 @@
+use agent_account::interfaces::{IAgentAccountDispatcher, IAgentAccountDispatcherTrait};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
+    stop_cheat_caller_address,
+};
+use starknet::ContractAddress;
+
+fn attacker() -> ContractAddress {
+    0xEEE.try_into().unwrap()
+}
+
+fn deploy_agent_account() -> (IAgentAccountDispatcher, ContractAddress) {
+    let contract = declare("AgentAccount").unwrap().contract_class();
+    let public_key: felt252 = 0x1234;
+    let (contract_address, _) = contract.deploy(@array![public_key, 0]).unwrap();
+    (IAgentAccountDispatcher { contract_address }, contract_address)
+}
+
+#[test]
+#[should_panic(expected: 'Account: unauthorized')]
+fn test_set_upgrade_delay_non_self_panics() {
+    let (agent, addr) = deploy_agent_account();
+    start_cheat_caller_address(addr, attacker());
+    agent.set_upgrade_delay(60);
+    stop_cheat_caller_address(addr);
+}
+
+#[test]
+#[should_panic(expected: 'Upgrade delay too small')]
+fn test_set_upgrade_delay_zero_panics() {
+    let (agent, addr) = deploy_agent_account();
+    start_cheat_caller_address(addr, addr);
+    agent.set_upgrade_delay(0);
+    stop_cheat_caller_address(addr);
+}
+
+#[test]
+fn test_set_upgrade_delay_updates_value() {
+    let (agent, addr) = deploy_agent_account();
+    start_cheat_caller_address(addr, addr);
+    agent.set_upgrade_delay(60);
+    stop_cheat_caller_address(addr);
+
+    let (_pending, _scheduled_at, delay, _now) = agent.get_upgrade_info();
+    assert_eq!(delay, 60);
+}
+


### PR DESCRIPTION
## Summary
- Enforces a minimum upgrade delay in `AgentAccount.set_upgrade_delay` (prevents setting the delay to 0 and effectively bypassing the timelock).
- Adds dedicated tests for `set_upgrade_delay`.

## Security rationale
A timelock that can be set to `0` is functionally optional. This makes the timelock invariant explicit on-chain.

## Test plan
- `cd contracts/agent-account && scarb test`
