### PR TITLE
chore(git): ignore demo receipt artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,11 @@ deployed_addresses*.json
 .mcp.json
 examples/onboard-agent/onboarding_secrets.json
 
+# Demo receipts (safe, but easy to accidentally commit)
+examples/**/crosschain_receipt.json
+examples/**/onboarding_receipt.json
+examples/**/validation_receipt.json
+
 # Claude Code
 .claude/settings.local.json
 


### PR DESCRIPTION
## Summary
Ignore demo receipt artifacts under `examples/**` so they aren’t accidentally committed.

These files aren’t secrets, but they’re noisy operational artifacts (tx hashes, IDs, etc.).

## Test plan
N/A (gitignore-only change)
