### PR TITLE
chore(onboarding): add waitForTransaction timeout helper

### DIFF
--- a/examples/crosschain-demo/run.ts
+++ b/examples/crosschain-demo/run.ts
@@ -13,6 +13,7 @@ import {
   cairo,
 } from "starknet";
 import { Contract, Interface, JsonRpcProvider, Wallet, ZeroAddress } from "ethers";
+import { waitForTransactionWithTimeout } from "@starknet-agentic/onboarding-utils";
 import { preflight } from "./steps/preflight.js";
 import { deployAccount } from "./steps/deploy-account.js";
 import { fundDeployer } from "./steps/fund-deployer.js";
@@ -240,7 +241,11 @@ async function updateStarknetUri(args: {
 
   if (!args.gasfree) {
     const tx = await account.execute(call);
-    await args.provider.waitForTransaction(tx.transaction_hash);
+    await waitForTransactionWithTimeout({
+      provider: args.provider as any,
+      txHash: tx.transaction_hash,
+      timeoutMs: 300_000,
+    });
     return tx.transaction_hash;
   }
 
@@ -251,7 +256,11 @@ async function updateStarknetUri(args: {
     feeMode: { mode: "sponsored" },
   });
 
-  await args.provider.waitForTransaction(tx.transaction_hash);
+  await waitForTransactionWithTimeout({
+    provider: args.provider as any,
+    txHash: tx.transaction_hash,
+    timeoutMs: 300_000,
+  });
   return tx.transaction_hash;
 }
 


### PR DESCRIPTION
## Summary
- Adds `waitForTransactionWithTimeout()` to `@starknet-agentic/onboarding-utils`.
- Uses the helper in the shared deploy + first-action codepaths.
- Replaces bare `waitForTransaction` usage in `examples/crosschain-demo/run.ts` and `examples/hello-agent/index.mjs` with a bounded wait.

## Why
Unbounded waits are brittle in demos and CI-like scripts: a stuck tx or RPC hiccup can hang the process indefinitely. A timeout gives a deterministic failure mode with a tx hash for manual follow-up.

## Test plan
- `pnpm --filter @starknet-agentic/onboarding-utils test`
- `pnpm --filter @starknet-agentic/crosschain-demo test`
