### PR TITLE
feat(erc8004): paginated list getters for bounded reads

### DIFF
--- a/contracts/erc8004-cairo/src/interfaces/reputation_registry.cairo
+++ b/contracts/erc8004-cairo/src/interfaces/reputation_registry.cairo
@@ -144,6 +144,33 @@ pub trait IReputationRegistry<TState> {
         Array<bool>,
     );
 
+    /// Read feedback entries matching filters using a bounded scan window.
+    /// Returns arrays: (clients, feedbackIndexes, values, valueDecimals, tag1s, tag2s, revokedStatuses, truncated)
+    /// - client_offset/client_limit paginate the client list
+    /// - feedback_offset/feedback_limit paginate feedback indices per client
+    /// - truncated=true means additional scan work exists outside this window
+    fn read_all_feedback_paginated(
+        self: @TState,
+        agent_id: u256,
+        client_addresses: Span<ContractAddress>,
+        tag1: ByteArray,
+        tag2: ByteArray,
+        include_revoked: bool,
+        client_offset: u32,
+        client_limit: u32,
+        feedback_offset: u64,
+        feedback_limit: u64,
+    ) -> (
+        Array<ContractAddress>,
+        Array<u64>,
+        Array<i128>,
+        Array<u8>,
+        Array<ByteArray>,
+        Array<ByteArray>,
+        Array<bool>,
+        bool,
+    );
+
     /// Get response count for feedback
     fn get_response_count(
         self: @TState,

--- a/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
+++ b/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
@@ -121,8 +121,22 @@ pub trait IValidationRegistry<TState> {
     /// @notice Get all validation request hashes for an agent
     fn get_agent_validations(self: @TState, agent_id: u256) -> Array<u256>;
 
+    /// @notice Get validation request hashes for an agent (paginated)
+    /// @return (request_hashes, truncated)
+    /// - truncated=true means additional items exist after this page
+    fn get_agent_validations_paginated(
+        self: @TState, agent_id: u256, offset: u64, limit: u64,
+    ) -> (Array<u256>, bool);
+
     /// @notice Get all request hashes created by a validator
     fn get_validator_requests(self: @TState, validator_address: ContractAddress) -> Array<u256>;
+
+    /// @notice Get request hashes created by a validator (paginated)
+    /// @return (request_hashes, truncated)
+    /// - truncated=true means additional items exist after this page
+    fn get_validator_requests_paginated(
+        self: @TState, validator_address: ContractAddress, offset: u64, limit: u64,
+    ) -> (Array<u256>, bool);
 
     /// @notice Check if a request exists
     fn request_exists(self: @TState, request_hash: u256) -> bool;

--- a/contracts/erc8004-cairo/src/validation_registry.cairo
+++ b/contracts/erc8004-cairo/src/validation_registry.cairo
@@ -427,6 +427,28 @@ pub mod ValidationRegistry {
             result
         }
 
+        fn get_agent_validations_paginated(
+            self: @ContractState, agent_id: u256, offset: u64, limit: u64,
+        ) -> (Array<u256>, bool) {
+            let mut result = ArrayTrait::new();
+            let vec = self.agent_validations.entry(agent_id);
+            let len = vec.len();
+
+            if offset >= len {
+                return (result, false);
+            }
+
+            let end = if offset + limit < len { offset + limit } else { len };
+
+            let mut i = offset;
+            while i < end {
+                result.append(vec.at(i).read());
+                i += 1;
+            }
+
+            (result, end < len)
+        }
+
         fn get_validator_requests(
             self: @ContractState, validator_address: ContractAddress,
         ) -> Array<u256> {
@@ -440,6 +462,28 @@ pub mod ValidationRegistry {
             }
 
             result
+        }
+
+        fn get_validator_requests_paginated(
+            self: @ContractState, validator_address: ContractAddress, offset: u64, limit: u64,
+        ) -> (Array<u256>, bool) {
+            let mut result = ArrayTrait::new();
+            let vec = self.validator_requests.entry(validator_address);
+            let len = vec.len();
+
+            if offset >= len {
+                return (result, false);
+            }
+
+            let end = if offset + limit < len { offset + limit } else { len };
+
+            let mut i = offset;
+            while i < end {
+                result.append(vec.at(i).read());
+                i += 1;
+            }
+
+            (result, end < len)
         }
 
         fn request_exists(self: @ContractState, request_hash: u256) -> bool {

--- a/contracts/erc8004-cairo/tests/test_reputation_registry.cairo
+++ b/contracts/erc8004-cairo/tests/test_reputation_registry.cairo
@@ -812,6 +812,54 @@ fn test_read_all_feedback_success() {
 }
 
 #[test]
+fn test_read_all_feedback_paginated_limits_work_and_sets_truncated() {
+    let (identity_registry, reputation_registry, identity_address, reputation_address) =
+        deploy_contracts();
+
+    start_cheat_caller_address(identity_address, agent_owner());
+    let agent_id = identity_registry.register();
+    stop_cheat_caller_address(identity_address);
+
+    // Client 1 gives two feedbacks
+    give_feedback_helper(
+        reputation_registry, reputation_address, agent_id, client(), 90, 0, "tag1", "tag2",
+    );
+    give_feedback_helper(
+        reputation_registry, reputation_address, agent_id, client(), 91, 0, "tag1", "tag2",
+    );
+    // Client 2 gives one feedback
+    give_feedback_helper(
+        reputation_registry, reputation_address, agent_id, client2(), 85, 0, "tag1", "tag2",
+    );
+
+    let empty_clients: Span<ContractAddress> = array![].span();
+
+    // First page: only first client, only first feedback index scanned.
+    let (clients_arr, indexes_arr, values_arr, _, _, _, _, truncated) = reputation_registry
+        .read_all_feedback_paginated(
+            agent_id, empty_clients, "", "", false, 0, 1, 0, 1,
+        );
+
+    assert_eq!(clients_arr.len(), 1);
+    assert_eq!(indexes_arr.len(), 1);
+    assert_eq!(values_arr.len(), 1);
+    assert_eq!(*clients_arr.at(0), client());
+    assert_eq!(*indexes_arr.at(0), 1);
+    assert_eq!(*values_arr.at(0), 90);
+    assert(truncated, 'truncated');
+
+    // Full window: all clients, enough feedback scan to include all three entries.
+    let (clients_full, _, values_full, _, _, _, _, truncated_full) = reputation_registry
+        .read_all_feedback_paginated(
+            agent_id, empty_clients, "", "", false, 0, 10, 0, 10,
+        );
+
+    assert_eq!(clients_full.len(), 3);
+    assert_eq!(values_full.len(), 3);
+    assert(!truncated_full, 'not truncated');
+}
+
+#[test]
 fn test_read_all_feedback_excludes_revoked() {
     let (identity_registry, reputation_registry, identity_address, reputation_address) =
         deploy_contracts();


### PR DESCRIPTION
## Why
The ERC-8004 registries include a few **unbounded list reads** (O(n) storage Vec -> full Array) that become impractical as the dataset grows.

This PR adds **bounded/paginated** alternatives so indexers/clients can page safely without changing parity semantics.

## What
### Additive API (Extension)
- ValidationRegistry:
  - `get_agent_validations_paginated(agent_id, offset, limit) -> (Array<u256>, bool truncated)`
  - `get_validator_requests_paginated(validator, offset, limit) -> (Array<u256>, bool truncated)`
- ReputationRegistry:
  - `read_all_feedback_paginated(..., client_offset, client_limit, feedback_offset, feedback_limit) -> (..., bool truncated)`

### Parity preserved
- Existing unbounded getters remain **unchanged**:
  - `get_agent_validations()`
  - `get_validator_requests()`
  - `read_all_feedback()`

These are still available for parity / small datasets; the new functions are the recommended production path.

## Tests
- Added unit tests covering slice correctness + `truncated` semantics.
- `contracts/erc8004-cairo`: `scarb test` (134 tests)
