### PR TITLE
security(validation-registry): enforce one immutable response per request

### DIFF
--- a/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
+++ b/contracts/erc8004-cairo/src/interfaces/validation_registry.cairo
@@ -71,7 +71,7 @@ pub trait IValidationRegistry<TState> {
         request_hash: u256,
     );
 
-    /// @notice Respond to a validation request
+    /// @notice Respond to a validation request (single immutable response)
     /// @param request_hash Hash of the original request
     /// @param response The validation result (0-100)
     /// @param response_uri URI containing response details

--- a/contracts/erc8004-cairo/src/validation_registry.cairo
+++ b/contracts/erc8004-cairo/src/validation_registry.cairo
@@ -7,7 +7,7 @@
 //
 // Key Features:
 // - Validation requests with URI and hash commitments
-// - Multiple responses per request (progressive validation)
+// - Single immutable response per request
 // - Tag-based categorization (ByteArray for Solidity string parity)
 // - On-chain aggregation for composability
 // - Support for various validation methods (stake-secured, zkML, TEE)
@@ -211,6 +211,10 @@ pub mod ValidationRegistry {
             // Only the designated validator can respond
             let caller = get_caller_address();
             assert(caller == request.validator_address, 'Not validator');
+
+            // Finalize-once policy: response is immutable once submitted.
+            let existing = self.responses.entry(request_hash).read();
+            assert(!existing.has_response, 'Response already submitted');
 
             // Store response
             self

--- a/contracts/erc8004-cairo/tests/test_validation_registry.cairo
+++ b/contracts/erc8004-cairo/tests/test_validation_registry.cairo
@@ -332,7 +332,8 @@ fn test_validation_response_success() {
 }
 
 #[test]
-fn test_validation_response_multiple_responses() {
+#[should_panic(expected: 'Response already submitted')]
+fn test_validation_response_second_submit_reverts() {
     let (identity_registry, validation_registry, identity_address, validation_address) =
         deploy_contracts();
 
@@ -357,14 +358,11 @@ fn test_validation_response_multiple_responses() {
     let (_, _, response1, _, _, _) = validation_registry.get_validation_status(request_hash);
     assert_eq!(response1, 20);
 
-    // Second response (80) - updates the first
+    // Second response must revert (immutable response policy)
     start_cheat_caller_address(validation_address, validator());
     let tag2: ByteArray = "hard-finality";
     validation_registry.validation_response(request_hash, 80, response_uri, 0, tag2);
     stop_cheat_caller_address(validation_address);
-
-    let (_, _, response2, _, _, _) = validation_registry.get_validation_status(request_hash);
-    assert_eq!(response2, 80);
 }
 
 #[test]

--- a/contracts/erc8004-cairo/tests/test_validation_registry_fuzz.cairo
+++ b/contracts/erc8004-cairo/tests/test_validation_registry_fuzz.cairo
@@ -46,8 +46,9 @@ fn deploy_contracts() -> (
 }
 
 #[test]
+#[should_panic(expected: 'Response already submitted')]
 #[fuzzer(runs: 64)]
-fn fuzz_validation_same_responder_can_update(raw_first: u8, raw_second: u8) {
+fn fuzz_validation_same_responder_cannot_overwrite(raw_first: u8, raw_second: u8) {
     let (identity_registry, validation_registry, identity_address, validation_address) =
         deploy_contracts();
 
@@ -67,10 +68,6 @@ fn fuzz_validation_same_responder_can_update(raw_first: u8, raw_second: u8) {
     validation_registry.validation_response(request_hash, first, "", 0, "");
     validation_registry.validation_response(request_hash, second, "", 0, "");
     stop_cheat_caller_address(validation_address);
-
-    let (_, _, resp, _, _, _) = validation_registry.get_validation_status(request_hash);
-
-    assert_eq!(resp, second);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make `validation_response` finalize-once: second submission for the same `request_hash` now reverts
- update interface/contract comments to reflect immutable response semantics
- update unit and fuzz tests to enforce the new invariant

## Security rationale
Prevents a designated validator (or compromised validator key) from overwriting a previously submitted response for the same request hash.

## Validation
- `cd contracts/erc8004-cairo && scarb test` (134 passed)
