### PR TITLE
refactor(skills): split cairo-contracts into 3 focused skills

### DIFF
--- a/skills/cairo-components/SKILL.md
+++ b/skills/cairo-components/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: cairo-components
+description: Use when composing contracts from reusable components — the Mixin pattern, writing custom components, and OpenZeppelin v3 component library (Ownable, ERC20, ERC721, AccessControl, Upgradeable, Pausable).
+license: Apache-2.0
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, components, openzeppelin, ownable, erc20, erc721, accesscontrol, upgradeable, pausable, mixin]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Components
+
+Reusable contract modules and OpenZeppelin v3 patterns for Starknet.
+
+> **Prerequisites:** Familiar with [cairo-language](../cairo-language/) basics and [cairo-contracts](../cairo-contracts/) structure (storage, events, interfaces).
+
+## When to Use
+
+- Composing a contract from OpenZeppelin components (Ownable, ERC20, AccessControl, etc.)
+- Writing a custom reusable component with `#[starknet::component]`
+- Understanding the Mixin pattern (`embeddable_as` / `#[abi(embed_v0)]`)
+
+**Not for:** Contract structure basics (use cairo-contracts), language fundamentals (use cairo-language), testing (use cairo-testing)
+
+## Scarb.toml Dependencies
+
+```toml
+[dependencies]
+starknet = ">=2.12.0"
+openzeppelin_access = "3.0.0"
+openzeppelin_token = "3.0.0"
+openzeppelin_upgrades = "3.0.0"
+openzeppelin_introspection = "3.0.0"
+openzeppelin_security = "3.0.0"
+```
+
+> **Note:** OZ packages are on the [Scarb registry](https://scarbs.dev). No git tags needed. Check `scarbs.dev` for the latest version.
+
+## Using a Component (Mixin Pattern)
+
+The Mixin pattern exposes all standard interface methods in a single `impl` block.
+This is the standard approach in OZ v3:
+
+```cairo
+#[starknet::contract]
+mod MyToken {
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    // Embed external implementations (makes functions callable from outside)
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+
+    // Internal implementations (for use inside the contract)
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.ownable.initializer(owner);
+        self.erc20.initializer("MyToken", "MTK");
+    }
+}
+```
+
+### Checklist for Adding a Component
+
+1. `use` the component module
+2. `component!(path: ..., storage: ..., event: ...)`
+3. `#[abi(embed_v0)] impl ... = Component::MixinImpl<ContractState>` (external)
+4. `impl ... = Component::InternalImpl<ContractState>` (internal)
+5. Add `#[substorage(v0)]` field in `Storage`
+6. Add `#[flat]` variant in `Event` enum
+7. Call `.initializer(...)` in constructor
+
+## Writing a Custom Component
+
+```cairo
+#[starknet::component]
+mod MyComponent {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        value: u256,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        new_value: u256,
+    }
+
+    #[embeddable_as(MyComponentImpl)]
+    impl MyComponent<
+        TContractState, +HasComponent<TContractState>
+    > of super::IMyComponent<ComponentState<TContractState>> {
+        fn get_value(self: @ComponentState<TContractState>) -> u256 {
+            self.value.read()
+        }
+
+        fn set_value(ref self: ComponentState<TContractState>, new_value: u256) {
+            self.value.write(new_value);
+            self.emit(ValueChanged { new_value });
+        }
+    }
+}
+```
+
+Key differences from a contract:
+- `#[starknet::component]` instead of `#[starknet::contract]`
+- `#[embeddable_as(Name)]` instead of `#[abi(embed_v0)]`
+- `ComponentState<TContractState>` instead of `ContractState`
+- `+HasComponent<TContractState>` trait bound required
+
+## OpenZeppelin Components Reference
+
+### Ownable
+
+```cairo
+use openzeppelin_access::ownable::OwnableComponent;
+
+component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+
+#[abi(embed_v0)]
+impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+// In constructor:
+self.ownable.initializer(owner);
+
+// In functions:
+self.ownable.assert_only_owner();
+```
+
+### Upgradeable
+
+```cairo
+use openzeppelin_upgrades::UpgradeableComponent;
+use openzeppelin_upgrades::interface::IUpgradeable;
+
+component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+#[abi(embed_v0)]
+impl UpgradeableImpl of IUpgradeable<ContractState> {
+    fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+        self.ownable.assert_only_owner();
+        self.upgradeable.upgrade(new_class_hash);
+    }
+}
+```
+
+### ERC20
+
+```cairo
+use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+#[abi(embed_v0)]
+impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+// In constructor:
+self.erc20.initializer("TokenName", "TKN");
+self.erc20.mint(recipient, initial_supply);
+```
+
+### AccessControl
+
+```cairo
+use openzeppelin_access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+
+component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
+
+#[abi(embed_v0)]
+impl AccessControlMixinImpl = AccessControlComponent::AccessControlMixinImpl<ContractState>;
+impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+
+// In constructor:
+self.access_control.initializer();
+self.access_control._grant_role(DEFAULT_ADMIN_ROLE, admin);
+self.access_control._grant_role(MINTER_ROLE, minter);
+
+// In functions:
+self.access_control.assert_only_role(MINTER_ROLE);
+```
+
+### Pausable
+
+```cairo
+use openzeppelin_security::pausable::PausableComponent;
+
+component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+
+#[abi(embed_v0)]
+impl PausableMixinImpl = PausableComponent::PausableMixinImpl<ContractState>;
+impl PausableInternalImpl = PausableComponent::InternalImpl<ContractState>;
+
+// In constructor — no initializer needed
+
+// In functions:
+self.pausable.assert_not_paused();
+
+// Owner pauses/unpauses:
+self.pausable.pause();
+self.pausable.unpause();
+```

--- a/skills/cairo-contracts/SKILL.md
+++ b/skills/cairo-contracts/SKILL.md
@@ -1,28 +1,30 @@
 ---
 name: cairo-contracts
-description: Use when writing Cairo smart contracts on Starknet — contract structure, storage, events, interfaces, components, OpenZeppelin v3 patterns, and common contract templates.
+description: Use when writing Cairo smart contracts on Starknet — contract structure, storage, events, interfaces, project layout, and common patterns.
 license: Apache-2.0
 metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
-keywords: [cairo, contracts, starknet, openzeppelin, components, storage, events, interfaces, erc20, erc721]
+keywords: [cairo, contracts, starknet, storage, events, interfaces, constructor, reentrancy]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true
 ---
 
 # Cairo Contracts
 
-Reference for writing Cairo smart contracts on Starknet. Covers structure, storage, events, interfaces, components, and OpenZeppelin v3 patterns.
+Reference for writing Cairo smart contracts on Starknet.
+Covers structure, storage, events, interfaces, and common patterns.
 
-> **Optimization:** After your contract compiles and tests pass, use the [cairo-optimization](../cairo-optimization/) skill as a separate pass.
+> **Related skills:**
+> - [cairo-language](../cairo-language/) — Cairo type system, ownership, traits, generics, modules
+> - [cairo-components](../cairo-components/) — Component pattern, OpenZeppelin v3 (Ownable, ERC20, AccessControl, etc.)
+> - [cairo-optimization](../cairo-optimization/) — Post-test gas optimization pass
 
 ## When to Use
 
 - Writing a new Starknet smart contract from scratch
 - Adding storage, events, or interfaces to an existing contract
-- Using OpenZeppelin components (Ownable, ERC20, ERC721, AccessControl, Upgradeable)
-- Implementing the component pattern with `embeddable_as`
 - Structuring a multi-contract project with Scarb
 
-**Not for:** Gas optimization (use cairo-optimization), testing (use cairo-testing), deployment (use cairo-deploy)
+**Not for:** Language basics (use cairo-language), components/OZ (use cairo-components), testing (use cairo-testing), deployment (use cairo-deploy), optimization (use cairo-optimization)
 
 ## Contract Structure
 
@@ -164,190 +166,6 @@ struct Transfer {
 self.emit(Transfer { from, to, amount });
 ```
 
-## Components (OpenZeppelin v3 Pattern)
-
-Components are reusable contract modules. This is the standard pattern in Cairo / OZ v3:
-
-### Using a Component
-
-The **Mixin pattern** is the most common approach in OZ v3 — it exposes all standard interface methods (e.g., `balance_of`, `transfer`, `approve`) in a single `impl` block:
-
-```cairo
-#[starknet::contract]
-mod MyToken {
-    use openzeppelin_access::ownable::OwnableComponent;
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-
-    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
-    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-
-    // Embed external implementations (makes functions callable from outside)
-    #[abi(embed_v0)]
-    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
-
-    // Internal implementations (for use inside the contract)
-    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
-    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
-
-    #[storage]
-    struct Storage {
-        #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
-        #[substorage(v0)]
-        erc20: ERC20Component::Storage,
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        OwnableEvent: OwnableComponent::Event,
-        #[flat]
-        ERC20Event: ERC20Component::Event,
-    }
-
-    #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress) {
-        self.ownable.initializer(owner);
-        self.erc20.initializer("MyToken", "MTK");
-    }
-}
-```
-
-### Writing a Component
-
-```cairo
-#[starknet::component]
-mod MyComponent {
-    use starknet::ContractAddress;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
-
-    #[storage]
-    struct Storage {
-        value: u256,
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        ValueChanged: ValueChanged,
-    }
-
-    #[derive(Drop, starknet::Event)]
-    struct ValueChanged {
-        new_value: u256,
-    }
-
-    #[embeddable_as(MyComponentImpl)]
-    impl MyComponent<
-        TContractState, +HasComponent<TContractState>
-    > of super::IMyComponent<ComponentState<TContractState>> {
-        fn get_value(self: @ComponentState<TContractState>) -> u256 {
-            self.value.read()
-        }
-
-        fn set_value(ref self: ComponentState<TContractState>, new_value: u256) {
-            self.value.write(new_value);
-            self.emit(ValueChanged { new_value });
-        }
-    }
-}
-```
-
-## Common OpenZeppelin Components
-
-### Scarb.toml Dependencies
-
-```toml
-[dependencies]
-starknet = ">=2.12.0"
-openzeppelin_access = "3.0.0"
-openzeppelin_token = "3.0.0"
-openzeppelin_upgrades = "3.0.0"
-openzeppelin_introspection = "3.0.0"
-openzeppelin_security = "3.0.0"
-```
-
-> **Note:** OZ packages are on the [Scarb registry](https://scarbs.dev). No git tags needed. Check `scarbs.dev` for the latest version.
-
-### Ownable
-
-```cairo
-use openzeppelin_access::ownable::OwnableComponent;
-
-component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
-
-#[abi(embed_v0)]
-impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
-impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
-
-// In constructor:
-self.ownable.initializer(owner);
-
-// In functions:
-self.ownable.assert_only_owner();
-```
-
-### Upgradeable
-
-```cairo
-use openzeppelin_upgrades::UpgradeableComponent;
-use openzeppelin_upgrades::interface::IUpgradeable;
-
-component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
-
-impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
-
-#[abi(embed_v0)]
-impl UpgradeableImpl of IUpgradeable<ContractState> {
-    fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
-        self.ownable.assert_only_owner();
-        self.upgradeable.upgrade(new_class_hash);
-    }
-}
-```
-
-### ERC20
-
-```cairo
-use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-
-component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-
-#[abi(embed_v0)]
-impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
-impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
-
-// In constructor:
-self.erc20.initializer("TokenName", "TKN");
-self.erc20.mint(recipient, initial_supply);
-```
-
-### AccessControl
-
-```cairo
-use openzeppelin_access::accesscontrol::AccessControlComponent;
-use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
-
-component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
-
-#[abi(embed_v0)]
-impl AccessControlMixinImpl = AccessControlComponent::AccessControlMixinImpl<ContractState>;
-impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
-
-const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
-
-// In constructor:
-self.access_control.initializer();
-self.access_control._grant_role(DEFAULT_ADMIN_ROLE, admin);
-self.access_control._grant_role(MINTER_ROLE, minter);
-
-// In functions:
-self.access_control.assert_only_role(MINTER_ROLE);
-```
-
 ## Project Structure
 
 ```
@@ -392,17 +210,6 @@ fn _exit(ref self: ContractState) {
 }
 ```
 
-### Pausable
-
-```cairo
-use openzeppelin_security::pausable::PausableComponent;
-
-component!(path: PausableComponent, storage: pausable, event: PausableEvent);
-
-// In functions:
-self.pausable.assert_not_paused();
-```
-
 ### Constructor Validation
 
 ```cairo
@@ -412,3 +219,5 @@ fn constructor(ref self: ContractState, owner: ContractAddress) {
     self.ownable.initializer(owner);
 }
 ```
+
+> **Components:** For Ownable, Pausable, AccessControl, ERC20, Upgradeable, and the Mixin pattern, see [cairo-components](../cairo-components/).

--- a/skills/cairo-language/SKILL.md
+++ b/skills/cairo-language/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: cairo-language
+description: Use when writing Cairo code — type system, ownership, traits, generics, collections, error handling, and module system. Language fundamentals before contract-specific patterns.
+license: Apache-2.0
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, language, types, traits, generics, ownership, modules, felt252, array, dict]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Language
+
+Cairo programming language fundamentals.
+What you need to know before writing contracts.
+
+> **Next step:** Once you're comfortable with the language, see [cairo-contracts](../cairo-contracts/) for Starknet contract patterns.
+
+## When to Use
+
+- Learning Cairo syntax, types, or ownership model
+- Working with generics, traits, or pattern matching
+- Understanding felt252, arrays, dicts, or error handling
+- Structuring modules and imports
+
+**Not for:** Contract storage/events (use cairo-contracts), components (use cairo-components), testing (use cairo-testing)
+
+## Scarb Project Setup
+
+```bash
+# Create a new project
+scarb init my_project
+cd my_project
+
+# Build
+scarb build
+
+# Format
+scarb fmt
+
+# Run (standalone Cairo, no Starknet)
+scarb cairo-run
+```
+
+`Scarb.toml` minimal config:
+
+```toml
+[package]
+name = "my_project"
+version = "0.1.0"
+edition = "2024_07"
+
+[dependencies]
+starknet = ">=2.12.0"
+
+[[target.starknet-contract]]
+```
+
+## Type System
+
+### Primitives
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `felt252` | Field element (0 ≤ x < P) | `let x: felt252 = 42;` |
+| `u8`..`u256` | Unsigned integers | `let n: u128 = 1000;` |
+| `i8`..`i128` | Signed integers | `let n: i8 = -5;` |
+| `bool` | Boolean | `let b = true;` |
+| `()` | Unit type (void) | `fn do_thing() { }` |
+
+### Strings
+
+```cairo
+// Short string — max 31 ASCII chars, stored as felt252
+let short: felt252 = 'hello';
+
+// ByteArray — arbitrary length string
+let long: ByteArray = "this can be any length";
+```
+
+### Tuples and Fixed-Size Arrays
+
+```cairo
+let tup: (u32, felt252, bool) = (10, 'hi', true);
+let (a, b, c) = tup;  // destructure
+
+let arr: [u32; 3] = [1, 2, 3];
+let first = arr[0];
+```
+
+### Type Conversion
+
+```cairo
+// Infallible — always succeeds (widening)
+let x: u8 = 5;
+let y: u16 = x.into();
+
+// Fallible — may fail (narrowing)
+let big: u16 = 500;
+let small: u8 = big.try_into().unwrap();  // panics if out of range
+let safe: Option<u8> = big.try_into();    // returns None if out of range
+```
+
+## Ownership and References
+
+Cairo uses a **linear type system** — every value must be used exactly once unless the type implements `Copy` or `Drop`.
+
+```cairo
+#[derive(Drop)]       // can be silently discarded
+struct MyStruct { val: u32 }
+
+#[derive(Copy, Drop)]  // can be copied implicitly (like primitives)
+struct Point { x: u32, y: u32 }
+```
+
+### Snapshots and Refs
+
+```cairo
+// Snapshot (@T) — immutable view, does not consume the value
+fn read_it(data: @MyStruct) -> u32 {
+    *data.val  // desnap with * (only for Copy types)
+}
+
+// Ref — mutable borrow
+fn mutate_it(ref data: MyStruct) {
+    data.val = 10;
+}
+
+let mut s = MyStruct { val: 5 };
+let _ = read_it(@s);   // pass snapshot
+mutate_it(ref s);       // pass mutable ref
+```
+
+## Structs
+
+```cairo
+#[derive(Drop, Serde, Copy, PartialEq)]
+struct Rectangle {
+    width: u64,
+    height: u64,
+}
+
+// Methods via trait + impl
+trait RectangleTrait {
+    fn area(self: @Rectangle) -> u64;
+}
+
+impl RectangleImpl of RectangleTrait {
+    fn area(self: @Rectangle) -> u64 {
+        *self.width * *self.height
+    }
+}
+```
+
+Common derive macros:
+- `Drop` — value can be discarded
+- `Copy` — value can be implicitly copied
+- `Serde` — serialization (required for contract calldata)
+- `PartialEq` — equality comparison
+- `Hash` — hashing support
+- `starknet::Store` — storable in contract storage
+- `starknet::Event` — emittable as event
+
+## Enums and Pattern Matching
+
+```cairo
+#[derive(Drop)]
+enum Direction {
+    North,
+    South,
+    East: u32,  // variant with data
+}
+
+fn describe(d: Direction) -> felt252 {
+    match d {
+        Direction::North => 'up',
+        Direction::South => 'down',
+        Direction::East(dist) => 'east',
+    }
+}
+```
+
+### Option and Result
+
+```cairo
+// Option<T> — None or Some(value)
+let maybe: Option<u32> = Option::Some(42);
+
+match maybe {
+    Option::Some(val) => val,
+    Option::None => 0,
+}
+
+// if-let shorthand
+if let Option::Some(val) = maybe {
+    // use val
+}
+
+// Result<T, E> — Ok(value) or Err(error)
+fn divide(a: u32, b: u32) -> Result<u32, felt252> {
+    if b == 0 {
+        Result::Err('division by zero')
+    } else {
+        Result::Ok(a / b)
+    }
+}
+```
+
+## Traits and Generics
+
+```cairo
+trait Summary<T> {
+    fn summarize(self: @T) -> ByteArray;
+}
+
+impl RectSummary of Summary<Rectangle> {
+    fn summarize(self: @Rectangle) -> ByteArray {
+        "a rectangle"
+    }
+}
+
+// Generic function with trait bounds
+fn print_summary<T, +Summary<T>, +Drop<T>>(item: @T) -> ByteArray {
+    item.summarize()
+}
+```
+
+Trait bounds use `+` syntax: `+Drop<T>`, `+Copy<T>`, `+Into<T, U>`.
+
+### Impl of vs Impl for
+
+```cairo
+// Named impl with `of` — standard pattern
+impl MyImpl of MyTrait<MyType> { ... }
+
+// Can also use `of` with generic impls
+impl GenericImpl<T, +Drop<T>> of MyTrait<T> { ... }
+```
+
+## Collections
+
+### Array
+
+```cairo
+let mut arr: Array<u32> = array![1, 2, 3];
+arr.append(4);
+
+let len = arr.len();
+let first: Option<u32> = arr.pop_front();  // removes from front
+let val: u32 = *arr.at(0);                 // panics if out of bounds
+let maybe: Option<@u32> = arr.get(0);      // returns Option
+
+// Span — immutable view of an Array
+let span: Span<u32> = arr.span();
+```
+
+Arrays are append-only and consume elements on `pop_front`.
+Use `Span<T>` to pass arrays without consuming them.
+
+### Felt252Dict
+
+```cairo
+let mut dict: Felt252Dict<u64> = Default::default();
+dict.insert('key', 100);
+let val = dict.get('key');  // returns 100
+```
+
+Keys must be `felt252`.
+Values must implement `Felt252DictValue` (felt252, u-integers, bool, Nullable<T>).
+For complex values, use `Nullable<T>`:
+
+```cairo
+let mut dict: Felt252Dict<Nullable<Span<u32>>> = Default::default();
+dict.insert('k', NullableTrait::new(array![1, 2].span()));
+let val = dict.get('k').deref();
+```
+
+## Error Handling
+
+```cairo
+// Assert — panics with message if false
+assert!(balance >= amount, "insufficient balance");
+
+// Panic — unconditional
+panic!("something went wrong");
+
+// Result-based — for recoverable errors
+fn safe_div(a: u32, b: u32) -> Result<u32, felt252> {
+    if b == 0 { return Result::Err('div by zero'); }
+    Result::Ok(a / b)
+}
+
+// Unwrap helpers
+let val = safe_div(10, 2).unwrap();          // panics on Err
+let val = safe_div(10, 2).expect('math err'); // panics with message
+```
+
+## Modules
+
+```cairo
+// lib.cairo — crate root
+mod math;        // loads from math.cairo or math/mod.cairo
+mod utils;
+
+// math.cairo
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+fn private_helper() -> u32 { 0 }  // not pub = private
+
+// main usage
+use crate::math::add;      // absolute path from crate root
+use super::utils::helper;  // relative path from parent module
+```
+
+Visibility: items are private by default.
+Use `pub` to make them accessible outside the module.
+`pub(crate)` makes items visible within the crate only.
+
+### File Layout Convention
+
+```
+src/
+  lib.cairo        # mod declarations
+  math.cairo       # single-file module
+  utils/
+    mod.cairo      # multi-file module root
+    helpers.cairo   # submodule
+```

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -3,7 +3,15 @@
   "repo": "keep-starknet-strange/starknet-agentic",
   "skills": [
     {
-      "description": "Use when writing Cairo smart contracts on Starknet \u2014 contract structure, storage, events, interfaces, components, OpenZeppelin v3 patterns, and common contract templates.",
+      "description": "Use when composing contracts from reusable components \u2014 the Mixin pattern, writing custom components, and OpenZeppelin v3 component library (Ownable, ERC20, ERC721, AccessControl, Upgradeable, Pausable).",
+      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-components",
+      "name": "cairo-components",
+      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-components/SKILL.md",
+      "repo_path": "skills/cairo-components",
+      "skill_md_path": "skills/cairo-components/SKILL.md"
+    },
+    {
+      "description": "Use when writing Cairo smart contracts on Starknet \u2014 contract structure, storage, events, interfaces, project layout, and common patterns.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-contracts",
       "name": "cairo-contracts",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-contracts/SKILL.md",
@@ -17,6 +25,14 @@
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-deploy/SKILL.md",
       "repo_path": "skills/cairo-deploy",
       "skill_md_path": "skills/cairo-deploy/SKILL.md"
+    },
+    {
+      "description": "Use when writing Cairo code \u2014 type system, ownership, traits, generics, collections, error handling, and module system. Language fundamentals before contract-specific patterns.",
+      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-language",
+      "name": "cairo-language",
+      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-language/SKILL.md",
+      "repo_path": "skills/cairo-language",
+      "skill_md_path": "skills/cairo-language/SKILL.md"
     },
     {
       "description": "Use as an explicit post-test optimization pass \u2014 fixing slow loops, expensive arithmetic, integer splitting or limb assembly, modular reduction, storage slot packing, or BoundedInt type bounds. Invoke after implementation and tests pass.",


### PR DESCRIPTION
## Summary

Closes #293.

- **cairo-language** (new, 329 lines): Cairo type system, ownership, traits, generics, collections, error handling, modules
- **cairo-components** (new, 241 lines): Mixin pattern, custom components, OZ v3 reference (Ownable, ERC20, AccessControl, Upgradeable, Pausable)
- **cairo-contracts** (slimmed, 223 lines, was 414): Contract structure, storage, events, interfaces, project layout, common patterns — with cross-references to the two new skills

All three skills cross-reference each other. `manifest.json` updated with 2 new entries and updated description.

## Test plan

- [ ] Each skill has valid YAML frontmatter (name, description, keywords, allowed-tools, user-invocable)
- [ ] No content duplication between skills
- [ ] Cross-references use correct relative paths (`../cairo-components/`, etc.)
- [ ] All skills under 500 lines
- [ ] `manifest.json` is valid JSON with all 15 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Cairo language fundamentals documentation covering syntax, type system, ownership models, collections, error handling, and project setup guidance.
  * Added Cairo Components documentation including design patterns, prerequisites, usage scenarios, and reference guides for common component implementations.
  * Reorganized Cairo smart contracts documentation with refined focus on project structure, layouts, and common contract patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->