### PR TITLE
security(factory): enforce two-step ownership transfer

### DIFF
--- a/contracts/agent-account/src/agent_account_factory.cairo
+++ b/contracts/agent-account/src/agent_account_factory.cairo
@@ -22,6 +22,7 @@ pub mod AgentAccountFactory {
     #[storage]
     struct Storage {
         owner: ContractAddress,
+        pending_owner: ContractAddress,
         account_class_hash: ClassHash,
         identity_registry: ContractAddress,
     }
@@ -32,7 +33,14 @@ pub mod AgentAccountFactory {
         AccountDeployed: AccountDeployed,
         AccountClassHashUpdated: AccountClassHashUpdated,
         IdentityRegistryUpdated: IdentityRegistryUpdated,
+        OwnershipTransferStarted: OwnershipTransferStarted,
         OwnershipTransferred: OwnershipTransferred,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct OwnershipTransferStarted {
+        previous_owner: ContractAddress,
+        pending_owner: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -69,6 +77,7 @@ pub mod AgentAccountFactory {
     ) {
         let caller = get_caller_address();
         self.owner.write(caller);
+        self.pending_owner.write(0.try_into().unwrap());
         self.account_class_hash.write(account_class_hash);
         self.identity_registry.write(identity_registry);
     }
@@ -154,13 +163,29 @@ pub mod AgentAccountFactory {
             self.owner.read()
         }
 
+        fn get_pending_owner(self: @ContractState) -> ContractAddress {
+            self.pending_owner.read()
+        }
+
         fn transfer_ownership(ref self: ContractState, new_owner: ContractAddress) {
             self._assert_owner();
             let zero: ContractAddress = 0.try_into().unwrap();
             assert(new_owner != zero, 'New owner is zero address');
             let previous_owner = self.owner.read();
-            self.owner.write(new_owner);
-            self.emit(OwnershipTransferred { previous_owner, new_owner });
+            self.pending_owner.write(new_owner);
+            self.emit(OwnershipTransferStarted { previous_owner, pending_owner: new_owner });
+        }
+
+        fn accept_ownership(ref self: ContractState) {
+            let caller = get_caller_address();
+            let pending_owner = self.pending_owner.read();
+            assert(caller == pending_owner, 'Only pending owner');
+
+            let previous_owner = self.owner.read();
+            let zero: ContractAddress = 0.try_into().unwrap();
+            self.owner.write(caller);
+            self.pending_owner.write(zero);
+            self.emit(OwnershipTransferred { previous_owner, new_owner: caller });
         }
     }
 

--- a/contracts/agent-account/src/interfaces.cairo
+++ b/contracts/agent-account/src/interfaces.cairo
@@ -65,5 +65,7 @@ pub trait IAgentAccountFactory<TContractState> {
     fn get_identity_registry(self: @TContractState) -> ContractAddress;
     fn set_identity_registry(ref self: TContractState, new_registry: ContractAddress);
     fn get_owner(self: @TContractState) -> ContractAddress;
+    fn get_pending_owner(self: @TContractState) -> ContractAddress;
     fn transfer_ownership(ref self: TContractState, new_owner: ContractAddress);
+    fn accept_ownership(ref self: TContractState);
 }

--- a/contracts/agent-account/tests/test_agent_account_factory.cairo
+++ b/contracts/agent-account/tests/test_agent_account_factory.cairo
@@ -182,7 +182,8 @@ fn test_transfer_ownership() {
     factory.transfer_ownership(new_owner);
     stop_cheat_caller_address(factory_addr);
 
-    assert(factory.get_owner() == new_owner, 'Owner transferred');
+    assert(factory.get_owner() == owner, 'Owner should remain');
+    assert(factory.get_pending_owner() == new_owner, 'Pending owner set');
 }
 
 #[test]
@@ -193,6 +194,11 @@ fn test_transfer_ownership_new_owner_can_admin() {
 
     start_cheat_caller_address(factory_addr, owner);
     factory.transfer_ownership(new_owner);
+    stop_cheat_caller_address(factory_addr);
+
+    // Pending owner accepts ownership
+    start_cheat_caller_address(factory_addr, new_owner);
+    factory.accept_ownership();
     stop_cheat_caller_address(factory_addr);
 
     // New owner can set class hash
@@ -215,10 +221,46 @@ fn test_transfer_ownership_old_owner_loses_access() {
     factory.transfer_ownership(new_owner);
     stop_cheat_caller_address(factory_addr);
 
+    // Ownership is finalized only after accept.
+    start_cheat_caller_address(factory_addr, new_owner);
+    factory.accept_ownership();
+    stop_cheat_caller_address(factory_addr);
+
     // Old owner can no longer admin
     let new_hash: ClassHash = 0xeee.try_into().unwrap();
     start_cheat_caller_address(factory_addr, owner);
     factory.set_account_class_hash(new_hash);
+}
+
+#[test]
+#[should_panic(expected: 'Only owner')]
+fn test_pending_owner_cannot_admin_before_accept() {
+    let (factory, factory_addr, _, _) = setup();
+    let owner = factory.get_owner();
+    let new_owner = other();
+
+    start_cheat_caller_address(factory_addr, owner);
+    factory.transfer_ownership(new_owner);
+    stop_cheat_caller_address(factory_addr);
+
+    let new_hash: ClassHash = 0xabc.try_into().unwrap();
+    start_cheat_caller_address(factory_addr, new_owner);
+    factory.set_account_class_hash(new_hash);
+}
+
+#[test]
+#[should_panic(expected: 'Only pending owner')]
+fn test_accept_ownership_rejects_non_pending_owner() {
+    let (factory, factory_addr, _, _) = setup();
+    let owner = factory.get_owner();
+    let new_owner = other();
+
+    start_cheat_caller_address(factory_addr, owner);
+    factory.transfer_ownership(new_owner);
+    stop_cheat_caller_address(factory_addr);
+
+    start_cheat_caller_address(factory_addr, addr(0x1234));
+    factory.accept_ownership();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- convert `AgentAccountFactory` ownership transfer to two-step flow
- `transfer_ownership(new_owner)` now sets `pending_owner`
- add `accept_ownership()` callable only by pending owner
- add `get_pending_owner()` view
- add `OwnershipTransferStarted` event and keep `OwnershipTransferred` on finalization

## Security rationale
Prevents accidental ownership loss from a one-step transfer typo and aligns with production-grade ownership handoff patterns.

## Validation
- `cd contracts/agent-account && scarb test` (117 passed)
