### PR TITLE
spike(mcp): starknet_build_calls for Cartridge Controller compatibility

### DIFF
--- a/examples/controller-calls/README.md
+++ b/examples/controller-calls/README.md
@@ -1,0 +1,125 @@
+# Controller Calls (Spike)
+
+Demonstrates the non-custodial integration path: MCP builds unsigned calls,
+an external signer (Cartridge Controller, hardware wallet, multisig) executes.
+
+Related: [#189](https://github.com/keep-starknet-strange/starknet-agentic/issues/189)
+
+## Architecture
+
+```
+Agent (MCP client)
+  │
+  ▼
+starknet_build_calls          ← call builder, no signing
+  │
+  ▼
+calls.json                    ← portable, unsigned
+  │
+  ▼
+External signer               ← Controller SessionAccount, multisig, etc.
+  │
+  ▼
+Starknet
+```
+
+## 1. Build calls via MCP
+
+Use the `starknet_build_calls` tool to compose validated, unsigned calls:
+
+```json
+{
+  "name": "starknet_build_calls",
+  "arguments": {
+    "calls": [
+      {
+        "contractAddress": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "entrypoint": "transfer",
+        "calldata": ["0x123", "0x0", "0x64", "0x0"]
+      }
+    ]
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "calls": [
+    {
+      "contractAddress": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      "entrypoint": "transfer",
+      "calldata": ["0x123", "0x0", "0x64", "0x0"]
+    }
+  ],
+  "callCount": 1,
+  "note": "Unsigned calls. Pass to account.execute(calls) or write to calls.json for external signing."
+}
+```
+
+## 2. Write calls.json
+
+Save the `calls` array to a file:
+
+```bash
+echo '<MCP response>' | jq '.calls' > calls.json
+```
+
+## 3. Execute with Cartridge Controller (Node.js)
+
+```ts
+import { SessionAccount } from "@cartridge/controller/node";
+import calls from "./calls.json" assert { type: "json" };
+
+const account = new SessionAccount(provider, sessionConfig);
+const { transaction_hash } = await account.execute(calls);
+```
+
+See `run.mjs` for a runnable script.
+
+## 4. Execute with starknet.js directly
+
+```ts
+import { Account, RpcProvider } from "starknet";
+import calls from "./calls.json" assert { type: "json" };
+
+const provider = new RpcProvider({ nodeUrl: process.env.STARKNET_RPC_URL });
+const account = new Account(provider, address, privateKey);
+const { transaction_hash } = await account.execute(calls);
+```
+
+## Wire format
+
+The `calls.json` schema is starknet.js `Call[]`:
+
+```ts
+interface Call {
+  contractAddress: string;  // 0x-prefixed felt
+  entrypoint: string;       // function name
+  calldata: string[];       // array of 0x-prefixed felt strings
+}
+```
+
+This is directly compatible with:
+- `starknet.js` `Account.execute()`
+- `@cartridge/controller` `SessionAccount.execute()`
+- Any signer that accepts starknet.js `Call[]`
+
+## Failure modes
+
+| Scenario | Behavior |
+|----------|----------|
+| Invalid contract address | `starknet_build_calls` rejects before output |
+| Invalid calldata felt | `starknet_build_calls` rejects before output |
+| No active session | Controller throws at `execute()` time |
+| Policy rejection | Controller throws if call doesn't match session policy |
+| Execution revert | RPC returns revert reason after submission |
+
+## Spike conclusion
+
+**GO** -- the `Call[]` wire format is identical between starknet.js and
+Cartridge Controller. No format translation needed. MCP builds calls,
+Controller executes. The split is clean.
+
+Open questions for Cartridge team remain in [#189](https://github.com/keep-starknet-strange/starknet-agentic/issues/189).

--- a/examples/controller-calls/run.mjs
+++ b/examples/controller-calls/run.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+/**
+ * Controller Calls Spike - Generate calls.json from MCP-style input
+ *
+ * Usage:
+ *   node run.mjs                       # prints sample calls.json to stdout
+ *   node run.mjs > calls.json          # save to file
+ *   node run.mjs --execute             # execute with starknet.js (needs env vars)
+ *
+ * Env vars (only for --execute):
+ *   STARKNET_RPC_URL
+ *   STARKNET_ACCOUNT_ADDRESS
+ *   STARKNET_PRIVATE_KEY
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+// --- Call builder (mirrors starknet_build_calls MCP tool logic) ---
+
+const FELT_MAX = (1n << 251n) - 1n;
+
+function validateFelt(name, value) {
+  const n = BigInt(value);
+  if (n < 0n || n > FELT_MAX) {
+    throw new Error(`${name}: ${value} is out of felt range`);
+  }
+  return "0x" + n.toString(16);
+}
+
+function buildCalls(rawCalls) {
+  if (!rawCalls || rawCalls.length === 0) {
+    throw new Error("calls array must not be empty");
+  }
+
+  return rawCalls.map((call, i) => {
+    if (!call.contractAddress) throw new Error(`calls[${i}].contractAddress required`);
+    if (!call.entrypoint) throw new Error(`calls[${i}].entrypoint required`);
+
+    const calldata = (call.calldata || []).map((v, j) =>
+      validateFelt(`calls[${i}].calldata[${j}]`, v)
+    );
+
+    return {
+      contractAddress: call.contractAddress,
+      entrypoint: call.entrypoint,
+      calldata,
+    };
+  });
+}
+
+// --- Sample calls ---
+
+const sampleCalls = [
+  {
+    contractAddress:
+      "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+    entrypoint: "transfer",
+    calldata: [
+      "0x0000000000000000000000000000000000000000000000000000000000000123",
+      "0x0",
+      "0x64",
+      "0x0",
+    ],
+  },
+];
+
+// --- Main ---
+
+const args = process.argv.slice(2);
+const executeMode = args.includes("--execute");
+
+const calls = buildCalls(sampleCalls);
+const callsJson = JSON.stringify(calls, null, 2);
+
+if (!executeMode) {
+  // Print calls.json to stdout
+  console.log(callsJson);
+  console.error(
+    `\n# ${calls.length} call(s) built. To execute with Cartridge Controller:\n` +
+    `#   node run.mjs > calls.json\n` +
+    `#   # Then in your Controller-enabled app:\n` +
+    `#   import calls from "./calls.json" assert { type: "json" };\n` +
+    `#   await account.execute(calls);\n`
+  );
+  process.exit(0);
+}
+
+// --- Execute mode (starknet.js, not Controller) ---
+
+const { RpcProvider, Account } = await import("starknet");
+
+const rpcUrl = process.env.STARKNET_RPC_URL;
+const address = process.env.STARKNET_ACCOUNT_ADDRESS;
+const privateKey = process.env.STARKNET_PRIVATE_KEY;
+
+if (!rpcUrl || !address || !privateKey) {
+  console.error(
+    "Set STARKNET_RPC_URL, STARKNET_ACCOUNT_ADDRESS, STARKNET_PRIVATE_KEY"
+  );
+  process.exit(1);
+}
+
+console.error("Executing calls with starknet.js...");
+console.error("Calls:", callsJson);
+
+const provider = new RpcProvider({ nodeUrl: rpcUrl });
+const account = new Account(provider, address, privateKey);
+const result = await account.execute(calls);
+
+console.log(JSON.stringify({ transactionHash: result.transaction_hash }, null, 2));
+
+const receipt = await provider.waitForTransaction(result.transaction_hash);
+console.error("Transaction accepted:", result.transaction_hash);


### PR DESCRIPTION
## Summary

- Adds `starknet_build_calls` MCP tool: validates and returns unsigned `Call[]` without executing
- Wire format is starknet.js `Call[]`, directly compatible with Cartridge Controller `SessionAccount.execute()`
- Example in `examples/controller-calls/` showing MCP -> calls.json -> external signer flow
- 7 deterministic tests for schema validation, multicall, decimal normalization, and error cases

Closes #189

## Spike conclusion

**GO** -- the `Call[]` wire format is identical between starknet.js and Cartridge Controller. No format translation needed. MCP builds calls, Controller executes. The split is clean.

Open questions for Cartridge team (policy enforcement scope, degradation behavior) remain in #189.

## Test plan

- [x] 171 tests pass (`pnpm --filter @starknet-agentic/mcp-server test`)
- [x] No new TypeScript errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)