### PR TITLE
security(mcp): require mTLS client certs for production signer transport

### DIFF
--- a/packages/starknet-mcp-server/README.md
+++ b/packages/starknet-mcp-server/README.md
@@ -43,6 +43,10 @@ STARKNET_ACCOUNT_ADDRESS=0x...
 STARKNET_SIGNER_MODE=proxy
 KEYRING_PROXY_URL=https://signer.internal:8545
 KEYRING_HMAC_SECRET=replace-with-long-random-secret
+# mTLS client material (required in production for non-loopback signer URLs)
+# KEYRING_TLS_CLIENT_CERT_PATH=/etc/starknet-mcp/tls/client.crt
+# KEYRING_TLS_CLIENT_KEY_PATH=/etc/starknet-mcp/tls/client.key
+# KEYRING_TLS_CA_PATH=/etc/starknet-mcp/tls/ca.crt
 # Optional:
 # KEYRING_CLIENT_ID=starknet-mcp-server
 # KEYRING_SIGNING_KEY_ID=default
@@ -51,6 +55,7 @@ KEYRING_HMAC_SECRET=replace-with-long-random-secret
 ```
 
 Production startup guard: `KEYRING_PROXY_URL` must use `https://` unless loopback is used (`http://127.0.0.1`, `http://localhost`, or `http://[::1]`).
+Production startup guard (non-loopback signer URLs): `KEYRING_TLS_CLIENT_CERT_PATH`, `KEYRING_TLS_CLIENT_KEY_PATH`, and `KEYRING_TLS_CA_PATH` are required.
 
 ## Usage
 
@@ -214,6 +219,7 @@ The server uses:
 
 - Production startup guard: `NODE_ENV=production` requires `STARKNET_SIGNER_MODE=proxy`
 - Production startup guard: rejects `STARKNET_PRIVATE_KEY` when `STARKNET_SIGNER_MODE=proxy`
+- Production startup guard: non-loopback proxy URLs require mTLS client cert/key/CA paths
 - Proxy mode keeps signing outside MCP process (`starknet-keyring-proxy`)
 - Direct private key mode is intended for local development only
 - All inputs are validated before execution

--- a/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
+++ b/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
@@ -1405,6 +1405,24 @@ describe("MCP Startup Guardrails", () => {
       "Production proxy mode requires KEYRING_PROXY_URL to use https unless loopback is used"
     );
   });
+
+  it("fails startup in production proxy mode when mTLS client cert config is missing", async () => {
+    for (const [key, value] of Object.entries(mockEnv)) {
+      process.env[key] = value;
+    }
+    process.env.NODE_ENV = "production";
+    process.env.STARKNET_SIGNER_MODE = "proxy";
+    process.env.KEYRING_PROXY_URL = "https://signer.internal:8545";
+    delete process.env.STARKNET_PRIVATE_KEY;
+    delete process.env.KEYRING_TLS_CLIENT_CERT_PATH;
+    delete process.env.KEYRING_TLS_CLIENT_KEY_PATH;
+    delete process.env.KEYRING_TLS_CA_PATH;
+
+    vi.resetModules();
+    await expect(import("../../src/index.js")).rejects.toThrow(
+      "Production proxy mode requires KEYRING_TLS_CLIENT_CERT_PATH, KEYRING_TLS_CLIENT_KEY_PATH, and KEYRING_TLS_CA_PATH for mTLS"
+    );
+  });
 });
 
 describe("Tool list", () => {

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -87,6 +87,9 @@ const envSchema = z.object({
   KEYRING_SIGNING_KEY_ID: z.string().min(1).optional(),
   KEYRING_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
   KEYRING_SESSION_VALIDITY_SECONDS: z.coerce.number().int().positive().optional(),
+  KEYRING_TLS_CLIENT_CERT_PATH: z.string().min(1).optional(),
+  KEYRING_TLS_CLIENT_KEY_PATH: z.string().min(1).optional(),
+  KEYRING_TLS_CA_PATH: z.string().min(1).optional(),
   NODE_ENV: z.string().optional(),
 });
 
@@ -114,6 +117,9 @@ const env = envSchema.parse({
   KEYRING_SIGNING_KEY_ID: process.env.KEYRING_SIGNING_KEY_ID,
   KEYRING_REQUEST_TIMEOUT_MS: process.env.KEYRING_REQUEST_TIMEOUT_MS,
   KEYRING_SESSION_VALIDITY_SECONDS: process.env.KEYRING_SESSION_VALIDITY_SECONDS,
+  KEYRING_TLS_CLIENT_CERT_PATH: process.env.KEYRING_TLS_CLIENT_CERT_PATH,
+  KEYRING_TLS_CLIENT_KEY_PATH: process.env.KEYRING_TLS_CLIENT_KEY_PATH,
+  KEYRING_TLS_CA_PATH: process.env.KEYRING_TLS_CA_PATH,
   NODE_ENV: process.env.NODE_ENV,
 });
 
@@ -149,6 +155,17 @@ if (signerMode === "proxy") {
         "Production proxy mode requires KEYRING_PROXY_URL to use https unless loopback is used"
       );
     }
+    if (!isLoopback) {
+      if (
+        !env.KEYRING_TLS_CLIENT_CERT_PATH ||
+        !env.KEYRING_TLS_CLIENT_KEY_PATH ||
+        !env.KEYRING_TLS_CA_PATH
+      ) {
+        throw new Error(
+          "Production proxy mode requires KEYRING_TLS_CLIENT_CERT_PATH, KEYRING_TLS_CLIENT_KEY_PATH, and KEYRING_TLS_CA_PATH for mTLS"
+        );
+      }
+    }
   }
   if (isProductionRuntime && env.STARKNET_PRIVATE_KEY) {
     throw new Error(
@@ -179,6 +196,9 @@ const accountSigner =
         requestTimeoutMs: env.KEYRING_REQUEST_TIMEOUT_MS ?? 5_000,
         sessionValiditySeconds: env.KEYRING_SESSION_VALIDITY_SECONDS ?? 300,
         keyId: env.KEYRING_SIGNING_KEY_ID,
+        tlsClientCertPath: env.KEYRING_TLS_CLIENT_CERT_PATH,
+        tlsClientKeyPath: env.KEYRING_TLS_CLIENT_KEY_PATH,
+        tlsCaPath: env.KEYRING_TLS_CA_PATH,
       })
     : env.STARKNET_PRIVATE_KEY!;
 


### PR DESCRIPTION
## Summary
Enforces production-grade mTLS client authentication for MCP -> signer transport.

This PR adds Node-side mTLS client support to `KeyringProxySigner` and startup guards that require client cert/key/CA in production when proxy URL is non-loopback.

## Threat Model
- Attacker on network path can target signer transport if only server TLS + HMAC are configured but no mutual client identity.
- Misconfiguration risk in production where proxy mode is enabled but client certs are omitted.

## Before / After
- Before:
  - MCP proxy signer used `fetch` only, without client certificate presentation.
  - Production guard required `https` proxy URL but not mTLS client material.
- After:
  - Optional mTLS transport path uses `https.request` with client `cert`/`key`/`ca`.
  - Production guard requires:
    - `KEYRING_TLS_CLIENT_CERT_PATH`
    - `KEYRING_TLS_CLIENT_KEY_PATH`
    - `KEYRING_TLS_CA_PATH`
    when proxy URL is non-loopback.

## Scope
- `packages/starknet-mcp-server/src/helpers/keyringProxySigner.ts`
- `packages/starknet-mcp-server/src/index.ts`
- `packages/starknet-mcp-server/__tests__/helpers/keyringProxySigner.test.ts`
- `packages/starknet-mcp-server/__tests__/handlers/tools.test.ts`
- `packages/starknet-mcp-server/README.md`

## Tests
- `pnpm --filter @starknet-agentic/mcp-server test` (261/261 passing)
- `pnpm --filter @starknet-agentic/mcp-server build` (passing)

## Backward Compatibility
- Existing proxy mode continues to work without mTLS in non-production or loopback deployments.
- Production non-loopback deployments must now provide mTLS client material.

## Rollback Plan
- Revert this PR commit.
- Startup guard and client mTLS behavior return to previous state.
