### PR TITLE
security(registry): strict SNIP-6 return + prevent Huginn profile overwrite

### DIFF
--- a/contracts/erc8004-cairo/src/identity_registry.cairo
+++ b/contracts/erc8004-cairo/src/identity_registry.cairo
@@ -529,8 +529,9 @@ pub mod IdentityRegistry {
             // SNIP-6 standard: returns 'VALID' (0x56414c4944) if signature is valid
             let result = account.is_valid_signature(message_hash, signature_array);
 
-            // Check if result equals 'VALID'
-            result == 'VALID' || result == starknet::VALIDATED
+            // SNIP-6 requires `is_valid_signature` to return 'VALID' on success.
+            // We intentionally do not accept alternative return markers here.
+            result == 'VALID'
         }
     }
 

--- a/contracts/huginn-registry/src/lib.cairo
+++ b/contracts/huginn-registry/src/lib.cairo
@@ -29,6 +29,7 @@ pub mod HuginnRegistry {
     struct Storage {
         verifier: ContractAddress,
         agents: Map<ContractAddress, AgentProfile>,
+        agent_registered: Map<ContractAddress, bool>,
         thought_owner: Map<u256, ContractAddress>,
         thought_proofs: Map<u256, Proof>,
     }
@@ -93,6 +94,7 @@ pub mod HuginnRegistry {
     impl HuginnRegistryImpl of super::IHuginnRegistry<ContractState> {
         fn register_agent(ref self: ContractState, name: felt252, metadata_url: ByteArray) {
             let caller = get_caller_address();
+            assert(!self.agent_registered.read(caller), 'Agent already registered');
             let timestamp = starknet::get_block_timestamp();
 
             let profile = AgentProfile {
@@ -101,6 +103,7 @@ pub mod HuginnRegistry {
                 registered_at: timestamp,
             };
             self.agents.write(caller, profile);
+            self.agent_registered.write(caller, true);
 
             self.emit(Event::OdinEye(OdinEye { agent_id: caller, name }));
         }

--- a/contracts/huginn-registry/tests/test_contract.cairo
+++ b/contracts/huginn-registry/tests/test_contract.cairo
@@ -52,6 +52,19 @@ fn test_register_agent() {
 }
 
 #[test]
+#[should_panic(expected: 'Agent already registered')]
+fn test_register_agent_rejects_overwrite() {
+    let contract_address = deploy_contract(test_address());
+    let dispatcher = IHuginnRegistryDispatcher { contract_address };
+
+    let caller = 0x1.try_into().unwrap();
+    start_cheat_caller_address(contract_address, caller);
+
+    dispatcher.register_agent('alpha_agent', "ipfs://metadata");
+    dispatcher.register_agent('new_name', "ipfs://new");
+}
+
+#[test]
 fn test_log_thought() {
     let contract_address = deploy_contract(test_address());
     let dispatcher = IHuginnRegistryDispatcher { contract_address };


### PR DESCRIPTION
## Summary
This hardening batch addresses two remaining audit items in low-risk, isolated changes:

1. **IdentityRegistry**: enforce strict SNIP-6 `is_valid_signature` success marker (`'VALID'`)
2. **HuginnRegistry**: block silent profile overwrite by rejecting re-registration for the same caller

## Changes
- `contracts/erc8004-cairo/src/identity_registry.cairo`
  - `_verify_wallet_signature` now accepts only `'VALID'`
- `contracts/huginn-registry/src/lib.cairo`
  - added `agent_registered: Map<ContractAddress, bool>`
  - `register_agent` now reverts with `Agent already registered` on second registration
- `contracts/huginn-registry/tests/test_contract.cairo`
  - added regression test `test_register_agent_rejects_overwrite`

## Validation
- `cd contracts/huginn-registry && scarb test`
- `cd contracts/erc8004-cairo && scarb test test_set_agent_wallet_success_with_valid_signature`
- `cd contracts/erc8004-cairo && scarb test test_set_agent_wallet_accepts_domain_separated_hash_signature`
- `cd contracts/erc8004-cairo && scarb test test_set_agent_wallet_rejects_legacy_hash_signature`

## Security impact
- Removes ambiguous signature-success semantics in wallet binding path
- Prevents undetected in-place identity profile mutation in Huginn registry
