### PR TITLE
feat(skills/starknet-mini-pay): enhance P2P payment skill

### DIFF
--- a/skills/cairo-components/SKILL.md
+++ b/skills/cairo-components/SKILL.md
@@ -1,0 +1,468 @@
+---
+name: cairo-components
+description: Use when composing contracts from reusable components — the Mixin pattern, writing custom components, and OpenZeppelin v3 component library (Ownable, ERC20, ERC721, AccessControl, Upgradeable, Pausable).
+license: Apache-2.0
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, components, openzeppelin, ownable, erc20, erc721, accesscontrol, upgradeable, pausable, mixin]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Components
+
+Reusable contract modules and OpenZeppelin v3 patterns for Starknet.
+
+> **Prerequisites:** Familiar with [cairo-language](../cairo-language/) basics and [cairo-contracts](../cairo-contracts/) structure (storage, events, interfaces).
+
+## When to Use
+
+- Composing a contract from OpenZeppelin components (Ownable, ERC20, AccessControl, etc.)
+- Writing a custom reusable component with `#[starknet::component]`
+- Understanding the Mixin pattern (`embeddable_as` / `#[abi(embed_v0)]`)
+
+**Not for:** Contract structure basics (use cairo-contracts), language fundamentals (use cairo-language), testing (use cairo-testing)
+
+## Scarb.toml Dependencies
+
+```toml
+[dependencies]
+starknet = ">=2.12.0"
+openzeppelin_access = "3.0.0"
+openzeppelin_token = "3.0.0"
+openzeppelin_upgrades = "3.0.0"
+openzeppelin_introspection = "3.0.0"
+openzeppelin_security = "3.0.0"
+```
+
+> **Note:** OZ packages are on the [Scarb registry](https://scarbs.dev). No git tags needed. Check `scarbs.dev` for the latest version.
+
+## Using a Component (Mixin Pattern)
+
+The Mixin pattern exposes all standard interface methods in a single `impl` block.
+This is the standard approach in OZ v3:
+
+```cairo
+#[starknet::contract]
+mod MyToken {
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    // Embed external implementations (makes functions callable from outside)
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+
+    // Internal implementations (for use inside the contract)
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.ownable.initializer(owner);
+        self.erc20.initializer("MyToken", "MTK");
+    }
+}
+```
+
+### Checklist for Adding a Component
+
+1. `use` the component module
+2. `component!(path: ..., storage: ..., event: ...)`
+3. `#[abi(embed_v0)] impl ... = Component::MixinImpl<ContractState>` (external)
+4. `impl ... = Component::InternalImpl<ContractState>` (internal)
+5. Add `#[substorage(v0)]` field in `Storage`
+6. Add `#[flat]` variant in `Event` enum
+7. Call `.initializer(...)` in constructor
+
+> **Important:** Component functions are **not exposed** in your contract's ABI unless you wire them in with `#[abi(embed_v0)]`.
+> If you add an ERC721 component but skip the `ERC721MixinImpl` embed, functions like `symbol()`, `token_uri()`, and `balance_of()` will not be callable.
+> The `MixinImpl` bundles all standard interface methods — always prefer it over embedding individual sub-impls.
+
+## Writing a Custom Component
+
+```cairo
+#[starknet::component]
+mod MyComponent {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        value: u256,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        new_value: u256,
+    }
+
+    #[embeddable_as(MyComponentImpl)]
+    impl MyComponent<
+        TContractState, +HasComponent<TContractState>
+    > of super::IMyComponent<ComponentState<TContractState>> {
+        fn get_value(self: @ComponentState<TContractState>) -> u256 {
+            self.value.read()
+        }
+
+        fn set_value(ref self: ComponentState<TContractState>, new_value: u256) {
+            self.value.write(new_value);
+            self.emit(ValueChanged { new_value });
+        }
+    }
+}
+```
+
+Key differences from a contract:
+- `#[starknet::component]` instead of `#[starknet::contract]`
+- `#[embeddable_as(Name)]` instead of `#[abi(embed_v0)]`
+- `ComponentState<TContractState>` instead of `ContractState`
+- `+HasComponent<TContractState>` trait bound required
+
+## OpenZeppelin Components Reference
+
+### Ownable
+
+```cairo
+use openzeppelin_access::ownable::OwnableComponent;
+
+component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+
+#[abi(embed_v0)]
+impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+// In constructor:
+self.ownable.initializer(owner);
+
+// In functions:
+self.ownable.assert_only_owner();
+```
+
+### Upgradeable
+
+```cairo
+use openzeppelin_upgrades::UpgradeableComponent;
+use openzeppelin_upgrades::interface::IUpgradeable;
+
+component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+#[abi(embed_v0)]
+impl UpgradeableImpl of IUpgradeable<ContractState> {
+    fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+        self.ownable.assert_only_owner();
+        self.upgradeable.upgrade(new_class_hash);
+    }
+}
+```
+
+### ERC20
+
+```cairo
+use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+#[abi(embed_v0)]
+impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+// In constructor:
+self.erc20.initializer("TokenName", "TKN");
+self.erc20.mint(recipient, initial_supply);
+```
+
+### AccessControl
+
+```cairo
+use openzeppelin_access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+
+component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
+
+#[abi(embed_v0)]
+impl AccessControlMixinImpl = AccessControlComponent::AccessControlMixinImpl<ContractState>;
+impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+
+// In constructor:
+self.access_control.initializer();
+self.access_control._grant_role(DEFAULT_ADMIN_ROLE, admin);
+self.access_control._grant_role(MINTER_ROLE, minter);
+
+// In functions:
+self.access_control.assert_only_role(MINTER_ROLE);
+```
+
+### Pausable
+
+```cairo
+use openzeppelin_security::pausable::PausableComponent;
+
+component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+
+#[abi(embed_v0)]
+impl PausableMixinImpl = PausableComponent::PausableMixinImpl<ContractState>;
+impl PausableInternalImpl = PausableComponent::InternalImpl<ContractState>;
+
+// In constructor — no initializer needed
+
+// In functions:
+self.pausable.assert_not_paused();
+
+// Owner pauses/unpauses:
+self.pausable.pause();
+self.pausable.unpause();
+```
+
+## Quick Reference
+
+| Component | Initializer | Key Methods |
+|-----------|-------------|-------------|
+| Ownable | `initializer(owner)` | `assert_only_owner()`, `transfer_ownership()` |
+| ERC20 | `initializer(name, symbol)` | `transfer()`, `approve()`, `balance_of()`, `mint()`, `burn()` |
+| ERC721 | `initializer(base_uri)` | `mint()`, `transfer_from()`, `owner_of()`, `token_uri()` |
+| AccessControl | `initializer()` | `grant_role()`, `revoke_role()`, `assert_only_role()` |
+| Upgradeable | — | `upgrade(class_hash)` |
+| Pausable | — | `pause()`, `unpause()`, `assert_not_paused()` |
+
+### Component Checklist
+
+- [ ] Add dependency to `Scarb.toml`
+- [ ] Import component module
+- [ ] Declare `component!` macro
+- [ ] Add `#[abi(embed_v0)]` impl for external interface
+- [ ] Add internal impl for `InternalImpl`
+- [ ] Add `#[substorage(v0)]` storage field
+- [ ] Add `#[flat]` event variant
+- [ ] Call initializer in constructor
+
+## Error Codes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Component not bound` | Missing `HasComponent` trait | Add `+HasComponent<TContractState>` to impl |
+| `Function not exposed` | Missing `#[abi(embed_v0)]` | Add embed attribute for MixinImpl |
+| `Storage not found` | Missing `#[substorage(v0)]` | Add substorage attribute to storage field |
+| `Event not emitted` | Missing `#[flat]` | Add `#[flat]` to Event enum variant |
+| `Initializer already called` | Double initialization | Ensure initializer called once in constructor |
+| `Not an embeddable` | Wrong attribute | Use `#[embeddable_as(Name)]` for components |
+
+### Troubleshooting
+
+**"Entry point not found"**
+- Component functions require `#[abi(embed_v0)]` to be in the contract's ABI
+- Add the MixinImpl line to expose all component methods
+
+**"Storage attribute not found"**
+- Storage fields for components need `#[substorage(v0)]`
+- Without this, the component cannot access its storage
+
+## starknet.js Patterns
+
+Interacting with component-based contracts from JavaScript/TypeScript:
+
+### Ownable Contract
+
+```typescript
+import { Account, Contract, json, Provider, RpcProvider } from 'starknet';
+
+// Connect to an Ownable contract
+async function callOwnableFunction(
+  account: Account,
+  contractAddress: string,
+  functionName: string,
+  calldata: any[]
+) {
+  const response = await account.execute({
+    contractAddress,
+    entrypoint: functionName,
+    calldata,
+  });
+  return account.waitForTransaction(response.transaction_hash);
+}
+
+// Check owner
+async function getOwner(contractAddress: string, provider: RpcProvider) {
+  const { owner } = await provider.callContract({
+    contractAddress,
+    entrypoint: 'owner',
+  });
+  return owner;
+}
+```
+
+### ERC20 Token
+
+```typescript
+import { Account, Contract, RpcProvider } from 'starknet';
+
+// ERC20 interface for type-safe calls
+const erc20Abi = [
+  {
+    name: 'transfer',
+    type: 'function',
+    inputs: [
+      { name: 'to', type: 'contractaddress' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: 'success', type: 'bool' }],
+  },
+  {
+    name: 'balance_of',
+    type: 'function',
+    inputs: [{ name: 'account', type: 'contractaddress' }],
+    outputs: [{ name: 'balance', type: 'uint256' }],
+  },
+  {
+    name: 'transfer',
+    type: 'function',
+    inputs: [
+      { name: 'from', type: 'contractaddress' },
+      { name: 'to', type: 'contractaddress' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: 'success', type: 'bool' }],
+  },
+];
+
+// Transfer tokens (uses uint256 for amount)
+async function transferTokens(
+  account: Account,
+  tokenAddress: string,
+  to: string,
+  amount: bigint
+) {
+  const contract = new Contract(erc20Abi, tokenAddress, account);
+  
+  // Convert to uint256 (low, high)
+  const amountUint256 = { low: amount & BigInt(0xFFFFFFFFFFFFFFFFFFFFFFFFn), high: amount >> 64n };
+  
+  await contract.transfer(to, amountUint256);
+}
+
+// Check balance
+async function getBalance(tokenAddress: string, account: string, provider: RpcProvider) {
+  const contract = new Contract(erc20Abi, tokenAddress, provider);
+  const { balance } = await contract.balance_of(account);
+  // Convert from uint256 to bigint
+  return balance.high * BigInt(0x10000000000000000) + balance.low;
+}
+```
+
+### Pausable Contract
+
+```typescript
+// Check if contract is paused
+async function isPaused(contractAddress: string, provider: RpcProvider) {
+  const { paused } = await provider.callContract({
+    contractAddress,
+    entrypoint: 'paused',
+  });
+  return paused === 1n;
+}
+
+// Pause (owner only)
+async function pauseContract(account: Account, contractAddress: string) {
+  const response = await account.execute({
+    contractAddress,
+    entrypoint: 'pause',
+    calldata: [],
+  });
+  return account.waitForTransaction(response.transaction_hash);
+}
+```
+
+### AccessControl Contract
+
+```typescript
+// Grant role (admin only)
+async function grantRole(
+  account: Account,
+  contractAddress: string,
+  role: string, // bytes32 role identifier
+  user: string
+) {
+  // Convert role string to felt252 (hex string without 0x prefix)
+  const roleFelt = role.startsWith('0x') ? role.slice(2) : role;
+  
+  const response = await account.execute({
+    contractAddress,
+    entrypoint: 'grant_role',
+    calldata: [roleFelt, user],
+  });
+  return account.waitForTransaction(response.transaction_hash);
+}
+
+// Check has role
+async function hasRole(
+  contractAddress: string,
+  role: string,
+  user: string,
+  provider: RpcProvider
+) {
+  const roleFelt = role.startsWith('0x') ? role.slice(2) : role;
+  const { has_role } = await provider.callContract({
+    contractAddress,
+    entrypoint: 'has_role',
+    calldata: [roleFelt, user],
+  });
+  return has_role === 1n;
+}
+```
+
+### Upgradeable Contract
+
+```typescript
+// Upgrade contract (owner only)
+async function upgradeContract(
+  account: Account,
+  proxyAddress: string,
+  newClassHash: string
+) {
+  const response = await account.execute({
+    contractAddress: proxyAddress,
+    entrypoint: 'upgrade',
+    calldata: [newClassHash],
+  });
+  return account.waitForTransaction(response.transaction_hash);
+}
+
+// Get current implementation
+async function getImplementation(contractAddress: string, provider: RpcProvider) {
+  const { implementation } = await provider.callContract({
+    contractAddress,
+    entrypoint: 'implementation',
+  });
+  return implementation;
+}
+```

--- a/skills/cairo-contracts/SKILL.md
+++ b/skills/cairo-contracts/SKILL.md
@@ -1,0 +1,627 @@
+---
+name: cairo-contracts
+description: Use when writing Cairo smart contracts on Starknet — contract structure, storage, events, interfaces, components, OpenZeppelin v3 patterns, and common contract templates.
+license: Apache-2.0
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, contracts, starknet, openzeppelin, components, storage, events, interfaces, erc20, erc721]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Contracts
+
+Reference for writing Cairo smart contracts on Starknet. Covers structure, storage, events, interfaces, components, and OpenZeppelin v3 patterns.
+
+> **Optimization:** After your contract compiles and tests pass, use the [cairo-optimization](../cairo-optimization/) skill as a separate pass.
+
+## When to Use
+
+- Writing a new Starknet smart contract from scratch
+- Adding storage, events, or interfaces to an existing contract
+- Using OpenZeppelin components (Ownable, ERC20, ERC721, AccessControl, Upgradeable)
+- Implementing the component pattern with `embeddable_as`
+- Structuring a multi-contract project with Scarb
+
+**Not for:** Gas optimization (use cairo-optimization), testing (use cairo-testing), deployment (use cairo-deploy)
+
+## Contract Structure
+
+Every Starknet contract follows this skeleton:
+
+```cairo
+#[starknet::contract]
+mod MyContract {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        owner: ContractAddress,
+        balance: u256,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        Transfer: Transfer,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct Transfer {
+        #[key]
+        from: ContractAddress,
+        #[key]
+        to: ContractAddress,
+        amount: u256,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.owner.write(owner);
+    }
+
+    #[abi(embed_v0)]
+    impl MyContractImpl of super::IMyContract<ContractState> {
+        fn get_balance(self: @ContractState) -> u256 {
+            self.balance.read()
+        }
+
+        fn transfer(ref self: ContractState, to: ContractAddress, amount: u256) {
+            // implementation
+        }
+    }
+}
+```
+
+## Interfaces
+
+Define interfaces outside the contract module. Use `#[starknet::interface]`:
+
+```cairo
+#[starknet::interface]
+trait IMyContract<TContractState> {
+    fn get_balance(self: @TContractState) -> u256;
+    fn transfer(ref self: TContractState, to: ContractAddress, amount: u256);
+}
+```
+
+- `self: @TContractState` — read-only (view function)
+- `ref self: TContractState` — read-write (external function)
+
+## Storage
+
+### Basic Types
+
+```cairo
+#[storage]
+struct Storage {
+    value: felt252,           // single felt
+    counter: u128,            // unsigned integer
+    owner: ContractAddress,   // address
+    is_active: bool,          // boolean
+}
+```
+
+### Maps
+
+```cairo
+use starknet::storage::Map;
+
+#[storage]
+struct Storage {
+    balances: Map<ContractAddress, u256>,
+    allowances: Map<(ContractAddress, ContractAddress), u256>,
+}
+
+// Usage:
+fn get_balance(self: @ContractState, account: ContractAddress) -> u256 {
+    self.balances.read(account)
+}
+
+fn set_allowance(ref self: ContractState, owner: ContractAddress, spender: ContractAddress, amount: u256) {
+    self.allowances.write((owner, spender), amount);
+}
+```
+
+### Composite Key Maps (Nested Map Alternative)
+
+Prefer composite key tuples over nested Maps:
+
+```cairo
+use starknet::storage::Map;
+
+#[storage]
+struct Storage {
+    // Map<(owner, spender), amount> — preferred over nested Map
+    allowances: Map<(ContractAddress, ContractAddress), u256>,
+}
+
+// Usage:
+let amount = self.allowances.entry((owner, spender)).read();
+self.allowances.entry((owner, spender)).write(new_amount);
+```
+
+## Events
+
+```cairo
+#[event]
+#[derive(Drop, starknet::Event)]
+enum Event {
+    Transfer: Transfer,
+    Approval: Approval,
+}
+
+#[derive(Drop, starknet::Event)]
+struct Transfer {
+    #[key]    // indexed — used for filtering
+    from: ContractAddress,
+    #[key]
+    to: ContractAddress,
+    amount: u256,  // not indexed — stored in data
+}
+
+// Emit:
+self.emit(Transfer { from, to, amount });
+```
+
+## Components (OpenZeppelin v3 Pattern)
+
+Components are reusable contract modules. This is the standard pattern in Cairo / OZ v3:
+
+### Using a Component
+
+The **Mixin pattern** is the most common approach in OZ v3 — it exposes all standard interface methods (e.g., `balance_of`, `transfer`, `approve`) in a single `impl` block:
+
+```cairo
+#[starknet::contract]
+mod MyToken {
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    // Embed external implementations (makes functions callable from outside)
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+
+    // Internal implementations (for use inside the contract)
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.ownable.initializer(owner);
+        self.erc20.initializer("MyToken", "MTK");
+    }
+}
+```
+
+### Writing a Component
+
+```cairo
+#[starknet::component]
+mod MyComponent {
+    use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        value: u256,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        new_value: u256,
+    }
+
+    #[embeddable_as(MyComponentImpl)]
+    impl MyComponent<
+        TContractState, +HasComponent<TContractState>
+    > of super::IMyComponent<ComponentState<TContractState>> {
+        fn get_value(self: @ComponentState<TContractState>) -> u256 {
+            self.value.read()
+        }
+
+        fn set_value(ref self: ComponentState<TContractState>, new_value: u256) {
+            self.value.write(new_value);
+            self.emit(ValueChanged { new_value });
+        }
+    }
+}
+```
+
+## Common OpenZeppelin Components
+
+### Scarb.toml Dependencies
+
+```toml
+[dependencies]
+starknet = ">=2.12.0"
+openzeppelin_access = "3.0.0"
+openzeppelin_token = "3.0.0"
+openzeppelin_upgrades = "3.0.0"
+openzeppelin_introspection = "3.0.0"
+openzeppelin_security = "3.0.0"
+```
+
+> **Note:** OZ packages are on the [Scarb registry](https://scarbs.dev). No git tags needed. Check `scarbs.dev` for the latest version.
+
+### Ownable
+
+```cairo
+use openzeppelin_access::ownable::OwnableComponent;
+
+component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+
+#[abi(embed_v0)]
+impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+// In constructor:
+self.ownable.initializer(owner);
+
+// In functions:
+self.ownable.assert_only_owner();
+```
+
+### Upgradeable
+
+```cairo
+use openzeppelin_upgrades::UpgradeableComponent;
+use openzeppelin_upgrades::interface::IUpgradeable;
+
+component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
+#[abi(embed_v0)]
+impl UpgradeableImpl of IUpgradeable<ContractState> {
+    fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+        self.ownable.assert_only_owner();
+        self.upgradeable.upgrade(new_class_hash);
+    }
+}
+```
+
+### ERC20
+
+```cairo
+use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+#[abi(embed_v0)]
+impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+// In constructor:
+self.erc20.initializer("TokenName", "TKN");
+self.erc20.mint(recipient, initial_supply);
+```
+
+### AccessControl
+
+```cairo
+use openzeppelin_access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::DEFAULT_ADMIN_ROLE;
+
+component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
+
+#[abi(embed_v0)]
+impl AccessControlMixinImpl = AccessControlComponent::AccessControlMixinImpl<ContractState>;
+impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
+
+const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+
+// In constructor:
+self.access_control.initializer();
+self.access_control._grant_role(DEFAULT_ADMIN_ROLE, admin);
+self.access_control._grant_role(MINTER_ROLE, minter);
+
+// In functions:
+self.access_control.assert_only_role(MINTER_ROLE);
+```
+
+## Project Structure
+
+```
+my-project/
+  Scarb.toml
+  src/
+    lib.cairo          # mod declarations
+    contract.cairo     # main contract
+    interfaces.cairo   # trait definitions
+    components/
+      mod.cairo
+      my_component.cairo
+  tests/
+    test_contract.cairo
+```
+
+### lib.cairo
+
+```cairo
+mod contract;
+mod interfaces;
+mod components;
+```
+
+## Common Patterns
+
+### Reentrancy Guard
+
+```cairo
+#[storage]
+struct Storage {
+    entered: bool,
+}
+
+fn _enter(ref self: ContractState) {
+    assert(!self.entered.read(), 'ReentrancyGuard: reentrant');
+    self.entered.write(true);
+}
+
+fn _exit(ref self: ContractState) {
+    self.entered.write(false);
+}
+```
+
+### Pausable
+
+```cairo
+use openzeppelin_security::pausable::PausableComponent;
+
+component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+
+// In functions:
+self.pausable.assert_not_paused();
+```
+
+### Constructor Validation
+
+```cairo
+#[constructor]
+fn constructor(ref self: ContractState, owner: ContractAddress) {
+    assert(!owner.is_zero(), 'Owner cannot be zero');
+    self.ownable.initializer(owner);
+}
+```
+
+## Quick Reference
+
+### Contract Anatomy
+
+| Section | Attribute | Purpose |
+|---------|----------|---------|
+| Storage | `#[storage]` | Persistent state |
+| Events | `#[event]` | Emit logs |
+| Constructor | `#[constructor]` | Initialize |
+| External | `#[abi(embed_v0)]` | Public entry points |
+| Internal | (no attribute) | Internal logic |
+
+### Storage Types
+
+| Type | Syntax | Notes |
+|------|--------|-------|
+| Single | `value: T` | Direct read/write |
+| Map | `Map<K, V>` | Key-value lookup |
+| Composite | `Map<(K1, K2), V>` | Multi-key lookup |
+
+### Entry Points
+
+- `#[constructor]` — deploy-time initialization
+- `#[abi(embed_v0)]` — external callable functions
+- `#[l1_handler]` — handle messages from L1
+
+### Common Imports
+
+```cairo
+use starknet::ContractAddress;
+use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+use starknet::storage::Map;
+```
+
+### Key Patterns
+
+- **View function**: `self: @ContractState` — read-only
+- **External function**: `ref self: ContractState` — can modify state
+- **Event emission**: `self.emit(EventName { ... })`
+- **Access control**: Use OpenZeppelin components (Ownable, AccessControl)
+
+## Error Codes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Entry point not found` | Function not marked `#[abi(embed_v0)]` | Add the attribute to make it public |
+| `Storage not initialized` | Reading uninitialized storage | Initialize in constructor or provide defaults |
+| `Zero address` | Using `ContractAddress::zero()` | Validate with `assert(!addr.is_zero(), ...)` |
+| `Insufficient balance` | Transfer exceeds balance | Check balance before transfer |
+| `Unauthorized` | Missing access control | Use Ownable/AccessControl component |
+| `Reentrancy detected` | Reentrant call detected | Implement reentrancy guard |
+| `Paused` | Contract is paused | Unpause via owner |
+| `Safe math overflow` | Integer overflow | Use checked arithmetic |
+
+### Troubleshooting
+
+**"Error: Transaction reverted"**
+- Check error message in the transaction receipt
+- Use `starknet-debug` or block explorer to see revert reason
+
+**"Assertion failed"**
+- Usually means validation failed (zero address, insufficient balance, etc.)
+- Check the error message string for the specific assertion
+
+**"Call to uninitialized contract"**
+- Contract not deployed or wrong address
+- Verify contract address is correct
+
+**"Class hash not found"**
+- Contract class not declared on the network
+- Declare the class first with `sncast declare`
+
+## starknet.js Examples
+
+Interacting with Starknet contracts from JavaScript/TypeScript:
+
+### Setup Provider and Account
+
+```typescript
+import { Account, Provider, RpcProvider, Account (with ECDSA signer) } from 'starknet';
+
+// Connect to Starknet mainnet/testnet
+const provider = new RpcProvider({
+  nodeUrl: 'https://starknet-mainnet.infura.io/v3/YOUR_API_KEY',
+});
+
+// Or use a local network
+const localProvider = new RpcProvider({
+  nodeUrl: 'http://localhost:5050/rpc',
+});
+
+// Create account from private key
+const account = new Account(
+  provider,
+  '0xYOUR_ACCOUNT_ADDRESS',
+  new Account(provider, address, privateKey) // or use other signers
+);
+```
+
+### Deploy Contract
+
+```typescript
+import { Account, Contract, json } from 'starknet';
+
+// Compile with starknet-compile to get class hash
+const classHash = '0x123...'; // from compilation
+
+// Declare and deploy
+const { address } = await account.deployContract({
+  classHash,
+  constructorCalldata: ['0xowner_address', 'TokenName', 'TKN'],
+});
+```
+
+### Call View Function
+
+```typescript
+// Read-only call (doesn't cost gas)
+const { balance } = await provider.callContract({
+  contractAddress: '0xTOKEN_ADDRESS',
+  entrypoint: 'balance_of',
+  calldata: ['0xUSER_ADDRESS'],
+});
+
+// balance is returned as uint256: { low: ..., high: ... }
+const balanceBigInt = balance.high * BigInt(0x10000000000000000) + balance.low;
+```
+
+### Execute External Function
+
+```typescript
+// Write operation (costs gas)
+const response = await account.execute({
+  contractAddress: '0xTOKEN_ADDRESS',
+  entrypoint: 'transfer',
+  calldata: [
+    '0xRECIPIENT_ADDRESS',  // to
+    '1000000',             // amount (low)
+    '0',                   // amount (high) - for uint256
+  ],
+});
+
+await provider.waitForTransaction(response.transaction_hash);
+```
+
+### Handle Events
+
+```typescript
+// Get events from transaction receipt
+const receipt = await provider.getTransactionReceipt(txHash);
+
+const transferEvents = receipt.events.filter(
+  (event) => event.from === contractAddress && event.keys[0] === transferEventKey
+);
+
+// Decode event data
+// Transfer(from, to, amount) - keys[0] is selector, data contains the values
+```
+
+### Estimate Fees
+
+```typescript
+const estimate = await account.estimateFee({
+  type: 'INVOKE_FUNCTION',
+  payload: {
+    contractAddress: '0x...',
+    entrypoint: 'transfer',
+    calldata: [...],
+  },
+});
+
+console.log(`Estimated fee: ${estimate.overall_fee} wei`);
+```
+
+### Multi-Call (Batching)
+
+```typescript
+import { Call } from 'starknet';
+
+// Batch multiple calls in one transaction
+const calls = [
+  {
+    contractAddress: tokenAddress,
+    entrypoint: 'transfer',
+    calldata: [to1, amount1Low, amount1High],
+  },
+  {
+    contractAddress: tokenAddress,
+    entrypoint: 'transfer',
+    calldata: [to2, amount2Low, amount2High],
+  },
+];
+
+const response = await account.execute(calls);
+```
+
+### Using Contract Class
+
+```typescript
+// Load compiled artifact
+const artifact = json.parse(fs.readFileSync('./artifact.json', 'utf8'));
+
+// Create typed contract instance
+const contract = new Contract(
+  artifact.abi,
+  contractAddress,
+  account
+);
+
+// Call with type safety
+await contract.transfer(toAddress, { low: amount, high: 0n });
+```

--- a/skills/cairo-contracts/SKILL.md
+++ b/skills/cairo-contracts/SKILL.md
@@ -492,7 +492,7 @@ Interacting with Starknet contracts from JavaScript/TypeScript:
 ### Setup Provider and Account
 
 ```typescript
-import { Account, Provider, RpcProvider, Account (with ECDSA signer) } from 'starknet';
+import { Account, RpcProvider } from 'starknet';
 
 // Connect to Starknet mainnet/testnet
 const provider = new RpcProvider({

--- a/skills/cairo-contracts/references/README.md
+++ b/skills/cairo-contracts/references/README.md
@@ -1,0 +1,20 @@
+# Cairo Contracts References
+
+Deep-dive topics and advanced patterns for Cairo contracts.
+
+## Topics
+
+- [ ] Upgradeable proxy patterns
+- [ ] Diamond pattern (EIP-2535)
+- [ ] Diamond proxy storage layout
+- [ ] Multi-signature wallets
+- [ ] Timelock controllers
+- [ ] Fee mechanisms
+- [ ] Reentrancy guard patterns
+- [ ] Merkle proofs
+- [ ] Signature verification (EIP-712)
+- [ ] L1 <-> L2 messaging
+
+## Contributing
+
+Add new reference topics as markdown files in this directory.

--- a/skills/cairo-contracts/scripts/README.md
+++ b/skills/cairo-contracts/scripts/README.md
@@ -1,0 +1,30 @@
+# Cairo Contracts Scripts
+
+Runnable examples and scripts for Cairo contract development.
+
+## Examples
+
+This directory contains executable examples demonstrating:
+
+- Contract deployment scripts
+- Integration with starknet.js
+- Testing utilities
+- Deployment automation
+
+## Usage
+
+Run examples with Scarb and starknet.js:
+
+```bash
+# Build contracts
+scarb build
+
+# Run JavaScript examples
+cd scripts
+npm install
+node deploy.js
+```
+
+## Contributing
+
+Add new runnable examples with clear documentation and comments.

--- a/skills/cairo-deploy/SKILL.md
+++ b/skills/cairo-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cairo-deploy
-description: Deployment guidance for Cairo contracts on Starknet covering sncast commands, account setup, declare/deploy workflow, network configuration, and contract verification.
+description: Use when deploying Cairo contracts to Starknet — sncast commands, account setup, declare/deploy workflow, network configuration, contract verification.
 license: Apache-2.0
 metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
 keywords: [cairo, deploy, sncast, starknet, devnet, sepolia, mainnet, declare, verification]
@@ -21,17 +21,7 @@ Reference for deploying Cairo smart contracts to Starknet using sncast (Starknet
 - Verifying deployed contracts
 - Invoking/calling deployed contracts
 
-## When NOT to Use
-
-- Writing or refactoring contract logic (`cairo-contract-authoring`).
-- Unit, integration, or fuzz testing (`cairo-testing`).
-- Gas or performance optimization (`cairo-optimization`).
-- Security review of existing code (`cairo-auditor`).
-
-## Quick Start
-
-1. Build with `scarb build`, then declare and deploy with `sncast`.
-2. Use [skills catalog](../README.md) when the task moves back into authoring, testing, or auditing.
+**Not for:** Writing contracts (use cairo-contracts), testing (use cairo-testing), optimization (use cairo-optimization)
 
 ## Setup
 
@@ -91,7 +81,7 @@ sncast account deploy \
 ### Import Existing Account
 
 ```bash
-sncast account import \
+sncast account add \
     --url https://starknet-sepolia.g.alchemy.com/v2/YOUR_KEY \
     --name my-deployer \
     --address 0x123... \
@@ -178,29 +168,6 @@ sncast call \
     --calldata 0xACCOUNT
 ```
 
-## Programmatic Deployment (starknet.js)
-
-```ts
-import { Account, CallData, Contract, RpcProvider } from "starknet";
-
-const provider = new RpcProvider({ nodeUrl: process.env.STARKNET_RPC! });
-const account = new Account(provider, process.env.ACCOUNT_ADDRESS!, process.env.PRIVATE_KEY!);
-
-const declareTx = await account.declare({ contract: compiledSierra, casm: compiledCasm });
-await provider.waitForTransaction(declareTx.transaction_hash);
-
-const deployTx = await account.deploy({
-  classHash: declareTx.class_hash,
-  constructorCalldata: CallData.compile({ owner: process.env.OWNER! }),
-});
-await provider.waitForTransaction(deployTx.transaction_hash);
-
-const contract = new Contract(abi, deployTx.contract_address[0], provider).connect(account);
-await contract.invoke("set_fee", [10]);
-const fee = await contract.call("get_fee", []);
-console.log({ fee });
-```
-
 ## Multicall
 
 Execute multiple calls in a single transaction:
@@ -238,18 +205,18 @@ echo "Building..."
 scarb build
 
 echo "Declaring MyToken..."
-TOKEN_CLASS=$(sncast --json declare --contract-name MyToken --url $RPC_URL --account $ACCOUNT | jq -r '.class_hash')
+TOKEN_CLASS=$(sncast declare --contract-name MyToken --url $RPC_URL --account $ACCOUNT | grep "class_hash" | awk '{print $2}')
 echo "Token class: $TOKEN_CLASS"
 
 echo "Deploying MyToken..."
-TOKEN_ADDR=$(sncast --json deploy --class-hash $TOKEN_CLASS --constructor-calldata 0xOWNER --url $RPC_URL --account $ACCOUNT | jq -r '.contract_address')
+TOKEN_ADDR=$(sncast deploy --class-hash $TOKEN_CLASS --constructor-calldata 0xOWNER --url $RPC_URL --account $ACCOUNT | grep "contract_address" | awk '{print $2}')
 echo "Token deployed at: $TOKEN_ADDR"
 
 echo "Declaring AMM..."
-AMM_CLASS=$(sncast --json declare --contract-name AMM --url $RPC_URL --account $ACCOUNT | jq -r '.class_hash')
+AMM_CLASS=$(sncast declare --contract-name AMM --url $RPC_URL --account $ACCOUNT | grep "class_hash" | awk '{print $2}')
 
 echo "Deploying AMM..."
-AMM_ADDR=$(sncast --json deploy --class-hash $AMM_CLASS --constructor-calldata $TOKEN_ADDR --url $RPC_URL --account $ACCOUNT | jq -r '.contract_address')
+AMM_ADDR=$(sncast deploy --class-hash $AMM_CLASS --constructor-calldata $TOKEN_ADDR --url $RPC_URL --account $ACCOUNT | grep "contract_address" | awk '{print $2}')
 echo "AMM deployed at: $AMM_ADDR"
 
 echo "Done. Addresses:"
@@ -289,7 +256,7 @@ Verify source code on Voyager or Starkscan:
 # https://app.walnut.dev
 ```
 
-> **Note:** `sncast verify` supports both Walnut and Voyager backends. Use `--verifier walnut` or `--verifier voyager` explicitly.
+> **Note:** `sncast verify` currently only supports the Walnut verification backend. Voyager and Starkscan verification must be done through their respective web UIs.
 
 ## Upgradeable Contracts
 

--- a/skills/cairo-language/SKILL.md
+++ b/skills/cairo-language/SKILL.md
@@ -1,23 +1,5 @@
 ---
 
-## JavaScript Interop (starknet.js)
-
-```javascript
-import { Account, Contract, RpcProvider } from 'starknet';
-
-// Connect to provider
-const provider = new RpcProvider({ nodeUrl: 'https://rpc.starknet.lava.build' });
-
-// Create account instance
-const account = new Account(provider, YOUR_ADDRESS, privateKey);
-
-// Call contract
-const result = await account.execute({
-  contractAddress: CONTRACT_ADDRESS,
-  entrypoint: 'get_balance',
-  calldata: []
-});
-```
 
 name: cairo-language
 description: Use when writing Cairo code — type system, ownership, traits, generics, collections, error handling, and module system. Language fundamentals before contract-specific patterns.
@@ -45,6 +27,25 @@ What you need to know before writing contracts.
 **Not for:** Contract storage/events (use cairo-contracts), components (use cairo-components), testing (use cairo-testing)
 
 ## Scarb Project Setup
+
+## JavaScript Interop (starknet.js)
+
+```javascript
+import { Account, Contract, RpcProvider } from 'starknet';
+
+// Connect to provider
+const provider = new RpcProvider({ nodeUrl: 'https://rpc.starknet.lava.build' });
+
+// Create account instance
+const account = new Account(provider, YOUR_ADDRESS, privateKey);
+
+// Call contract
+const result = await account.execute({
+  contractAddress: CONTRACT_ADDRESS,
+  entrypoint: 'get_balance',
+  calldata: []
+});
+```
 
 ```bash
 # Create a new project

--- a/skills/cairo-language/SKILL.md
+++ b/skills/cairo-language/SKILL.md
@@ -1,0 +1,349 @@
+---
+
+## JavaScript Interop (starknet.js)
+
+```javascript
+import { Account, Contract, RpcProvider } from 'starknet';
+
+// Connect to provider
+const provider = new RpcProvider({ nodeUrl: 'https://rpc.starknet.lava.build' });
+
+// Create account instance
+const account = new Account(provider, YOUR_ADDRESS, privateKey);
+
+// Call contract
+const result = await account.execute({
+  contractAddress: CONTRACT_ADDRESS,
+  entrypoint: 'get_balance',
+  calldata: []
+});
+```
+
+name: cairo-language
+description: Use when writing Cairo code — type system, ownership, traits, generics, collections, error handling, and module system. Language fundamentals before contract-specific patterns.
+license: Apache-2.0
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, language, types, traits, generics, ownership, modules, felt252, array, dict]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Language
+
+Cairo programming language fundamentals.
+What you need to know before writing contracts.
+
+> **Next step:** Once you're comfortable with the language, see [cairo-contracts](../cairo-contracts/) for Starknet contract patterns.
+
+## When to Use
+
+- Learning Cairo syntax, types, or ownership model
+- Working with generics, traits, or pattern matching
+- Understanding felt252, arrays, dicts, or error handling
+- Structuring modules and imports
+
+**Not for:** Contract storage/events (use cairo-contracts), components (use cairo-components), testing (use cairo-testing)
+
+## Scarb Project Setup
+
+```bash
+# Create a new project
+scarb init my_project
+cd my_project
+
+# Build
+scarb build
+
+# Format
+scarb fmt
+
+# Run (standalone Cairo, no Starknet)
+scarb cairo-run
+```
+
+`Scarb.toml` minimal config:
+
+```toml
+[package]
+name = "my_project"
+version = "0.1.0"
+edition = "2024_07"
+
+[dependencies]
+starknet = ">=2.12.0"
+
+[[target.starknet-contract]]
+```
+
+## Type System
+
+### Primitives
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `felt252` | Field element (0 ≤ x < P) | `let x: felt252 = 42;` |
+| `u8`..`u256` | Unsigned integers | `let n: u128 = 1000;` |
+| `i8`..`i128` | Signed integers | `let n: i8 = -5;` |
+| `bool` | Boolean | `let b = true;` |
+| `()` | Unit type (void) | `fn do_thing() { }` |
+
+### Strings
+
+```cairo
+// Short string — max 31 ASCII chars, stored as felt252
+let short: felt252 = 'hello';
+
+// ByteArray — arbitrary length string
+let long: ByteArray = "this can be any length";
+```
+
+### Tuples and Fixed-Size Arrays
+
+```cairo
+let tup: (u32, felt252, bool) = (10, 'hi', true);
+let (a, b, c) = tup;  // destructure
+
+let arr: [u32; 3] = [1, 2, 3];
+let first = arr[0];
+```
+
+### Type Conversion
+
+```cairo
+// Infallible — always succeeds (widening)
+let x: u8 = 5;
+let y: u16 = x.into();
+
+// Fallible — may fail (narrowing)
+let big: u16 = 500;
+let small: u8 = big.try_into().unwrap();  // panics if out of range
+let safe: Option<u8> = big.try_into();    // returns None if out of range
+```
+
+## Ownership and References
+
+Cairo uses a **linear type system** — every value must be used exactly once unless the type implements `Copy` or `Drop`.
+
+```cairo
+#[derive(Drop)]       // can be silently discarded
+struct MyStruct { val: u32 }
+
+#[derive(Copy, Drop)]  // can be copied implicitly (like primitives)
+struct Point { x: u32, y: u32 }
+```
+
+### Snapshots and Refs
+
+```cairo
+// Snapshot (@T) — immutable view, does not consume the value
+fn read_it(data: @MyStruct) -> u32 {
+    *data.val  // desnap with * (only for Copy types)
+}
+
+// Ref — mutable borrow
+fn mutate_it(ref data: MyStruct) {
+    data.val = 10;
+}
+
+let mut s = MyStruct { val: 5 };
+let _ = read_it(@s);   // pass snapshot
+mutate_it(ref s);       // pass mutable ref
+```
+
+## Structs
+
+```cairo
+#[derive(Drop, Serde, Copy, PartialEq)]
+struct Rectangle {
+    width: u64,
+    height: u64,
+}
+
+// Methods via trait + impl
+trait RectangleTrait {
+    fn area(self: @Rectangle) -> u64;
+}
+
+impl RectangleImpl of RectangleTrait {
+    fn area(self: @Rectangle) -> u64 {
+        *self.width * *self.height
+    }
+}
+```
+
+Common derive macros:
+- `Drop` — value can be discarded
+- `Copy` — value can be implicitly copied
+- `Serde` — serialization (required for contract calldata)
+- `PartialEq` — equality comparison
+- `Hash` — hashing support
+- `starknet::Store` — storable in contract storage
+- `starknet::Event` — emittable as event
+
+## Enums and Pattern Matching
+
+```cairo
+#[derive(Drop)]
+enum Direction {
+    North,
+    South,
+    East: u32,  // variant with data
+}
+
+fn describe(d: Direction) -> felt252 {
+    match d {
+        Direction::North => 'up',
+        Direction::South => 'down',
+        Direction::East(dist) => 'east',
+    }
+}
+```
+
+### Option and Result
+
+```cairo
+// Option<T> — None or Some(value)
+let maybe: Option<u32> = Option::Some(42);
+
+match maybe {
+    Option::Some(val) => val,
+    Option::None => 0,
+}
+
+// if-let shorthand
+if let Option::Some(val) = maybe {
+    // use val
+}
+
+// Result<T, E> — Ok(value) or Err(error)
+fn divide(a: u32, b: u32) -> Result<u32, felt252> {
+    if b == 0 {
+        Result::Err('division by zero')
+    } else {
+        Result::Ok(a / b)
+    }
+}
+```
+
+## Traits and Generics
+
+```cairo
+trait Summary<T> {
+    fn summarize(self: @T) -> ByteArray;
+}
+
+impl RectSummary of Summary<Rectangle> {
+    fn summarize(self: @Rectangle) -> ByteArray {
+        "a rectangle"
+    }
+}
+
+// Generic function with trait bounds
+fn print_summary<T, +Summary<T>, +Drop<T>>(item: @T) -> ByteArray {
+    item.summarize()
+}
+```
+
+Trait bounds use `+` syntax: `+Drop<T>`, `+Copy<T>`, `+Into<T, U>`.
+
+### Impl of vs Impl for
+
+```cairo
+// Named impl with `of` — standard pattern
+impl MyImpl of MyTrait<MyType> { ... }
+
+// Can also use `of` with generic impls
+impl GenericImpl<T, +Drop<T>> of MyTrait<T> { ... }
+```
+
+## Collections
+
+### Array
+
+```cairo
+let mut arr: Array<u32> = array![1, 2, 3];
+arr.append(4);
+
+let len = arr.len();
+let first: Option<u32> = arr.pop_front();  // removes from front
+let val: u32 = *arr.at(0);                 // panics if out of bounds
+let maybe: Option<Box<@u32>> = arr.get(0);  // returns Option<Box<@T>>
+
+// Span — immutable view of an Array
+let span: Span<u32> = arr.span();
+```
+
+Arrays are append-only and consume elements on `pop_front`.
+Use `Span<T>` to pass arrays without consuming them.
+
+### Felt252Dict
+
+```cairo
+let mut dict: Felt252Dict<u64> = Default::default();
+dict.insert('key', 100);
+let val = dict.get('key');  // returns 100
+```
+
+Keys must be `felt252`.
+Values must implement `Felt252DictValue` (felt252, u-integers, bool, Nullable<T>).
+For complex values, use `Nullable<T>`:
+
+```cairo
+let mut dict: Felt252Dict<Nullable<Span<u32>>> = Default::default();
+dict.insert('k', NullableTrait::new(array![1, 2].span()));
+let val = dict.get('k').deref();
+```
+
+## Error Handling
+
+```cairo
+// Assert — panics with message if false
+assert!(balance >= amount, "insufficient balance");
+
+// Panic — unconditional
+panic!("something went wrong");
+
+// Result-based — for recoverable errors
+fn safe_div(a: u32, b: u32) -> Result<u32, felt252> {
+    if b == 0 { return Result::Err('div by zero'); }
+    Result::Ok(a / b)
+}
+
+// Unwrap helpers
+let val = safe_div(10, 2).unwrap();          // panics on Err
+let val = safe_div(10, 2).expect('math err'); // panics with message
+```
+
+## Modules
+
+```cairo
+// lib.cairo — crate root
+mod math;        // loads from math.cairo or math/mod.cairo
+mod utils;
+
+// math.cairo
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+fn private_helper() -> u32 { 0 }  // not pub = private
+
+// main usage
+use crate::math::add;      // absolute path from crate root
+use super::utils::helper;  // relative path from parent module
+```
+
+Visibility: items are private by default.
+Use `pub` to make them accessible outside the module.
+`pub(crate)` makes items visible within the crate only.
+
+### File Layout Convention
+
+```text
+src/
+  lib.cairo        # mod declarations
+  math.cairo       # single-file module
+  utils/
+    mod.cairo      # multi-file module root
+    helpers.cairo   # submodule
+```

--- a/skills/cairo-optimization/SKILL.md
+++ b/skills/cairo-optimization/SKILL.md
@@ -1,179 +1,446 @@
 ---
 name: cairo-optimization
-description: Improves Cairo performance after correctness is established. Trigger on "optimize", "gas usage", "reduce steps", "profile", "BoundedInt", "storage packing", "benchmark". Guides profiling, arithmetic optimization, and bounded-int hardening.
+description: Use as an explicit post-test optimization pass — fixing slow loops, expensive arithmetic, integer splitting or limb assembly, modular reduction, storage slot packing, or BoundedInt type bounds. Invoke after implementation and tests pass.
 license: Apache-2.0
-metadata: {"author":"feltroidprime","contributors":["starknet-agentic"],"version":"1.3.0","org":"keep-starknet-strange","upstream":"https://github.com/feltroidprime/cairo-skills","upstream_commit":"7fde29f","sync_date":"2026-03-08","upstream_paths":["skills/cairo-coding","skills/benchmarking-cairo"],"permission_ref":"maintainer-confirmed-2026-03-08"}
-keywords: [cairo, optimization, profiling, benchmarking, gas, bounded-int, storage-packing, arithmetic, starknet]
+metadata: {"author":"feltroidprime","contributors":["starknet-agentic"],"version":"1.1.0","org":"keep-starknet-strange","upstream":"https://github.com/feltroidprime/cairo-skills/tree/main/skills/cairo-coding"}
+keywords: [cairo, optimization, gas, bounded-int, storage-packing, arithmetic, starknet, smart-contracts, performance, garaga]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true
 ---
 
-# Cairo Optimization
+# Coding Cairo
 
-You are a Cairo optimization assistant. Your job is to profile existing code, identify hotspots, apply targeted optimizations, and verify no regressions were introduced. Apply only after tests pass and behavior is locked.
+Rules and patterns for writing efficient Cairo code. Sourced from audit findings and production profiling.
+
+> **Attribution:** Originally authored by [feltroidprime](https://github.com/feltroidprime) ([cairo-skills](https://github.com/feltroidprime/cairo-skills)). Integrated with permission into starknet-agentic.
 
 ## When to Use
 
-- Reducing gas/steps in hot paths after correctness is established.
-- Profiling Cairo functions to find bottlenecks.
-- Rewriting expensive arithmetic, loops, or storage patterns.
-- Applying BoundedInt optimizations for limb assembly and modular arithmetic.
-- Packing storage fields to reduce slot usage.
+- Implementing arithmetic (modular, parity checks, quotient/remainder)
+- Optimizing loops (slow iteration, repeated `.len()` calls, index-based access)
+- Splitting or assembling integer limbs (u256 → u128, u32s → u128, felt252 → u96)
+- Packing struct fields into storage slots
+- Using `BoundedInt` for zero-overhead arithmetic with compile-time bounds
+- Choosing integer types (u128 vs u256, BoundedInt vs native types)
 
-## When NOT to Use
+**Not for:** Profiling/benchmarking (use benchmarking-cairo if available)
 
-- Early feature prototyping without tests (write tests first with `cairo-testing`).
-- Contract architecture decisions (`cairo-contract-authoring`).
-- Security audit (`cairo-auditor`).
-- Deployment operations (`cairo-deploy`).
+## Quick Reference — All Rules
 
-## Quick Start
+| # | Rule | Instead of | Use |
+|---|------|-----------|-----|
+| 1 | Combined quotient+remainder | `x / m` + `x % m` | `DivRem::div_rem(x, m)` |
+| 2 | Cheap loop conditions | `while i < n` | `while i != n` |
+| 3 | Constant powers of 2 | `2_u32.pow(k)` | `match`-based lookup table |
+| 4 | Pointer-based iteration | `*data.at(i)` in index loop | `pop_front` / `for` / `multi_pop_front` |
+| 5 | Cache array length | `.len()` in loop condition | `let n = data.len();` before loop |
+| 6 | Pointer-based slicing | Manual loop extraction | `span.slice(start, length)` |
+| 7 | Cheap parity/halving | `index & 1`, `index / 2` | `DivRem::div_rem(index, 2)` |
+| 8 | Smallest integer type | `u256` when range < 2^128 | `u128` (type encodes constraint) |
+| 9 | Storage slot packing | One slot per field | `StorePacking` trait |
+| 10 | BoundedInt for limbs | Bitwise ops / raw u128 math | `bounded_int::{div_rem, mul, add}` |
+| 11 | Fast 2-input Poseidon | `poseidon_hash_span([x,y])` | `hades_permutation(x, y, 2)` |
 
-1. Confirm tests pass with `snforge test`.
-2. Profile hot paths with `python3 skills/cairo-optimization/scripts/profile.py profile`.
-3. Load references based on optimization type — see the table in [Orchestration](#orchestration).
-4. Apply one optimization class at a time, re-test after each.
-5. Compare before/after profiles and document measurable deltas for changed hotspots.
-6. Encode stable optimization regressions in `../../evals/cases/contract_skill_benchmark.jsonl` to prevent benchmark drift.
-7. Emit a handoff block using `../references/skill-handoff.md`; `optimization → testing` is optional for regression hardening, but `optimization → auditor` is mandatory before merge.
+## Always / Never Rules
 
-## Rationalizations to Reject
+### 1. Always use `DivRem::div_rem` — never separate `%` and `/`
 
-- "Let's optimize before we have tests."
-- "We can skip re-profiling — the change is obviously better."
-- "BoundedInt types are too complex — let's use raw u128 math."
-- "We can calculate bounds by hand instead of using the CLI tool."
+Cairo computes quotient and remainder in a single operation. Using both `%` and `/` on the same value doubles the cost.
 
-## Mode Selection
+```cairo
+// BAD
+let q = x / m;
+let r = x % m;
 
-- **profile**: User wants to find bottlenecks. Run profiler, identify hotspots.
-- **arithmetic**: User wants to optimize math (DivRem, loops, Poseidon). Apply rules from legacy-full.md.
-- **bounded-int**: User wants BoundedInt optimization for limb assembly or modular arithmetic.
-- **storage**: User wants to pack storage fields or reduce slot usage.
+// GOOD
+let (q, r) = DivRem::div_rem(x, m);
+```
 
-## Orchestration
+### 2. Never use `<` or `>` in while loop conditions — use `!=`
 
-**Turn 1 — Baseline.** Before optimizing anything:
+Equality checks are cheaper than comparisons in Cairo.
 
-(a) Determine mode: `profile`, `arithmetic`, `bounded-int`, or `storage`.
+```cairo
+// BAD
+while i < n { ... i += 1; }
 
-(b) Verify tests pass. Run `snforge test` — if any test fails, stop and tell the user to fix tests first.
+// GOOD
+while i != n { ... i += 1; }
+```
 
-(c) Read the target code. Use Glob to find `.cairo` files, then Read to inspect them. Identify:
-- Hot-path functions (called frequently or with expensive operations).
-- Current arithmetic patterns (division, modulus, loops, bitwise ops).
-- Storage layout (field types, packing opportunities).
-- BoundedInt usage or opportunities.
+### 3. Never compute `2^k` with `pow()` — use a lookup table
 
-(d) Profile the baseline. Run `python3 {skill_dir}/scripts/profile.py profile` with the appropriate arguments. Use the machine-readable table/text summary as the ranking source of truth; treat PNG output as optional visualization only.
+`u32::pow()` is expensive. Use a `match` lookup for known ranges.
 
-(e) Load references based on the optimization type:
+```cairo
+// BAD
+let p = 2_u32.pow(depth.into());
 
-| Request involves | Load reference |
-|-----------------|---------------|
-| Arithmetic rules (DivRem, loops, Poseidon, integer types) | `{skill_dir}/references/legacy-full.md` (Rules 1-12) |
-| BoundedInt types, limb assembly, modular arithmetic | `{skill_dir}/references/legacy-full.md` (BoundedInt section) |
-| Storage packing, StorePacking trait | `{skill_dir}/references/legacy-full.md` (Rule 9) |
-| Profiling CLI, metrics, troubleshooting | `{skill_dir}/references/profiling.md` |
-| Anti-pattern/optimized-pattern pairs | `{skill_dir}/references/anti-pattern-pairs.md` |
-
-Where `{skill_dir}` is the directory containing this SKILL.md. Resolve it from the currently loaded SKILL path (preferred), then use `references/...` and `scripts/...` relative paths from that directory.
-
-**Turn 2 — Plan.** Before changing any code, output a brief plan:
-
-1. **Hotspots** — list the top 3-5 functions by step cost from the profile.
-2. **Optimizations** — for each hotspot, identify which rule(s) apply (by number from legacy-full.md).
-3. **Anti-patterns found** — list any anti-pattern/optimized-pattern pairs detected in the code.
-4. **BoundedInt opportunities** — if applicable, list functions that would benefit from BoundedInt types.
-5. **Expected impact** — rough estimate of step reduction per optimization.
-
-Keep the plan under 30 lines. Wait for user confirmation before implementing.
-
-**Turn 3 — Optimize.** Apply changes following these rules:
-
-*Process rules:*
-- Apply ONE optimization class per commit. Never mix arithmetic and storage optimizations.
-- Run `snforge test` after each change — if any test fails, revert and investigate.
-- Re-profile after each change to measure actual impact.
-
-*Arithmetic rules (from legacy-full.md):*
-- Use `DivRem::div_rem` instead of separate `/` and `%` (Rule 1).
-- Use `!=` instead of `<` in loop conditions (Rule 2).
-- Use match-based lookup tables instead of `pow()` (Rule 3).
-- Use `pop_front` / `for` / `multi_pop_front` instead of index loops (Rule 4).
-- Cache `.len()` before loops (Rule 5).
-- Use `span.slice()` instead of manual loop extraction (Rule 6).
-- Use `DivRem` for parity checks instead of bitwise ops (Rule 7).
-- Use the smallest integer type that fits the range (Rule 8).
-- Use `hades_permutation` for 2-input Poseidon hashes (Rule 11).
-
-*Storage rules:*
-- Pack small fields into one slot with `StorePacking` trait (Rule 9).
-
-*BoundedInt rules:*
-- Use BoundedInt types as function inputs AND outputs — never downcast at every call (Rule 10).
-- Use `u128s_from_felt252` + `upcast` for bulk felt252 → BoundedInt conversions (Rule 12).
-- Always use `python3 {skill_dir}/scripts/bounded_int_calc.py` to compute bounds — never calculate manually.
-- Use the SHIFT pattern for negative dividends in `bounded_int_div_rem`: `SHIFT = ceil(|min_possible_value| / modulus) * modulus`, then reduce `value + SHIFT`.
-
-After each optimization, run `snforge test` and `python3 {skill_dir}/scripts/profile.py profile` to verify improvement.
-
-**Turn 4 — Verify.** After all optimizations:
-
-- Run full test suite: `snforge test` (all tests must pass).
-- Summarize before/after hotspot metrics and include step deltas in the PR description.
-- Suggest next steps: run `cairo-auditor` on touched files and update eval cases (`contract_skill_benchmark.jsonl`, `contract_skill_generation_eval.jsonl`) to lock gains.
-
-For the full execution checklist, use [workflows/default.md](workflows/default.md).
-
-## starknet.js Example
-
-```ts
-import { Account, Contract, RpcProvider } from "starknet";
-
-const provider = new RpcProvider({ nodeUrl: process.env.STARKNET_RPC! });
-const account = new Account(provider, process.env.ACCOUNT_ADDRESS!, process.env.PRIVATE_KEY!);
-const contract = new Contract(abi, process.env.CONTRACT_ADDRESS!, provider).connect(account);
-
-try {
-  const before = await contract.call("hot_path_steps", []);
-  const tx = await contract.invoke("apply_optimized_path", []);
-  await provider.waitForTransaction(tx.transaction_hash);
-  const after = await contract.call("hot_path_steps", []);
-  console.log({ before, after });
-} catch (err) {
-  console.error("optimization check failed", err);
+// GOOD — match-based lookup
+fn pow2(n: u32) -> u32 {
+    match n {
+        0 => 1, 1 => 2, 2 => 4, 3 => 8, 4 => 16, 5 => 32,
+        6 => 64, 7 => 128, 8 => 256, 9 => 512, 10 => 1024,
+        // extend as needed
+        _ => core::panic_with_felt252('pow2 out of range'),
+    }
 }
 ```
 
-## Error Codes and Recovery
+### 4. Always iterate arrays with `pop_front` / `for` / `multi_pop_front` — never index-loop
 
-| Code | Condition | Recovery |
-| --- | --- | --- |
-| `OPT-001` | Baseline tests failed before optimization | Stop optimization work, fix failing tests, then rerun baseline profiling. |
-| `OPT-002` | Profiling artifacts missing (`trace`/`pb.gz`) | Re-run `profile.py` with correct `--mode`/`--package` and validate tool availability. |
-| `OPT-003` | BoundedInt bounds invalid or unsafe | Recompute bounds with `bounded_int_calc.py`; reject manual bounds and rerun tests. |
-| `OPT-004` | Post-change profile regressed | Revert the change, isolate one optimization class, and measure again with identical inputs. |
+Index-based access (`array.at(i)`) is more expensive than pointer-based iteration.
 
-## Security-Critical Rules
+```cairo
+// BAD
+let mut i = 0;
+while i != data.len() {
+    let val = *data.at(i);
+    i += 1;
+}
 
-These are non-negotiable. Every optimization you apply must satisfy all of them:
+// GOOD — pop_front
+while let Option::Some(val) = data.pop_front() { ... }
 
-1. Tests pass before AND after every optimization. Never optimize untested code.
-2. One optimization class per commit. Never mix unrelated changes.
-3. BoundedInt bounds are computed with the CLI tool — never by hand.
-4. Re-profile after every change to confirm measurable improvement.
-5. Anti-pattern/optimized-pattern pairs are enforced — never write the anti-pattern.
+// GOOD — for loop (equivalent)
+for val in data { ... }
 
-## References
+// GOOD — batch iteration
+while let Option::Some(chunk) = data.multi_pop_front::<4>() { ... }
+```
 
-- Optimization rules and BoundedInt: [legacy-full.md](references/legacy-full.md)
-- Profiling CLI and troubleshooting: [profiling.md](references/profiling.md)
-- Optimization anti-pattern pairs: [anti-pattern-pairs.md](references/anti-pattern-pairs.md)
-- Cross-skill handoff format: `../references/skill-handoff.md`
-- Module index: [references/README.md](references/README.md)
+### 5. Never call `.len()` inside a loop condition — cache it
 
-## Workflow
+`.len()` recomputes every iteration. Store it once.
 
-- Main optimization flow: [default workflow](workflows/default.md)
-- Mandatory pre-merge chain: `optimization → auditor` (with `optimization → testing` only as an optional regression-hardening pass before auditor).
+```cairo
+// BAD
+while i != data.len() { ... i += 1; }
+
+// GOOD
+let n = data.len();
+while i != n { ... i += 1; }
+```
+
+### 6. Always use `span.slice()` instead of manual loop extraction
+
+`slice()` manipulates pointers directly — no element-by-element copying.
+
+```cairo
+// BAD
+let mut result: Array = array![];
+let mut i = 0;
+while i != length {
+    result.append(*data.at(start + i));
+    i += 1;
+}
+
+// GOOD
+let result = data.slice(start, length);
+```
+
+### 7. Always use `DivRem` for parity checks — never use bitwise ops
+
+Bitwise AND is more expensive than `div_rem` in Cairo. Use `DivRem::div_rem(x, 2)` to get both the halved value and parity in one operation.
+
+```cairo
+// BAD
+let is_odd = (index & 1) == 1;
+index = index / 2;
+
+// GOOD
+let (q, r) = DivRem::div_rem(index, 2);
+if r == 1 { /* odd branch */ }
+index = q;
+```
+
+### 8. Always use the smallest integer type that fits the value range
+
+`u128` instead of `u256` when the range is known. Adds clarity, prevents intermediate overflow.
+
+```cairo
+// BAD — u256 for a value known to be < 2^128
+fn deposit(value: u256) { assert(value < MAX_U128, '...'); ... }
+
+// GOOD — type encodes the constraint
+fn deposit(value: u128) { ... }
+```
+
+### 9. Always use `StorePacking` to pack small fields into one storage slot
+
+Multiple small fields (basis points, flags, bounded amounts) can share a single `felt252` slot.
+
+```cairo
+use starknet::storage_access::StorePacking;
+
+const POW_2_128: felt252 = 0x100000000000000000000000000000000;
+
+impl MyStorePacking of StorePacking<MyStruct, felt252> {
+    fn pack(value: MyStruct) -> felt252 {
+        value.amount.into() + value.fee_bps.into() * POW_2_128
+    }
+    fn unpack(value: felt252) -> MyStruct {
+        let u256 { low, high } = value.into();
+        MyStruct { amount: low, fee_bps: high.try_into().unwrap() }
+    }
+}
+```
+
+### 10. Always use BoundedInt for byte cutting, limb assembly, and type conversions
+
+Never use bitwise ops (`&`, `|`, shifts) or raw `u128`/`u256` arithmetic for splitting or combining integer limbs. Use `bounded_int::div_rem` to extract parts and `bounded_int::mul` + `bounded_int::add` to assemble them. BoundedInt tracks bounds at compile time, eliminating overflow checks.
+
+**Assembling limbs** (e.g., 4 x u32 → u128):
+
+```cairo
+// BAD — direct u128 arithmetic (28,340 gas)
+fn u32s_to_u128(d0: u32, d1: u32, d2: u32, d3: u32) -> u128 {
+    d0.into() + d1.into() * POW_2_32 + d2.into() * POW_2_64 + d3.into() * POW_2_96
+}
+
+// GOOD — BoundedInt (13,840 gas, 2x faster)
+fn u32s_to_u128(d0: u32, d1: u32, d2: u32, d3: u32) -> u128 {
+    let d0_bi: u32_bi = upcast(d0);
+    let d1_bi: u32_bi = upcast(d1);
+    let d2_bi: u32_bi = upcast(d2);
+    let d3_bi: u32_bi = upcast(d3);
+    let r: u128_bi = add(add(add(d0_bi, mul(d1_bi, POW_32_UI)), mul(d2_bi, POW_64_UI)), mul(d3_bi, POW_96_UI));
+    upcast(r)
+}
+```
+
+**Splitting values** (e.g., felt252 → two u96 limbs):
+
+```cairo
+// GOOD — div_rem to split, mul+add to reassemble
+fn felt252_to_two_u96(value: felt252) -> (u96, u96) {
+    match u128s_from_felt252(value) {
+        U128sFromFelt252Result::Narrow(low) => {
+            let (hi32, lo96) = bounded_int::div_rem(low, NZ_POW96_TYPED);
+            (lo96, upcast(hi32))
+        },
+        U128sFromFelt252Result::Wide((high, low)) => {
+            let (lo_hi32, lo96) = bounded_int::div_rem(low, NZ_POW96_TYPED);
+            let hi64: BoundedInt<0, { POW64 - 1 }> = downcast(high).unwrap();
+            (lo96, bounded_int::add(bounded_int::mul(hi64, POW32_TYPED), lo_hi32))
+        },
+    }
+}
+```
+
+**Extracting bits** (e.g., building a 4-bit selector):
+
+```cairo
+// GOOD — div_rem by 2 extracts LSB, quotient is right-shifted value
+let (qu1, bit0) = bounded_int::div_rem(u1, TWO_NZ); // bit0 in {0,1}
+let (qu2, bit1) = bounded_int::div_rem(u2, TWO_NZ);
+let selector = add(bit0, mul(bit1, TWO_UI)); // selector in {0..3}
+```
+
+See [garaga/selectors.cairo](https://github.com/keep-starknet-strange/garaga/blob/main/src/src/ec/selectors.cairo) and [cairo-perfs-snippets](https://github.com/feltroidprime/cairo-perfs-snippets) for production examples.
+
+### 11. Always use `hades_permutation` for 2-input Poseidon hashes
+
+`poseidon_hash_span` has overhead for span construction. For exactly two inputs, use the permutation directly.
+
+```cairo
+// BAD
+let hash = poseidon_hash_span(array![x, y].span());
+
+// GOOD
+let (hash, _, _) = hades_permutation(x, y, 2);
+```
+
+## Code Quality
+
+- **DRY:** Extract repeated validation into helper functions. If two functions validate-then-write the same struct, extract a shared `_set_config()`.
+- **`scarb fmt`:** Run before every commit.
+- **`.tool-versions`:** Pin Scarb (2.15.1) and Starknet Foundry (0.56.0) versions with ASDF for reproducible builds.
+- **Keep dependencies updated:** Newer Scarb/Foundry versions include gas optimizations and compiler improvements.
+
+---
+
+## BoundedInt Optimization
+
+`BoundedInt<MIN, MAX>` encodes value constraints in the type system, eliminating runtime overflow checks. Use the CLI tool (`bounded_int_calc.py` in this skill directory) to compute bounds — do NOT calculate manually.
+
+### Critical Architecture Decision: Avoid Downcast
+
+**The #1 optimization pitfall:** Converting between `u16`/`u32`/`u64` and `BoundedInt` at function boundaries.
+
+#### The Problem
+
+If your functions take `u16` and return `u16`, you must:
+1. `downcast` input to `BoundedInt` (expensive — requires range check)
+2. Do bounded arithmetic (cheap)
+3. `upcast` result back to `u16` (cheap but wasteful)
+
+The `downcast` operation adds a range check that **dominates the savings** from bounded arithmetic. In profiling:
+- `downcast`: 161,280 steps (18.86%)
+- `bounded_int_div_rem`: 204,288 steps (23.89%)
+- Total bounded approach: worse than original!
+
+#### The Solution: BoundedInt Throughout
+
+**Use `BoundedInt` types as function inputs AND outputs.** This eliminates downcast entirely.
+
+```cairo
+// BAD: Converts at every call (downcast overhead kills performance)
+pub fn add_mod(a: u16, b: u16) -> u16 {
+    let a: Zq = downcast(a).expect('overflow'); // EXPENSIVE
+    let b: Zq = downcast(b).expect('overflow'); // EXPENSIVE
+    let sum: ZqSum = add(a, b);
+    let (_q, rem) = bounded_int_div_rem(sum, nz_q);
+    upcast(rem)
+}
+
+// GOOD: BoundedInt in, BoundedInt out (no downcast)
+pub fn add_mod(a: Zq, b: Zq) -> Zq {
+    let sum: ZqSum = add(a, b);
+    let (_q, rem) = bounded_int_div_rem(sum, nz_q);
+    rem
+}
+```
+
+#### Refactoring Strategy
+
+When optimizing existing code:
+1. **Identify the hot path** — profile to find which functions use modular arithmetic heavily
+2. **Change signatures** — update function inputs/outputs to use `BoundedInt` types
+3. **Propagate types outward** — callers must also use `BoundedInt`
+4. **Downcast only at boundaries** — convert from u16/u32 only at system entry points (e.g., deserialization)
+
+#### Type Conversion Rules
+
+| From | To | Operation | Cost |
+|------|-----|-----------|------|
+| `u16` | `BoundedInt<0, 65535>` | `upcast` | Free (superset) |
+| `u16` | `BoundedInt<0, 12288>` | `downcast` | **Expensive** (range check) |
+| `BoundedInt<0, 12288>` | `u16` | `upcast` | Free (subset) |
+| `BoundedInt<A, B>` | `BoundedInt<C, D>` where [A,B] ⊆ [C,D] | `upcast` | Free |
+| `BoundedInt<A, B>` | `BoundedInt<C, D>` where [A,B] ⊄ [C,D] | `downcast` | **Expensive** |
+
+**Key insight:** `upcast` only works when target range is a **superset** of source range. You cannot upcast `u32` to `BoundedInt<0, 150994944>` because `u32` max (4294967295) > 150994944.
+
+### Prerequisites
+
+```toml
+# Scarb.toml
+[dependencies]
+corelib_imports = "0.1.2"
+```
+
+```cairo
+// CORRECT imports — copy exactly
+use corelib_imports::bounded_int::{
+    BoundedInt, upcast, downcast, bounded_int_div_rem,
+    AddHelper, MulHelper, DivRemHelper, UnitInt,
+};
+use corelib_imports::bounded_int::bounded_int::{SubHelper, add, sub, mul};
+```
+
+### Copy-Paste Template
+
+Working example for modular arithmetic mod 100:
+
+```cairo
+use corelib_imports::bounded_int::{
+    BoundedInt, upcast, downcast, bounded_int_div_rem,
+    AddHelper, MulHelper, DivRemHelper, UnitInt,
+};
+use corelib_imports::bounded_int::bounded_int::{SubHelper, add, sub, mul};
+
+type Val = BoundedInt<0, 99>;          // [0, 99]
+type ValSum = BoundedInt<0, 198>;      // [0, 198]
+type ValConst = UnitInt<100>;          // singleton {100}
+
+impl AddValImpl of AddHelper<Val, Val> {
+    type Result = ValSum;
+}
+
+impl DivRemValImpl of DivRemHelper<ValSum, ValConst> {
+    type DivT = BoundedInt<0, 1>;
+    type RemT = Val;
+}
+
+fn add_mod_100(a: Val, b: Val) -> Val {
+    let sum: ValSum = add(a, b);
+    let nz_100: NonZero<ValConst> = 100;
+    let (_q, rem) = bounded_int_div_rem(sum, nz_100);
+    rem
+}
+```
+
+### CLI Tool
+
+Use `bounded_int_calc.py` in this skill directory. **Always use CLI — never calculate manually.**
+
+```bash
+# Addition: [a_lo, a_hi] + [b_lo, b_hi]
+python3 bounded_int_calc.py add 0 12288 0 12288
+# -> BoundedInt<0, 24576>
+
+# Subtraction: [a_lo, a_hi] - [b_lo, b_hi]
+python3 bounded_int_calc.py sub 0 12288 0 12288
+# -> BoundedInt<-12288, 12288>
+
+# Multiplication
+python3 bounded_int_calc.py mul 0 12288 0 12288
+# -> BoundedInt<0, 150994944>
+
+# Division: quotient and remainder bounds
+python3 bounded_int_calc.py div 0 24576 12289 12289
+# -> DivT: BoundedInt<0, 1>, RemT: BoundedInt<0, 12288>
+
+# Custom impl name
+python3 bounded_int_calc.py mul 0 12288 0 12288 --name MulZqImpl
+```
+
+### BoundedInt Bounds Quick Reference
+
+| Operation | Formula |
+|-----------|---------|
+| Add | `[a_lo + b_lo, a_hi + b_hi]` |
+| Sub | `[a_lo - b_hi, a_hi - b_lo]` |
+| Mul (unsigned) | `[a_lo * b_lo, a_hi * b_hi]` |
+| Div quotient | `[a_lo / b_hi, a_hi / b_lo]` |
+| Div remainder | `[0, b_hi - 1]` |
+
+### Negative Dividends: SHIFT Pattern
+
+`bounded_int_div_rem` doesn't support negative lower bounds. When a subtraction produces a negative-bounded result that needs reduction, add a multiple of the modulus first:
+
+```cairo
+// sub_mod: (a - b) mod Q via SHIFT
+pub fn sub_mod(a: Zq, b: Zq) -> Zq {
+    let a_plus_q: BoundedInt<12289, 24577> = add(a, Q_CONST); // shift by +Q
+    let diff: BoundedInt<1, 24577> = sub(a_plus_q, b);        // now non-negative
+    let (_q, rem) = bounded_int_div_rem(diff, nz_q());
+    rem
+}
+
+// fused_sub_mul_mod: a - (b*c) mod Q via large SHIFT
+// OFFSET = 12288 * Q = 151007232 (smallest multiple of Q >= max product)
+pub fn fused_sub_mul_mod(a: Zq, b: Zq, c: Zq) -> Zq {
+    let prod: ZqProd = mul(b, c);
+    let a_offset: BoundedInt<151007232, 151019520> = add(a, OFFSET_CONST);
+    let diff: BoundedInt<12288, 151019520> = sub(a_offset, prod);
+    let (_q, rem) = bounded_int_div_rem(diff, nz_q());
+    rem
+}
+```
+
+Rule: SHIFT = `ceil(|min_possible_value| / modulus) * modulus`. Adding SHIFT preserves the result mod Q (since SHIFT ≡ 0 mod Q) while making all values non-negative.
+
+### Common BoundedInt Mistakes
+
+- **Downcast at every function call** — the biggest performance killer. Use `BoundedInt` types throughout, not just inside arithmetic functions.
+- **Trying to upcast to a narrower type** — `upcast(val: u32)` to `BoundedInt<0, 150994944>` fails because u32 max > 150994944.
+- **Wrong imports** — use exact imports from Prerequisites section above.
+- **Wrong subtraction bounds** — it's `[a_lo - b_hi, a_hi - b_lo]`, NOT `[a_lo - b_lo, a_hi - b_hi]`.
+- **Negative dividend in `bounded_int_div_rem`** — div_rem doesn't support negative lower bounds. Add a SHIFT (multiple of modulus) before reducing. See SHIFT pattern above.
+- **Missing intermediate types** — always annotate: `let sum: ZqSum = add(a, b);`
+- **Division quotient off-by-one** — integer division floors: `24576 / 12289 = 1`, not 2.
+- **Using `UnitInt` vs `BoundedInt` for constants** — use `UnitInt<N>` for singleton constants like divisors.
+- **Using `div_rem` vs `bounded_int_div_rem`** — the function is `bounded_int_div_rem`, not `div_rem`.
+- **Bounds exceed u128::max** — BoundedInt bounds are hard-capped at 2^128. Larger values crash the Sierra specializer: 'Provided generic argument is unsupported.'

--- a/skills/cairo-optimization/bounded_int_calc.py
+++ b/skills/cairo-optimization/bounded_int_calc.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Bounded Integer Implementation Calculator
+
+Computes exact type bounds for Cairo BoundedInt helper trait implementations.
+Outputs ready-to-paste Cairo code.
+
+Original author: feltroidprime (https://github.com/feltroidprime/cairo-skills)
+
+Usage:
+    python3 bounded_int_calc.py add <a_lo> <a_hi> <b_lo> <b_hi> [--name NAME]
+    python3 bounded_int_calc.py sub <a_lo> <a_hi> <b_lo> <b_hi> [--name NAME]
+    python3 bounded_int_calc.py mul <a_lo> <a_hi> <b_lo> <b_hi> [--name NAME]
+    python3 bounded_int_calc.py div <a_lo> <a_hi> <b_lo> <b_hi> [--name NAME]
+"""
+
+import argparse
+import sys
+
+# felt252 prime (for validation)
+FELT252_PRIME = 0x800000000000011000000000000000000000000000000000000000000000001
+
+
+def validate_felt252(value: int, name: str) -> None:
+    """Warn if value exceeds felt252 range."""
+    if value < 0:
+        # Negative values are represented as P - |value| in felt252
+        if abs(value) >= FELT252_PRIME:
+            print(f"WARNING: {name} = {value} exceeds felt252 range!", file=sys.stderr)
+    elif value >= FELT252_PRIME:
+        print(f"WARNING: {name} = {value} exceeds felt252 range!", file=sys.stderr)
+
+
+def format_bound(value: int) -> str:
+    """Format a bound value, handling negatives."""
+    if value < 0:
+        return str(value)
+    return str(value)
+
+
+def calc_add(a_lo: int, a_hi: int, b_lo: int, b_hi: int) -> tuple:
+    """Calculate addition bounds: [a_lo + b_lo, a_hi + b_hi]"""
+    result_lo = a_lo + b_lo
+    result_hi = a_hi + b_hi
+    return result_lo, result_hi
+
+
+def calc_sub(a_lo: int, a_hi: int, b_lo: int, b_hi: int) -> tuple:
+    """Calculate subtraction bounds: [a_lo - b_hi, a_hi - b_lo]"""
+    result_lo = a_lo - b_hi
+    result_hi = a_hi - b_lo
+    return result_lo, result_hi
+
+
+def calc_mul(a_lo: int, a_hi: int, b_lo: int, b_hi: int) -> tuple:
+    """
+    Calculate multiplication bounds.
+    For unsigned: [a_lo * b_lo, a_hi * b_hi]
+    For signed/mixed: evaluate all corners.
+    """
+    corners = [
+        a_lo * b_lo,
+        a_lo * b_hi,
+        a_hi * b_lo,
+        a_hi * b_hi,
+    ]
+    return min(corners), max(corners)
+
+
+def calc_div(a_lo: int, a_hi: int, b_lo: int, b_hi: int) -> tuple:
+    """
+    Calculate division bounds.
+    Quotient: [a_lo // b_hi, a_hi // b_lo]
+    Remainder: [0, b_hi - 1]
+
+    Note: Cairo's bounded_int_div_rem requires non-negative dividends.
+    """
+    if b_lo <= 0:
+        print(
+            "ERROR: Divisor lower bound must be positive!",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if a_lo < 0:
+        print(
+            "ERROR: Dividend lower bound must be non-negative! "
+            "Cairo's bounded_int_div_rem does not support negative dividends.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    quot_lo = a_lo // b_hi
+    quot_hi = a_hi // b_lo
+    rem_lo = 0
+    rem_hi = b_hi - 1
+
+    return (quot_lo, quot_hi), (rem_lo, rem_hi)
+
+
+def generate_add_impl(
+    a_lo: int, a_hi: int, b_lo: int, b_hi: int, name: str
+) -> str:
+    result_lo, result_hi = calc_add(a_lo, a_hi, b_lo, b_hi)
+
+    validate_felt252(result_lo, "Result min")
+    validate_felt252(result_hi, "Result max")
+
+    return (
+        f"impl {name} of AddHelper<"
+        f"BoundedInt<{format_bound(a_lo)}, {format_bound(a_hi)}>, "
+        f"BoundedInt<{format_bound(b_lo)}, {format_bound(b_hi)}>> {{\n"
+        f"    type Result = BoundedInt<"
+        f"{format_bound(result_lo)}, {format_bound(result_hi)}>;\n"
+        f"}}"
+    )
+
+
+def generate_sub_impl(
+    a_lo: int, a_hi: int, b_lo: int, b_hi: int, name: str
+) -> str:
+    result_lo, result_hi = calc_sub(a_lo, a_hi, b_lo, b_hi)
+
+    validate_felt252(result_lo, "Result min")
+    validate_felt252(result_hi, "Result max")
+
+    return (
+        f"impl {name} of SubHelper<"
+        f"BoundedInt<{format_bound(a_lo)}, {format_bound(a_hi)}>, "
+        f"BoundedInt<{format_bound(b_lo)}, {format_bound(b_hi)}>> {{\n"
+        f"    type Result = BoundedInt<"
+        f"{format_bound(result_lo)}, {format_bound(result_hi)}>;\n"
+        f"}}"
+    )
+
+
+def generate_mul_impl(
+    a_lo: int, a_hi: int, b_lo: int, b_hi: int, name: str
+) -> str:
+    result_lo, result_hi = calc_mul(a_lo, a_hi, b_lo, b_hi)
+
+    validate_felt252(result_lo, "Result min")
+    validate_felt252(result_hi, "Result max")
+
+    return (
+        f"impl {name} of MulHelper<"
+        f"BoundedInt<{format_bound(a_lo)}, {format_bound(a_hi)}>, "
+        f"BoundedInt<{format_bound(b_lo)}, {format_bound(b_hi)}>> {{\n"
+        f"    type Result = BoundedInt<"
+        f"{format_bound(result_lo)}, {format_bound(result_hi)}>;\n"
+        f"}}"
+    )
+
+
+def generate_div_impl(
+    a_lo: int, a_hi: int, b_lo: int, b_hi: int, name: str
+) -> str:
+    (quot_lo, quot_hi), (rem_lo, rem_hi) = calc_div(a_lo, a_hi, b_lo, b_hi)
+
+    validate_felt252(quot_lo, "Quotient min")
+    validate_felt252(quot_hi, "Quotient max")
+    validate_felt252(rem_lo, "Remainder min")
+    validate_felt252(rem_hi, "Remainder max")
+
+    return (
+        f"impl {name} of DivRemHelper<"
+        f"BoundedInt<{format_bound(a_lo)}, {format_bound(a_hi)}>, "
+        f"BoundedInt<{format_bound(b_lo)}, {format_bound(b_hi)}>> {{\n"
+        f"    type DivT = BoundedInt<"
+        f"{format_bound(quot_lo)}, {format_bound(quot_hi)}>;\n"
+        f"    type RemT = BoundedInt<"
+        f"{format_bound(rem_lo)}, {format_bound(rem_hi)}>;\n"
+        f"}}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Calculate BoundedInt helper trait implementations",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Addition: [0, 12288] + [0, 12288]
+    python3 bounded_int_calc.py add 0 12288 0 12288
+
+    # Subtraction: [0, 12288] - [0, 12288]
+    python3 bounded_int_calc.py sub 0 12288 0 12288
+
+    # Multiplication: [0, 12288] * [0, 12288]
+    python3 bounded_int_calc.py mul 0 12288 0 12288
+
+    # Division: [128, 255] / [3, 8]
+    python3 bounded_int_calc.py div 128 255 3 8
+
+    # Custom impl name
+    python3 bounded_int_calc.py mul 0 12288 0 12288 --name Zq12289MulHelper
+        """,
+    )
+
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    for op_name, op_help, default_name in [
+        ("add", "Addition: [a_lo, a_hi] + [b_lo, b_hi]", "AddImpl"),
+        ("sub", "Subtraction: [a_lo, a_hi] - [b_lo, b_hi]", "SubImpl"),
+        ("mul", "Multiplication: [a_lo, a_hi] * [b_lo, b_hi]", "MulImpl"),
+        ("div", "Division: [a_lo, a_hi] / [b_lo, b_hi]", "DivRemImpl"),
+    ]:
+        sub = subparsers.add_parser(op_name, help=op_help)
+        sub.add_argument("a_lo", type=int, help="Lower bound of first operand")
+        sub.add_argument("a_hi", type=int, help="Upper bound of first operand")
+        sub.add_argument("b_lo", type=int, help="Lower bound of second operand")
+        sub.add_argument("b_hi", type=int, help="Upper bound of second operand")
+        sub.add_argument(
+            "--name", default=default_name, help="Name for the impl"
+        )
+
+    args = parser.parse_args()
+
+    generators = {
+        "add": generate_add_impl,
+        "sub": generate_sub_impl,
+        "mul": generate_mul_impl,
+        "div": generate_div_impl,
+    }
+
+    print(generators[args.operation](args.a_lo, args.a_hi, args.b_lo, args.b_hi, args.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/cairo-security/SKILL.md
+++ b/skills/cairo-security/SKILL.md
@@ -1,0 +1,1641 @@
+---
+name: cairo-security
+description: Use when reviewing Cairo contracts for security — common vulnerabilities, audit patterns, production hardening, Cairo-specific pitfalls, L1/L2 bridging safety, session key security, precision/rounding bugs, static analysis tooling. Sourced from 50+ public audits and the Cairo Book.
+license: Apache-2.0
+metadata: {"author":"omarespejel","version":"3.2.0","last_updated":"2026-02-11","org":"keep-starknet-strange","github":"https://github.com/omarespejel","x":"https://x.com/omarespejel"}
+keywords: [cairo, security, audit, vulnerabilities, access-control, reentrancy, starknet, production, hardening, l1-l2, session-keys, precision, rounding, static-analysis, snip-12, snip-9, outside-execution, governance, pausable, paymaster, account-abstraction, storage-node, vec, map, felt252, erc4626, erc20-permit]
+allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+user-invocable: true
+---
+
+# Cairo Security
+
+Security patterns and common vulnerabilities for Cairo smart contracts on Starknet. Sourced from 50+ public audit reports including Nethermind, ConsenSys Diligence, Code4rena, ChainSecurity, Cairo Security Clan, Zellic, and Nethermind AuditAgent, plus the [Cairo Book security chapter](https://book.cairo-lang.org/ch104-01-general-recommendations.html), [Crytic's Not So Smart Contracts](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/cairo), [Oxor.io Cairo Security Flaws](https://oxor.io/blog/2024-08-16-cairo-security-flaws/), and [FuzzingLabs Top 4 Vulnerabilities](https://fuzzinglabs.com/top-4-vulnerability-cairo-starknet-smart-contract/).
+
+> **Versions:** This skill targets **Cairo 2.12.4** (latest stable tagged on GitHub; v2.15.0 exists but 2.12.4 carries the "Latest" tag), **Scarb 2.15.1**, **Starknet Foundry 0.56.0**, **OpenZeppelin Contracts for Cairo 3.0.0** (v4.0.0-alpha.0 is pre-release, uses Scarb 2.15.1 / snforge 0.55.0), and **Starknet v0.14.1** (mainnet Dec 2025). All code examples and import paths are verified against these versions.
+
+> **Cairo Editions:** Cairo v2.15.0 introduced `edition 2025_12`, which changes snapshot/member access syntax (e.g., `(@a).b` returns desnapped value). If your `Scarb.toml` specifies this edition, test code that accesses struct members through snapshots — the number of `@` levels needed may differ from pre-2025_12 behavior.
+
+> **Workflow:** Use this skill as a review pass after your contract compiles and tests pass. Not a replacement for a professional audit.
+
+## When to Use
+
+- Reviewing a contract before audit or deployment
+- Checking for common Cairo/Starknet vulnerabilities
+- Hardening a contract for production
+- Implementing access control, upgrade safety, input validation
+- Writing session key or delegated execution contracts
+- Reviewing L1/L2 bridge handlers
+
+**Not for:** Writing contracts (use cairo-contracts), testing (use cairo-testing), gas optimization (use cairo-optimization)
+
+## Critical Patterns — Read These First
+
+These are the highest-impact Cairo/Starknet security patterns. Each has caused real losses or was flagged in multiple audits. If you read nothing else, read these.
+
+1. **`felt252` division is modular inverse, not floor division.** `felt252_div(10, 3)` does NOT return 3. It returns a huge field element. Never use `felt252` for financial math — use `u256` or `u128`. (Section 7)
+
+2. **`Map.read()` returns zero on missing keys — no panic.** An attacker bypassed oracle validation by reading a non-existent key that returned zero, then signed over zeroed data. Always assert non-zero/non-default after reading from storage Maps. (Section 4, Section 16 C4 Perpetual H-01)
+
+3. **`felt252` arithmetic wraps silently.** `balance - amount` where `amount > balance` wraps to a huge number with no error. Use `u256`/`u128` for all balances, amounts, prices. (Section 7)
+
+4. **Floor division always favors the actor.** When burning/withdrawing, round UP against the user. When minting/depositing, round DOWN against the user. The zkLend $10M exploit chained precision loss with accumulator manipulation. (Section 3)
+
+5. **Empty market initialization + flash loan = catastrophic.** First depositor controls the exchange rate. Lock minimum liquidity on first deposit. Applies to lending pools and ERC-4626 vaults. (Section 3)
+
+6. **OZ embedded impls leak privileged selectors to session keys.** Every OZ version exposes new selectors (`set_public_key`, `setPublicKey`, `upgrade`). Block self-calls from session keys: `assert(call.to != get_contract_address())`. (Section 13)
+
+7. **SNIP-9 `execute_from_outside` needs nonce + caller + time bounds.** Missing any one enables replay attacks. Signature must be validated via SNIP-12 over the full `OutsideExecution` struct. (Section 14)
+
+8. **Starknet v0.14.0 killed v0/v1/v2 transactions and cut blocks to ~6s.** Time-dependent logic calibrated for 30s blocks is now wrong by 5x. STRK-only fees. (Section 15)
+
+9. **`__validate__` in custom accounts must be lightweight.** No storage writes (except nonce), no external calls, bounded gas. Expensive validation griefs the sequencer. (Section 12)
+
+10. **Checks-effects-interactions is not optional.** C4 Starknet Perpetual H-02: state diff applied before validation caused double-application. C4 Opus H-01: `charge()` called after computing withdrawal amount overwrote the result. (Section 2, Section 16)
+
+---
+
+## Pre-Deployment Checklist
+
+Before any mainnet deployment:
+
+- [ ] All tests pass (`snforge test`) including fuzz tests for arithmetic-heavy logic
+- [ ] Fuzz tests written for arithmetic-heavy and state-transition logic (`snforge test --fuzzer-runs 500`)
+- [ ] No `unwrap()` on user-controlled inputs — use `expect()` or pattern match
+- [ ] Access control on all state-changing functions
+- [ ] Zero-address checks on constructor arguments
+- [ ] Initializer can only be called once (use OZ `InitializableComponent`)
+- [ ] Events emitted for all state changes (upgrades, config, pausing, privileged actions)
+- [ ] No storage collisions between components
+- [ ] Upgrade function protected by owner/admin check
+- [ ] Checks-effects-interactions pattern on all external calls
+- [ ] ReentrancyGuard on functions that make external calls before state updates
+- [ ] No unbounded loops on user-controlled data
+- [ ] L1 handler validates `from_address` against trusted L1 contract
+- [ ] Boolean returns from ERC20 `transfer`/`transfer_from` checked
+- [ ] Operator precedence verified in complex boolean expressions
+- [ ] Bit-packing does not exceed 251 bits for felt252
+- [ ] Precision/rounding in division reviewed — truncation can be exploited (see Section 3)
+- [ ] Nonces used for all signature-gated operations (see Section 5)
+- [ ] No sensitive data stored in plaintext on-chain (see Section 6)
+- [ ] Market initialization protected against empty-state manipulation
+- [ ] Contract verified on block explorer
+- [ ] `LegacyMap` migrated to `Map` (Cairo 2.7+)
+- [ ] Storage `Map.read()` results validated when absence should be an error (returns zero, not panic)
+- [ ] `felt252` not used for balances, amounts, prices, or counters (use `u256`/`u128`)
+- [ ] SNIP-12 used for all off-chain signature verification (not raw Pedersen hashing)
+- [ ] SNIP-9 `execute_from_outside` validates nonce, caller, and time bounds
+- [ ] `__validate__` in custom accounts is lightweight and makes no external calls
+- [ ] Liquidation/risk-management functions NOT blocked by pause mechanism
+- [ ] Paymaster interactions rate-limited and allowlisted
+- [ ] `NoncesComponent` from OZ used for replay protection (not hand-rolled nonces)
+- [ ] V3 transaction resource bounds handled (STRK-only fees since v0.14.0)
+- [ ] ERC-4626 vault first-depositor protection applied (minimum liquidity lock or virtual shares/assets) if applicable
+- [ ] `PausableComponent` integrated with exclusions for liquidation/risk functions
+- [ ] Public key inputs validated to lie on the STARK curve
+- [ ] No legacy v0/v1/v2 transaction assumptions (deprecated since v0.14.0)
+- [ ] Time-dependent logic recalibrated for ~6s block time (v0.14.0)
+- [ ] Global validation functions scoped correctly — no cross-contamination where unrelated state failures block valid operations
+- [ ] Per-asset risk parameters (not one-size-fits-all) for price staleness, funding caps, collateral factors
+- [ ] `AccessControlDefaultAdminRulesComponent` used for admin role transfer delay
+
+---
+
+## 1. Access Control, Upgrades & Initializers
+
+*Source: [Cairo Book ch104](https://book.cairo-lang.org/ch104-01-general-recommendations.html), [Code4rena Starknet Perpetual H-02](https://code4rena.com/reports/2025-03-starknet-perpetual)*
+
+The most common critical findings in Starknet audits are "who can call this?" and "can this be re-initialized?"
+
+### Missing Access Control
+
+```cairo
+// BAD — anyone can mint
+fn mint(ref self: ContractState, to: ContractAddress, amount: u256) {
+    self.erc20.mint(to, amount);
+}
+
+// GOOD — only minter role
+fn mint(ref self: ContractState, to: ContractAddress, amount: u256) {
+    self.access_control.assert_only_role(MINTER_ROLE);
+    self.erc20.mint(to, amount);
+}
+```
+
+### Unprotected Upgrade (Full Contract Takeover)
+
+If a non-authorized user can upgrade, they replace the class with anything and get full control.
+
+```cairo
+// BAD — anyone can upgrade
+fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+    self.upgradeable.upgrade(new_class_hash);
+}
+
+// GOOD — owner-only, with event
+fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+    self.ownable.assert_only_owner();
+    self.upgradeable.upgrade(new_class_hash);
+    self.emit(Upgraded { new_class_hash });
+}
+```
+
+### Re-Initializable Initializer
+
+A publicly exposed initializer that can be called post-deploy is a frequent vulnerability.
+
+```cairo
+// BAD — can be called multiple times
+fn initializer(ref self: ContractState, owner: ContractAddress) {
+    self.ownable.initializer(owner);
+}
+
+// GOOD — one-shot guard
+#[storage]
+struct Storage {
+    initialized: bool,
+}
+
+fn initializer(ref self: ContractState, owner: ContractAddress) {
+    assert!(!self.initialized.read(), "ALREADY_INIT");
+    self.initialized.write(true);
+    self.ownable.initializer(owner);
+}
+```
+
+**Rule:** If it must be external during deployment, make sure it can only be called once. If it doesn't need to be external, keep it internal.
+
+---
+
+## 2. Checks-Effects-Interactions (Reentrancy)
+
+*Source: [0xEniotna/Starknet-contracts-vulnerabilities](https://github.com/0xEniotna/Starknet-contracts-vulnerabilities), Code4rena Starknet Perpetual H-02*
+
+Code4rena's H-02 finding on Starknet Perpetual: `_execute_transfer` applied state diffs *before* performing checks. Always: check, then update state, then call external contracts.
+
+```cairo
+// BAD — state update after external call (reentrancy window)
+fn withdraw(ref self: ContractState, amount: u256) {
+    let caller = get_caller_address();
+    let balance = self.balances.read(caller);
+    assert(balance >= amount, 'Insufficient balance');
+
+    IERC20Dispatcher { contract_address: self.token.read() }
+        .transfer(caller, amount);       // external call FIRST
+
+    self.balances.write(caller, balance - amount);  // state update AFTER
+}
+
+// GOOD — checks-effects-interactions
+fn withdraw(ref self: ContractState, amount: u256) {
+    let caller = get_caller_address();
+    let balance = self.balances.read(caller);
+    assert(balance >= amount, 'Insufficient balance');
+
+    self.balances.write(caller, balance - amount);  // state update FIRST
+
+    IERC20Dispatcher { contract_address: self.token.read() }
+        .transfer(caller, amount);       // external call LAST
+}
+```
+
+---
+
+## 3. Precision, Rounding & Accumulator Manipulation
+
+*Source: [BlockSec — zkLend Exploit Post-Mortem (Feb 2025)](https://blocksec.com/blog/zklend-exploit-post-mortem), [FuzzingLabs zkLend Analysis](https://fuzzinglabs.com/rediscovery-zklend-hack/)*
+
+The zkLend exploit ($10M, Feb 12, 2025) is the largest Cairo-specific exploit to date. Root cause: precision loss through truncation in division, combined with accumulator manipulation via flash loan donations in an empty market.
+
+### The Attack Pattern
+
+1. **Empty market initialization** — attacker deposits 1 wei into an empty lending pool. Both `reserve_balance` and `ztoken_supply` start at 0 with `lending_accumulator = 1`.
+2. **Accumulator inflation via flash loan donations** — attacker takes flash loans of 1 wei, repays 1000 wei. Excess is treated as a "donation" that inflates `lending_accumulator`. After 10 flash loans: accumulator reaches ~4.069 × 10^18.
+3. **Rounding exploitation** — with a huge accumulator, `scaled_down_amount = amount / lending_accumulator` uses floor division (truncation). Burning tokens decreases `raw_balance` by only 1 unit despite burning large token amounts. Repeated deposit/withdraw cycles increment `raw_balance` by 1 each cycle.
+4. **Profit extraction** — `raw_balance` reaches 1,724 → collateral value of 7,015 wstETH → borrow other assets from the market.
+
+### Defense Patterns
+
+```cairo
+// PATTERN 1: Minimum liquidity lock (prevent empty-market manipulation)
+// On first deposit, lock a minimum amount permanently
+fn first_deposit(ref self: ContractState, amount: u256) {
+    let MIN_LIQUIDITY: u256 = 1000;  // dead shares
+    assert(amount > MIN_LIQUIDITY, 'BELOW_MIN_LIQUIDITY');
+    // Mint MIN_LIQUIDITY shares to zero address (locked forever)
+    self._mint(Zeroable::zero(), MIN_LIQUIDITY);
+    // Mint remainder to depositor
+    self._mint(get_caller_address(), amount - MIN_LIQUIDITY);
+}
+
+// PATTERN 2: Guard accumulator changes per transaction
+fn settle_extra_reserve(ref self: ContractState) {
+    let new_acc = self._compute_accumulator();
+    let old_acc = self.lending_accumulator.read();
+    let MAX_ACC_CHANGE: u256 = old_acc / 10; // max 10% change per tx
+    assert(new_acc - old_acc <= MAX_ACC_CHANGE, 'ACC_CHANGE_TOO_LARGE');
+    self.lending_accumulator.write(new_acc);
+}
+
+// PATTERN 3: Round UP when burning shares (penalize withdrawer, not pool)
+fn burn_scaled(amount: u256, accumulator: u256) -> u256 {
+    // Round up: (amount + accumulator - 1) / accumulator
+    (amount + accumulator - 1) / accumulator
+}
+```
+
+### Key Takeaway
+
+Floor division in share/token math always favors the actor performing the operation. **When burning/withdrawing, round UP (against the user). When minting/depositing, round DOWN (against the user).** This ensures the pool never loses value through rounding.
+
+### Fuzz Testing for Precision Bugs
+
+```cairo
+#[test]
+#[fuzzer(runs: 1000)]
+fn test_deposit_withdraw_invariant(deposit_amount: u256) {
+    // After deposit + immediate full withdraw, user should get back <= deposit_amount
+    // (never more, due to rounding favoring the pool)
+    let shares = pool.deposit(deposit_amount);
+    let withdrawn = pool.withdraw(shares);
+    assert(withdrawn <= deposit_amount, 'ROUNDING_EXPLOIT');
+}
+```
+
+### ERC-4626 Vault Share Manipulation
+
+The same accumulator/precision attack from the zkLend exploit applies directly to ERC-4626 tokenized vaults (`ERC4626Component` in OZ Cairo 3.x). The first depositor can manipulate the share price by donating assets to inflate the exchange rate, causing subsequent depositors to receive fewer shares than expected.
+
+**Two defense approaches:**
+
+1. **Minimum liquidity lock** (described above) — the first depositor burns a small amount of shares to a dead address, establishing a baseline exchange rate that cannot be trivially inflated.
+2. **Virtual shares/assets** — add 1 (or a small constant) to both the numerator and denominator in share calculations: `shares = (assets + 1) / (totalAssets + 1) * totalShares`. This eliminates the zero-denominator edge case and makes share price manipulation economically infeasible without requiring a liquidity lock. This is the approach used by OpenZeppelin's Solidity ERC-4626 implementation.
+
+Both are valid; choose based on your protocol's constraints. Minimum liquidity lock is simpler but requires a one-time setup cost. Virtual shares are more elegant but require modifying the conversion math throughout.
+
+### Wad Precision Truncation for Low-Decimal Tokens
+
+*Source: [Code4rena Opus H-02 (Jan 2024)](https://code4rena.com/reports/2024-01-opus)*
+
+Cairo's fixed-point `Wad` type (18 decimals) silently truncates when multiplied with tokens that have fewer decimals. In the Opus audit, `convert_to_yang_helper()` computed `(asset_amt * total_yang) / total_assets` — but because `Wad` multiplication divides by 1e18 internally, tokens with 8 decimals (like BTC) lost precision. A deposit of 0.0009 BTC ($36 at BTC=40K) resulted in **zero** shares.
+
+**Rule:** When doing fixed-point math with tokens that have < 18 decimals, compute the numerator fully as `u256` before dividing. Never let intermediate `Wad` multiplication truncate low-decimal amounts to zero.
+
+---
+
+## 4. Cairo-Specific Pitfalls
+
+*Source: [Cairo Book ch104](https://book.cairo-lang.org/ch104-01-general-recommendations.html)*
+
+These are unique to Cairo and not found in Solidity auditing guides.
+
+### Operator Precedence Bug
+
+In Cairo, `&&` has higher precedence than `||`. Combined boolean expressions must be parenthesized.
+
+```cairo
+// BAD — && binds tighter than ||, so this means:
+// mode == None || (mode == Recovery && coll_ok && debt_ok)
+assert!(
+    mode == Mode::None || mode == Mode::Recovery && ctx.coll_ok && ctx.debt_ok,
+    "EMERGENCY_MODE"
+);
+
+// GOOD — explicit parentheses
+assert!(
+    (mode == Mode::None || mode == Mode::Recovery) && (ctx.coll_ok && ctx.debt_ok),
+    "EMERGENCY_MODE"
+);
+```
+
+### Unsigned Loop Underflow
+
+Decrementing a `u32` counter past 0 panics. Use signed integers or explicit break.
+
+```cairo
+// BAD — panics when i decrements below 0
+let mut i: u32 = n - 1;
+while i >= 0 {  // always true for unsigned, then underflow panic
+    process(i);
+    i -= 1;
+}
+
+// GOOD — signed counter
+let mut i: i32 = (n.try_into().unwrap()) - 1;
+while i >= 0 {
+    process(i.try_into().unwrap());
+    i -= 1;
+}
+```
+
+### Bit-Packing Overflow into felt252
+
+Packing multiple fields into one `felt252` is common for gas optimization, but the sum of field sizes must not exceed 251 bits.
+
+```cairo
+// GOOD — explicit width checks before packing
+fn pack_order(book_id: u256, tick_u24: u256, index_u40: u256) -> felt252 {
+    assert!(book_id < (1_u256 * POW_2_187), "BOOK_OVER");
+    assert!(tick_u24 < (1_u256 * POW_2_24), "TICK_OVER");
+    assert!(index_u40 < (1_u256 * POW_2_40), "INDEX_OVER");
+    let packed: u256 = (book_id * POW_2_64) + (tick_u24 * POW_2_40) + index_u40;
+    packed.try_into().expect("PACK_OVERFLOW")
+}
+```
+
+### `deploy_syscall(deploy_from_zero=true)` Collisions
+
+Deterministic deployment from zero can collide if two contracts deploy with the same calldata. Set `deploy_from_zero` to `false` unless you specifically need deterministic addresses.
+
+### Storage `Map.read()` Returns Zero for Non-Existent Keys (No Panic)
+
+*Source: [Code4rena Starknet Perpetual H-01](https://code4rena.com/reports/2025-03-starknet-perpetual)*
+
+Unlike languages that throw on missing keys, Cairo's `Map.read(key)` returns the type's default value (zero) when the key doesn't exist. This caused the H-01 finding in the Starknet Perpetual audit — an attacker used an arbitrary public key that mapped to empty storage, getting a zero value that bypassed oracle validation.
+
+```cairo
+// BAD — doesn't check if oracle exists, zero passes silently
+let oracle_data = self.oracles.entry(asset_id).entry(public_key).read();
+// oracle_data is 0 for non-existent keys — attacker signs over zeroed values
+
+// GOOD — explicitly check for existence
+let oracle_data = self.oracles.entry(asset_id).entry(public_key).read();
+assert(oracle_data.is_non_zero(), 'ORACLE_NOT_REGISTERED');
+```
+
+**Rule:** Always validate that storage reads return non-default values when absence should be an error. This applies to all `Map` reads, not just oracle lookups.
+
+### `get_caller_address().is_zero()` Is Useless
+
+On Starknet, `get_caller_address()` is never the zero address (unlike Solidity's `msg.sender` for contract creation). Zero-address checks on caller are dead code.
+
+### Unsafe `unwrap()` on User Input
+
+*Source: [chipi-pay Nethermind AuditAgent finding #9](https://github.com/chipi-pay/sessions-smart-contract) — DoS via unsafe unwrap*
+
+```cairo
+// BAD — panics if conversion fails, exploitable DoS
+let value: u64 = input.try_into().unwrap();
+
+// GOOD — safe conversion
+let value: u64 = match input.try_into() {
+    Option::Some(v) => v,
+    Option::None => { return 0; }  // safe failure, no panic
+};
+```
+
+---
+
+## 5. Signature Replay & Nonce Protection
+
+*Source: [Oxor.io — Cairo Security Flaws (Aug 2024)](https://oxor.io/blog/2024-08-16-cairo-security-flaws/)*
+
+Any signature-gated function without a nonce is replayable. An attacker can resubmit the same valid signature to execute the action multiple times.
+
+### The Problem
+
+```cairo
+// BAD — no nonce, signature is replayable forever
+fn claim_reward(
+    ref self: ContractState, amount: felt252, r: felt252, s: felt252
+) {
+    let caller = get_caller_address();
+    let msg = pedersen::pedersen(amount, caller.into());
+    verify_ecdsa_signature(msg, self.signer.read(), r, s);
+    // Transfer reward — attacker replays this with same (r, s) infinitely
+    self._transfer_reward(caller, amount);
+}
+```
+
+### The Fix — Always Include Nonce
+
+```cairo
+// GOOD — nonce prevents replay
+fn claim_reward(
+    ref self: ContractState, amount: felt252, r: felt252, s: felt252
+) {
+    let caller = get_caller_address();
+    let nonce = self.nonces.read(caller);
+    // Increment nonce BEFORE use (checks-effects-interactions)
+    self.nonces.write(caller, nonce + 1);
+    let msg = pedersen::pedersen(amount, caller.into());
+    let msg_with_nonce = pedersen::pedersen(msg, nonce);
+    verify_ecdsa_signature(msg_with_nonce, self.signer.read(), r, s);
+    self._transfer_reward(caller, amount);
+}
+```
+
+**Rule:** Every signature-verified operation must include (1) a nonce, (2) a chain_id, and (3) the contract address in the signed message to prevent cross-chain and cross-contract replay.
+
+### Production Approach: OZ NoncesComponent
+
+Don't roll your own nonce logic. Use OZ's `NoncesComponent`:
+
+```cairo
+use openzeppelin_utils::cryptography::nonces::NoncesComponent;
+
+component!(path: NoncesComponent, storage: nonces, event: NoncesEvent);
+
+#[abi(embed_v0)]
+impl NoncesImpl = NoncesComponent::NoncesImpl<ContractState>;
+impl NoncesInternalImpl = NoncesComponent::InternalImpl<ContractState>;
+
+fn claim_reward(ref self: ContractState, amount: u256, nonce: felt252, signature: Span<felt252>) {
+    let caller = get_caller_address();
+    // Validates nonce is the next expected value AND increments it atomically
+    self.nonces.use_checked_nonce(caller, nonce);
+    // ... verify signature over (amount, nonce, chain_id, contract_address) ...
+    self._transfer_reward(caller, amount);
+}
+```
+
+`use_checked_nonce(owner, nonce)` verifies the nonce matches the expected next value and increments it in one step. `use_nonce(owner)` consumes and returns the current nonce without checking.
+
+### SNIP-12: Typed Structured Data Signing
+
+*Source: [OZ SNIP-12 Guide](https://docs.openzeppelin.com/contracts-cairo/3.x/guides/snip12), [SNIP-12 Spec](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md)*
+
+SNIP-12 is Starknet's equivalent of EIP-712 — typed structured data signing that prevents signature reuse across contracts, chains, and message types. **Use SNIP-12 for all off-chain signature verification.**
+
+```cairo
+use openzeppelin_utils::cryptography::snip12;
+
+// 1. Define your message struct
+#[derive(Copy, Drop, Hash)]
+struct Transfer {
+    recipient: ContractAddress,
+    amount: u256,
+    nonce: felt252,
+    expiry: u128,  // SNIP-12 has no u64, use u128 in type hash
+}
+
+// 2. Compute type hash offline and hardcode it
+// starknet_keccak("Transfer(recipient:ContractAddress,amount:u256,nonce:felt,expiry:u128)")
+const TRANSFER_TYPE_HASH: felt252 = 0x...; // Compute offline, don't do on-chain
+
+// 3. Implement StructHash for your message type
+// 4. Use OZ's OffchainMessageHash to compute the full hash including domain separator
+```
+
+**Key SNIP-12 security rules:**
+- Domain separator MUST include `name`, `version`, `chain_id`, and `revision`
+- **Breaking change:** Older revisions used `StarkNetDomain` (capital N), current uses `StarknetDomain` — mixing them produces different hashes
+- Compute type hashes offline and hardcode them — on-chain computation is expensive and error-prone
+- Always include a nonce and expiry in the message struct
+
+---
+
+## 6. Private Data in Storage
+
+*Source: [FuzzingLabs — Top 4 Vulnerabilities (Nov 2024)](https://fuzzinglabs.com/top-4-vulnerability-cairo-starknet-smart-contract/)*
+
+No data stored on Starknet is private. Any value written to contract storage is readable by anyone via RPC calls (`starknet_getStorageAt`). This includes "private" fields, passwords, API keys, and secrets.
+
+```cairo
+// BAD — secret is readable by anyone via RPC
+#[storage]
+struct Storage {
+    secret: felt252,        // Anyone can read this
+    admin_password: felt252, // This too
+}
+
+// GOOD — store hash, not plaintext
+#[storage]
+struct Storage {
+    secret_hash: felt252,  // Store pedersen(secret) or poseidon(secret)
+}
+
+fn verify_secret(self: @ContractState, secret: felt252) -> bool {
+    let hash = pedersen::pedersen(secret, 0);
+    hash == self.secret_hash.read()
+}
+```
+
+**Rule:** If your contract needs to verify a secret, store its hash on-chain and verify the preimage. Never store plaintext secrets, encryption keys, or passwords in contract storage.
+
+---
+
+## 7. felt252 Arithmetic & Safe Integer Types
+
+*Source: [Oxor.io — Overflow and Underflow in Cairo](https://oxor.io/blog/2024-08-16-overflow-and-underflow-vulnerabilities-in-cairo/), [FuzzingLabs — Top 4 Vulnerabilities](https://fuzzinglabs.com/top-4-vulnerability-cairo-starknet-smart-contract/), [Crytic — Not So Smart Contracts](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/cairo)*
+
+The `felt252` type is a field element (0 to P-1, where P = 2^251 + 17*2^192 + 1). Arithmetic on `felt252` wraps modulo P silently — there is no overflow/underflow panic. This is the single most Cairo-specific footgun.
+
+### The Problem
+
+```cairo
+// BAD — felt252 arithmetic wraps silently
+fn vulnerable_subtract(balance: felt252, amount: felt252) -> felt252 {
+    balance - amount  // If amount > balance, result wraps to a huge number (no panic!)
+}
+
+fn vulnerable_overflow(input: felt252) -> felt252 {
+    let max_felt: felt252 = 0x800000000000000000000000000000000000000000000000000000000000000
+        + 17 * 0x1000000000000000000000000000000000000000000000000;
+    max_felt + input  // If input > 0, wraps to 0 (no panic!)
+}
+```
+
+### The Fix — Use Safe Integer Types
+
+Cairo's unsigned integer types (`u8`, `u16`, `u32`, `u64`, `u128`, `u256`) and signed types (`i8`, `i16`, `i32`, `i64`, `i128`) have built-in overflow/underflow protection. They panic on overflow, which is what you want.
+
+```cairo
+// GOOD — u256 panics on overflow/underflow
+fn safe_subtract(balance: u256, amount: u256) -> u256 {
+    assert(balance >= amount, 'INSUFFICIENT_BALANCE');
+    balance - amount  // Would panic on underflow even without assert
+}
+
+// NOTE: In Cairo 2.x, plain a + b on integer types ALREADY panics on overflow.
+// For non-panicking alternatives, use:
+use core::num::traits::SaturatingAdd;
+fn safe_add_saturating(a: u128, b: u128) -> u128 {
+    a.saturating_add(b)  // Returns u128::MAX on overflow instead of panicking
+}
+
+// Or use overflowing_add for explicit overflow detection:
+use core::integer::u128_overflowing_add;
+fn safe_add_overflowing(a: u128, b: u128) -> (u128, bool) {
+    match u128_overflowing_add(a, b) {
+        Result::Ok(sum) => (sum, false),
+        Result::Err(sum) => (sum, true),  // Overflow occurred
+    }
+}
+
+// Or use wrapping_add for modular arithmetic (no panic, wraps):
+use core::num::traits::WrappingAdd;
+fn wrapping_add(a: u128, b: u128) -> u128 {
+    a.wrapping_add(b)
+}
+```
+
+### CRITICAL: `felt252` Division Is Field Division, NOT Floor Division
+
+`felt252_div(a, b)` computes the **modular inverse**: it returns `n` such that `n * b ≡ a (mod P)`. This is NOT integer floor division. `felt252_div(10, 3)` does NOT return `3` — it returns a huge field element that, multiplied by 3 modulo P, equals 10.
+
+```cairo
+// BAD — gives completely wrong result for financial math
+let price_per_unit: felt252 = felt252_div(total_cost, quantity);
+// This is modular inverse, NOT 10/3 = 3
+
+// GOOD — use integer division
+let price_per_unit: u256 = total_cost / quantity;  // Floor division, panics on zero
+```
+
+**Rule:** NEVER use `felt252` for any division in financial calculations. Always use `u128`, `u256`, or `u64` which perform actual integer floor division. `felt252` division is only correct for cryptographic operations where you explicitly need modular arithmetic.
+
+### When felt252 Is Acceptable
+
+- **Hash computations** (pedersen, poseidon) — these are inherently modular arithmetic
+- **Selectors and class hashes** — these are field elements by design
+- **Storage keys** — addresses are felt252
+- **Cryptographic operations** — signature verification, curve arithmetic
+
+### When felt252 Is Dangerous
+
+- **Balances, amounts, prices, fees** — always use `u256` or `u128`
+- **Counters, indices, timestamps** — use `u64` or `u32`
+- **Any user-controlled arithmetic** — never use felt252
+- **Division** — `felt252_div` is modular inverse, not floor division
+- **Comparisons** (`<`, `>`, `>=`) — felt252 comparisons work but can produce unexpected results near the field boundary
+
+### Detecting felt252 Issues
+
+Write targeted fuzz tests for functions that use felt252 arithmetic:
+
+```cairo
+#[test]
+#[fuzzer(runs: 1000)]
+fn fuzz_no_felt_underflow(a: felt252, b: felt252) {
+    // If your function does a - b, test that the result is meaningful
+    // Use u256 instead to get automatic underflow protection
+    let safe_a: u256 = a.into();
+    let safe_b: u256 = b.into();
+    if safe_a >= safe_b {
+        let result = safe_a - safe_b;
+        assert(result <= safe_a, 'UNDERFLOW');
+    }
+}
+```
+
+> **Note:** FuzzingLabs' `sierra-analyzer` had a `felt_overflow` detector but the repo is no longer maintained. Until a replacement ships, fuzz testing is the primary detection method.
+
+---
+
+## 8. Storage Layout Security
+
+*Source: [Starknet Docs — Storage](https://docs.starknet.io/build/starknet-by-example/basic/storage), [Cairo Book — Security (ch104)](https://book.cairo-lang.org/ch104-00-starknet-smart-contracts-security.html)*
+
+Starknet storage is a flat key-value space of 2^251 slots, each holding one `felt252`. Understanding this model is critical for upgrade safety and collision avoidance.
+
+### Storage Address Derivation
+
+```
+// Simple variables: base = sn_keccak("variable_name")
+// Map entries: address = pedersen(sn_keccak("map_name"), key)
+// Nested maps: address = pedersen(pedersen(sn_keccak("map_name"), key1), key2)
+// Component storage: base = sn_keccak("component_name") (with substorage(v0))
+```
+
+### `LegacyMap` → `Map` Migration (Cairo 2.7+)
+
+Cairo 2.7.0 introduced `Map<K, V>` (from `core::starknet::storage::Map`) to replace `LegacyMap<K, V>`. The storage layout is identical, so migration is safe for upgradeable contracts. `LegacyMap` is deprecated but still compiles on current Cairo versions — it emits a deprecation warning, not an error. Projects on older Scarb versions that cannot upgrade immediately can defer this migration, but should plan for it: `LegacyMap` may be removed in a future Cairo edition.
+
+```cairo
+// DEPRECATED — LegacyMap (Cairo < 2.7)
+#[storage]
+struct Storage {
+    balances: LegacyMap<ContractAddress, u256>,
+}
+// Access: self.balances.read(addr), self.balances.write(addr, val)
+
+// CURRENT — Map (Cairo 2.7+)
+use core::starknet::storage::Map;
+#[storage]
+struct Storage {
+    balances: Map<ContractAddress, u256>,
+}
+// Access: self.balances.entry(addr).read(), self.balances.entry(addr).write(val)
+```
+
+### Storage Nodes and `Vec` (Cairo 2.7+)
+
+Cairo 2.7+ introduced `#[starknet::storage_node]` for composable nested storage and `Vec` for dynamic-length storage arrays:
+
+```cairo
+use core::starknet::storage::Vec;
+
+// Storage Node — structured nested storage
+#[starknet::storage_node]
+struct UserData {
+    balance: u256,
+    last_active: u64,
+}
+
+#[storage]
+struct Storage {
+    users: Map<ContractAddress, UserData>,   // Nested: users.entry(addr).balance.read()
+    pending_items: Vec<u256>,                 // Dynamic array in storage
+}
+```
+
+**Security note for Vec:** `Vec` has no built-in length cap. User-growable Vecs can be used for DoS via unbounded storage growth. Always cap Vec length in user-facing functions.
+
+### Storage Collision Between Components
+
+If two components use the same storage variable name, their base addresses will collide. OZ's `#[substorage(v0)]` pattern avoids this for components, but custom storage vars can still collide.
+
+```cairo
+// BAD — two components both define a storage var named "balance"
+// They will write to the same slot and corrupt each other's data
+
+// GOOD — use unique prefixed names or rely on OZ component patterns
+#[storage]
+struct Storage {
+    #[substorage(v0)]
+    erc20: ERC20Component::Storage,       // OZ handles namespacing
+    #[substorage(v0)]
+    ownable: OwnableComponent::Storage,   // No collision with erc20
+    my_custom_balance: u256,              // Explicit, unique name
+}
+```
+
+**Storage Node collision note:** Storage nodes hash member names with `selector!("name")`. Two unrelated storage nodes with the same member name in different contexts won't collide because the parent path differs. However, custom `Store` implementations that pack data into raw slots bypass this namespacing.
+
+### Upgrade Storage Layout Rules
+
+When upgrading a contract (replacing the class hash), storage persists but layout must be compatible:
+
+```
+SAFE:
+  - Add new storage variables (new base addresses)
+  - Append new fields to the end of packed structs
+  - Add new component substorages
+  - Migrate LegacyMap to Map (same layout)
+
+UNSAFE (will corrupt existing data):
+  - Remove or reorder existing storage variables
+  - Change the type of an existing variable (e.g., u128 -> u256)
+  - Rename a storage variable (changes base address)
+  - Change a component's substorage name
+  - Change Map key types
+```
+
+### Multi-Slot Values
+
+Types larger than 252 bits (e.g., `u256`) span consecutive slots. A `u256` uses slot `base + 0` for the low 128 bits and `base + 1` for the high 128 bits. Packing multiple small values into one `felt252` is a gas optimization but must respect the 251-bit limit (see Section 4, Bit-Packing).
+
+---
+
+## 9. Token Integration Pitfalls
+
+*Source: [Cairo Book ch104](https://book.cairo-lang.org/ch104-01-general-recommendations.html)*
+
+### Always Check Boolean Returns
+
+While OpenZeppelin's ERC20 reverts on failure, not all ERC-20 implementations do. Some return `false` without panicking.
+
+```cairo
+// BAD — ignores return value
+IERC20Dispatcher { contract_address: token }.transfer(to, amount);
+
+// GOOD — check the return
+let success = IERC20Dispatcher { contract_address: token }.transfer(to, amount);
+assert(success, 'Transfer failed');
+```
+
+### CamelCase / snake_case Dual Interfaces
+
+Most ERC20 tokens on Starknet use `snake_case`. Legacy tokens may have `camelCase` entrypoints (`transferFrom` vs `transfer_from`). If your contract interacts with arbitrary tokens, handle both or verify the tokens you'll integrate with.
+
+### ERC20Permit — Off-Chain Approval Attack Surface
+
+OZ Cairo 3.x added `ERC20Permit`, enabling token `approve` via off-chain SNIP-12 signatures. This is a new attack surface:
+
+- **Front-running:** Permit signatures can be front-run — someone sees the permit in the mempool and submits it first. The standard handles this gracefully (the approve succeeds if allowance matches), but protocols should not assume permit calls are exclusive.
+- **Expired permits:** Always check the deadline/expiry. A signed permit with a far-future expiry is a long-lived approval.
+- **Nonce correctness:** Permit uses the owner's nonce from `NoncesComponent`. A consumed nonce invalidates the permit.
+- **Integration rule:** When integrating with permit-enabled tokens, accept that `permit` + `transferFrom` may happen atomically in one call or separately. Don't rely on the approval being set in a previous transaction.
+
+---
+
+## 10. L1/L2 Bridging Safety
+
+*Source: [Crytic/building-secure-contracts](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/cairo)*
+
+### L1 Handler Must Validate Caller
+
+The `#[l1_handler]` attribute marks an entrypoint as callable from L1. Always validate that `from_address` is the trusted L1 contract.
+
+> **Type note:** `from_address` in `#[l1_handler]` is `felt252`, NOT `ContractAddress`. This is a common source of bugs — you cannot use `ContractAddress` comparison directly. Compare as `felt252` or convert explicitly.
+
+```cairo
+// BAD — anyone on L1 can call this
+#[l1_handler]
+fn handle_deposit(
+    ref self: ContractState,
+    from_address: felt252,
+    account: ContractAddress,
+    amount: u256
+) {
+    self.balances.write(account, self.balances.read(account) + amount);
+}
+
+// GOOD — validate L1 caller
+// NOTE: from_address is felt252, NOT ContractAddress.
+// Store your L1 bridge address as felt252 to match, or convert explicitly.
+#[l1_handler]
+fn handle_deposit(
+    ref self: ContractState,
+    from_address: felt252,  // felt252 — not ContractAddress!
+    account: ContractAddress,
+    amount: u256
+) {
+    let l1_bridge: felt252 = self.l1_bridge.read(); // stored as felt252
+    assert!(!l1_bridge.is_zero(), "UNINIT_BRIDGE");
+    assert!(from_address == l1_bridge, "ONLY_L1_BRIDGE");
+    self.balances.write(account, self.balances.read(account) + amount);
+}
+```
+
+### L1-to-L2 Message Failure
+
+L1->L2 messages can fail silently if the L2 handler reverts. The message stays in a "pending" state and can be retried, but the L1 side may have already updated its state. Design for idempotent handlers or include replay protection.
+
+### L1/L2 Address Conversion
+
+L1 (Ethereum) addresses are 20 bytes. Starknet addresses are felt252. Incorrect conversion or comparison between the two is a common bug. Always use explicit conversion functions and never compare raw values across domains.
+
+### Replay Protection
+
+Cross-chain messages need nonces or unique identifiers to prevent replay. If a message can be re-consumed, an attacker can double-credit.
+
+### Bridge Withdrawal Limits (StarkGate Pattern)
+
+*Source: [StarkGate 2.0 `token_bridge.cairo`](https://github.com/starknet-io/starkgate-contracts), [Starknet Docs — StarkGate](https://docs.starknet.io/learn/protocol/starkgate)*
+
+StarkGate implements a daily withdrawal limit of 5% TVL per token (`DEFAULT_DAILY_WITHDRAW_LIMIT_PCT = 5`). A `SECURITY_AGENT` role can freeze withdrawals; lifting the freeze requires a quorum of `SECURITY_ADMIN` signers. This pattern limits damage from exploits to a single day's quota.
+
+**Rule:** Any bridge or high-TVL vault should implement per-token daily withdrawal caps, a security freeze role (single key, fast response), and a multi-sig requirement to unfreeze. Do not let a single key both freeze and unfreeze.
+
+### Unprotected Escrow Funds (MakerDAO DAI Bridge)
+
+*Source: [ChainSecurity — MakerDAO StarkNet-DAI-Bridge Audit (2021)](https://chainsecurity.com/wp-content/uploads/2021/12/ChainSecurity_MakerDAO_StarkNet-DAI-Bridge_audit.pdf)*
+
+ChainSecurity found a Critical finding in the MakerDAO StarkNet-DAI-Bridge: escrow funds on L1 were unprotected, allowing unauthorized access. The audit covered both Solidity L1 contracts and the Cairo L2 `dai.cairo` contract. Additional findings included 1 High, 5 Medium, and 5 Low — all fixed.
+
+**Pattern:** L1/L2 bridges must protect escrowed funds on both sides. The L1 escrow is only as safe as the L2 handler validation, and vice versa.
+
+---
+
+## 11. Economic / DoS Patterns
+
+*Source: [Cairo Book ch104](https://book.cairo-lang.org/ch104-01-general-recommendations.html)*
+
+### Unbounded Loops
+
+User-controlled iterations can exceed the Starknet steps limit, bricking the contract permanently — no one can interact with it anymore.
+
+```cairo
+// BAD — unbounded loop, attacker grows the list to exceed step limit
+fn process_all(ref self: ContractState) {
+    let mut i = 0;
+    let count = self.pending_count.read();
+    while i < count {
+        self._process(i);
+        i += 1;
+    }
+}
+
+// GOOD — pagination pattern with bounded iterations
+fn process_batch(ref self: ContractState, start: u64, max: u64) -> u64 {
+    let mut i = start;
+    let end = core::cmp::min(self.pending_count.read(), start + max);
+    while i < end {
+        self._process(i);
+        i += 1;
+    }
+    end  // return next cursor
+}
+```
+
+### Bad Randomness
+
+Never use `block_timestamp`, `block_number`, or transaction hashes as randomness sources. They are known to validators/sequencers before execution. Use Pragma VRF or similar oracle-based randomness.
+
+### Pause Mechanism — Don't Pause Liquidations
+
+*Source: [Code4rena Starknet Perpetual L-05](https://code4rena.com/reports/2025-03-starknet-perpetual)*
+
+When implementing `PausableComponent`, do NOT apply `assert_not_paused()` to liquidation or risk-management functions. Blocking liquidations during an emergency pause compounds the crisis — insolvent positions can't be closed, leading to bad debt accumulation.
+
+```cairo
+// BAD — pause blocks liquidation
+fn liquidate(ref self: ContractState, position_id: u64) {
+    self.pausable.assert_not_paused(); // Blocks during emergency!
+    self._liquidate(position_id);
+}
+
+// GOOD — liquidation always available, other functions paused
+fn open_position(ref self: ContractState, ...) {
+    self.pausable.assert_not_paused(); // Paused during emergency
+    // ...
+}
+
+fn liquidate(ref self: ContractState, position_id: u64) {
+    // No pause check — must always be available
+    self._liquidate(position_id);
+}
+```
+
+---
+
+## 12. Account Abstraction Security
+
+*Source: [Starknet Docs — Account Abstraction](https://docs.starknet.io/build/starknet-by-example/advanced/account-abstraction)*
+
+Starknet's native account abstraction means every account is a smart contract with `__validate__` and `__execute__` entry points. This is a unique attack surface.
+
+### `__validate__` Constraints
+
+`__validate__` runs before `__execute__` and has strict constraints:
+- **Limited gas** — cannot perform expensive computation
+- **Cannot modify storage** (except the nonce)
+- **If `__validate__` fails, the sequencer loses gas** — no fee is charged to the account, but the sequencer still consumed resources for the validation attempt. This is a practical gotcha when testing custom accounts: failed validations cost the network real gas but produce no state changes or receipts.
+- Must return `VALID` (felt252 value of `'VALID'`) or the transaction is rejected
+
+### Sequencer DoS via `__validate__`
+
+A malicious account can implement `__validate__` to always succeed initially but fail on re-execution (after the sequencer has committed gas). This griefs sequencers. Mitigation is sequencer-side (reputation systems, deposit requirements), but be aware when deploying custom account contracts.
+
+### Custom Account Security Rules
+
+```cairo
+// Required entrypoints for an account contract
+#[abi(embed_v0)]
+fn __validate__(ref self: ContractState, calls: Array<Call>) -> felt252 {
+    // 1. Verify signature (MUST be fast and cheap)
+    // 2. Validate nonce (handled by protocol, but check custom logic)
+    // 3. Do NOT make external calls
+    // 4. Do NOT write to storage (except nonce)
+    starknet::VALIDATED  // Return 'VALID'
+}
+
+#[abi(embed_v0)]
+fn __execute__(ref self: ContractState, calls: Array<Call>) -> Array<Span<felt252>> {
+    // 1. Assert caller is the protocol (assert_only_protocol)
+    // 2. Verify correct tx version
+    // 3. Execute calls
+    // 4. Emit TransactionExecuted event
+    execute_multicall(calls.span())
+}
+```
+
+---
+
+## 13. Session Key Security
+
+*Source: [chipi-pay SNIP draft and Nethermind AuditAgent findings](https://github.com/chipi-pay/sessions-smart-contract) — 18 findings across 4 scans*
+
+For contracts implementing session key delegation (relevant to AI agents):
+
+### Admin Selector Blocklist
+
+Session keys MUST NOT be able to call privileged functions. Each of these was discovered in a separate Nethermind audit scan:
+
+```cairo
+const BLOCKED_SELECTORS: [felt252; 7] = [
+    selector!("upgrade"),                   // scan 1: contract replacement
+    selector!("add_or_update_session_key"), // scan 1: create unrestricted sessions
+    selector!("revoke_session_key"),        // scan 1: revoke other sessions
+    selector!("__execute__"),               // scan 2: nested execution privilege escalation
+    selector!("set_public_key"),            // scan 3: owner key rotation (OZ PublicKeyImpl)
+    selector!("setPublicKey"),              // scan 3: owner key rotation (OZ PublicKeyCamelImpl)
+    selector!("execute_from_outside_v2"),   // scan 3: nested SNIP-9 double-consumption
+];
+```
+
+**Key lesson:** The denylist approach is inherently fragile — each audit scan found new selectors. Prefer the self-call block (below) as the primary defense.
+
+### Self-Call Block (Primary Defense)
+
+Block ALL calls where `call.to == get_contract_address()` when the session has no explicit whitelist. This eliminates the entire class of privilege escalation via self-calls, protecting against any future OZ embedded impl exposing new privileged selectors.
+
+```cairo
+// In validation, when allowed_entrypoints_len == 0:
+for call in calls {
+    assert(call.to != get_contract_address(), 'SESSION_NO_SELF_CALL');
+}
+```
+
+> **OZ version note:** OZ 3.x `AccountComponent` has evolved its embedded impls and selectors compared to earlier versions. The exact set of privileged selectors exposed may differ between OZ v0.x, v2.x, and v3.x. The self-call block pattern above remains the primary defense regardless of OZ version, because it protects against the entire class of privilege escalation without enumerating specific selectors.
+
+### Spending Limits (Value Control)
+
+Selector whitelists control *which functions* a session can call, but not *how much value* each call moves. A session authorized to call `transfer` can transfer the entire balance.
+
+```cairo
+struct SpendingPolicy {
+    token_address: ContractAddress,
+    max_amount_per_call: u256,
+    max_amount_per_window: u256,    // rolling window cap
+    window_seconds: u64,             // e.g., 86400 = 24h
+    amount_spent_in_window: u256,
+    window_start: u64,
+}
+```
+
+**Why rolling window instead of total cap?** A total cap (`max = 100 USDC`) doesn't protect against burst attacks — the attacker drains it in one call. A rolling window (`max 10 USDC per 24h`) limits damage even if the key is compromised for days.
+
+### Call Consumption Ordering
+
+*Source: chipi-pay Nethermind scan 2, finding #3*
+
+Increment `calls_used` AFTER signature verification, not before. Otherwise a session with `max_calls = 1` fails on its first valid use because the counter was incremented before the limit check runs.
+
+### `is_valid_signature` Has No Call Context
+
+*Source: chipi-pay Nethermind scan 1, finding #5*
+
+`is_valid_signature(hash, signature)` receives only hash and signature — no calls. It cannot enforce selector whitelists. Enforce whitelists in `__validate__` and `execute_from_outside_v2` where calls are available. This is an inherent ERC-1271 limitation, not a bug.
+
+---
+
+## 14. SNIP-9 Outside Execution Security
+
+*Source: [SNIP-9 Spec](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md), [Starknet.js Outside Execution Guide](https://starknetjs.com/docs/guides/outsideExecution)*
+
+SNIP-9 enables meta-transactions: a third party submits transactions on behalf of an account using the account's signature. This is a major attack surface.
+
+### How It Works
+
+An `OutsideExecution` object contains:
+- `caller` — who is allowed to submit (or `'ANY_CALLER'` for anyone)
+- `execute_after` / `execute_before` — time window
+- `nonce` — dedicated outside-execution nonce (separate from tx nonce)
+- `calls` — the actual calls to execute
+
+The account signs this typed data (SNIP-12 format), and any permitted caller can submit it within the time window.
+
+### Security Rules
+
+```cairo
+// 1. ALWAYS validate and consume the outside-execution nonce
+// The nonce is separate from the normal transaction nonce.
+// If not consumed, the same signed payload can be replayed.
+assert(!self.outside_nonces.read(nonce), 'NONCE_ALREADY_USED');
+self.outside_nonces.write(nonce, true);
+
+// 2. Validate caller
+let outside_caller = outside_execution.caller;
+if outside_caller != 'ANY_CALLER'.try_into().unwrap() {
+    assert(get_caller_address() == outside_caller, 'INVALID_CALLER');
+}
+
+// 3. Validate time bounds
+let now = get_block_timestamp();
+assert(now > outside_execution.execute_after, 'TOO_EARLY');
+assert(now < outside_execution.execute_before, 'TOO_LATE');
+```
+
+### Common Vulnerabilities
+
+- **Missing nonce consumption** — allows unlimited replay of a signed outside execution within the time window
+- **Overly permissive `ANY_CALLER`** — anyone can submit the transaction, not just the intended relayer
+- **Wide time windows** — `execute_before` set too far in the future gives attackers more time to replay
+- **Nested reentrancy** — `execute_from_outside` calling `__execute__` calling `execute_from_outside` again. Block this with ReentrancyGuard or explicit nesting checks
+- **Missing SNIP-12 domain binding** — signatures must include `chain_id` and contract version to prevent cross-chain replay
+
+### Interaction with Session Keys
+
+When combining SNIP-9 with session keys (Section 13), the session key's `execute_from_outside_v2` selector should be in the blocklist to prevent a session key from creating nested outside executions that bypass call limits.
+
+---
+
+## 15. Starknet Protocol Security Considerations
+
+*Source: [Starknet Version Notes](https://docs.starknet.io/learn/cheatsheets/version-notes), [Starknet v0.14.0 "Grinta" Announcement](https://starknet.io/blog/starknet-grinta-the-architecture-of-a-more-decentralized-future)*
+
+### Starknet v0.14.0 "Grinta" (Sep 1, 2025) — Breaking Changes
+
+Grinta introduced multi-sequencer architecture (three independent sequencers with Tendermint consensus), a mempool, fee market, and subsecond pre-confirmations.
+
+**Breaking changes that affect deployed contracts:**
+
+- **v0, v1, v2 transactions are no longer supported.** Any contracts or tooling relying on legacy transaction types will fail. Accounts that lack `__validate__` must be called via the new `meta_tx_v0` syscall through v3 transactions. This is a hard break.
+- **Block time shortened from ~30s to ~6s.** All time-dependent logic (funding rate calculations, price staleness windows, oracle freshness checks, time-locked operations) must be recalibrated. A 10-block window went from ~5 minutes to ~1 minute.
+- **L2 gas fee market (EIP-1559 style).** L2 gas now has a dynamic base price. Contracts that estimate or hardcode gas costs will be wrong. Use current pricing from `get_execution_info`.
+- **Transactions with internal calls to `__execute__` are reverted.** If your contract makes calls to an entry point literally named `__execute__`, those transactions will revert under v0.14.0.
+
+**Security implications:**
+
+- **MEV risk** — with a mempool and multiple sequencers, transaction ordering is no longer deterministic. Contracts sensitive to execution ordering (DEXes, liquidations) must implement slippage protection and deadline checks
+- **Sequencer reorgs** — the Sep 2, 2025 incident showed reorgs are possible when sequencers diverge. Design for idempotent operations where possible
+- **L1 handler failures** — failed L1 handlers are now included as `REVERTED` in blocks (bounded execution resources). Contracts relying on L1 handlers must handle reverts gracefully
+
+### Sequencer-Prover Inconsistency (Zellic/Starknet OS Audit)
+
+*Source: [Starknet Community Forum — Remediating a potential sequencer-prover inconsistency](https://community.starknet.io/t/remediating-a-potential-sequencer-prover-inconsistency-in-the-cairo-vm/115313)*
+
+Zellic auditor @fcremo discovered an opcode with different validation logic between the RustVM (sequencer) and the Cairo AIR (prover). A transaction that passed sequencer validation could fail proof verification, or vice versa. StarkWare patched this as an immediate fix in v0.13.3. LambdaClass confirmed the impact on their VM implementation.
+
+**This is a novel vulnerability class unique to STARK-based systems.** Contracts themselves cannot cause or prevent it, but developers should know: the trust model assumes sequencer and prover agree on all execution semantics. If they diverge, valid-looking transactions can fail at proof time, or invalid ones could pass sequencing. This is why Cairo VM formal verification (see Sources) matters.
+
+### Starknet v0.14.1 (Dec 2025) — BLAKE Hash Migration
+
+v0.14.1 migrated from Poseidon to BLAKE hash functions for `compiled_class_hash` computation. If your contract or tooling computes or verifies class hashes, ensure you use the correct hash function for the target Starknet version.
+
+### V3 Transaction Resource Bounds
+
+Since v0.13.0, V3 transactions use separate `L1_GAS` and `L2_GAS` resource bounds instead of a single `max_fee`. Contracts that validate or limit fees (e.g., account contracts during escapes) must check both resource types. See the ConsenSys Argent finding in Section 16 for a real example of this bug.
+
+### Paymaster Security Considerations
+
+Starknet's fee abstraction (via AVNU paymaster, Cartridge paymaster, etc.) allows third parties to pay gas on behalf of users. Security considerations:
+
+- **Griefing:** A malicious account can pass `__validate__` but intentionally fail `__execute__`, wasting the paymaster's gas. Paymasters should implement reputation systems or require pre-deposits.
+- **Token-based paymasters** must lock the user's payment tokens (e.g., ERC20) BEFORE paying gas, or the user can drain the paymaster by failing after gas is consumed.
+- **Allowlists:** Production paymasters should maintain a whitelist of approved contracts/entrypoints to prevent abuse.
+- **Rate limiting:** Per-account or per-session rate limits prevent a single agent from exhausting the paymaster's gas budget.
+
+---
+
+## 16. Real Audit Findings Reference
+
+### zkLend Exploit — $10M Loss (February 12, 2025)
+
+*Source: [BlockSec Post-Mortem](https://blocksec.com/blog/zklend-exploit-post-mortem), [SolidityScan Analysis](https://blog.solidityscan.com/zklend-hack-analysis), [FuzzingLabs](https://fuzzinglabs.com/rediscovery-zklend-hack/)*
+
+- **Root cause:** Precision loss through truncation in `safe_decimal_math` division, combined with accumulator manipulation via flash loan donation mechanism in an empty market.
+- **Impact:** Attacker inflated collateral from 1 wei to 7,015 wstETH, then borrowed other assets. Stolen funds bridged to Ethereum and attempted laundering via Railgun.
+- **Recovery:** Railgun's compliance policies partially blocked the laundering attempt. The attacker later sent an on-chain message to zkLend and partial fund recovery negotiations followed. Not all funds were recovered.
+- **Key lesson:** Empty market initialization + flash loan donation + floor division = catastrophic precision exploit. Detectable with fuzz tests targeting deposit/withdraw invariants.
+- **Mitigation:** Minimum liquidity lock on first deposit, accumulator change caps, round-up on burns. (See Section 3 above.)
+
+### CVE-2024-45304 — OpenZeppelin Cairo Ownership Bug
+
+OZ Cairo Contracts before v0.16.0: `renounce_ownership` could be used to transfer ownership unintentionally. Fixed in v0.16.0.
+
+### ConsenSys Diligence — Argent Account Starknet V3 (Jan 2024)
+
+*Source: [ConsenSys Diligence Report](https://diligence.consensys.io/audits/2024/01/argent-account-argent-multisig-starknet-transaction-v3-updates/)*
+
+- **Major — Lack of Fee Limits for V3 Transactions:** V3 transactions introduced separate L1_GAS and L2_GAS resource bounds, but only the `tip` was capped for escape transactions. A malicious Guardian could set excessive `max_price_per_unit` on L1_GAS or L2_GAS to drain the account. Fixed by introducing `MAX_ESCAPE_MAX_FEE_STRK = 50 STRK` and `MAX_ESCAPE_TIP_STRK = 1 STRK`.
+- **Minor — `__validate_deploy__` reused `assert_correct_invoke_version`:** Deploy transactions should have their own version check for better maintainability and correctness.
+- **Minor — `OUTSIDE_EXECUTION_TYPE_HASH` comment mismatch:** Hardcoded hash constant was correct but comments described the wrong preimage string.
+- **Minor — Self-written `get_execution_info`:** Duplicate implementations of stdlib functions. Use `starknet::info` module directly.
+
+**Pattern:** When Starknet introduces new transaction versions, all fee-limiting logic must be reviewed. Fee caps that work for V1 may not cover V3 resource bounds.
+
+### Code4rena Starknet Perpetual (Mar–Apr 2025) — 2 High, 3 Medium, 14 Low
+
+*Source: [Code4rena Report](https://code4rena.com/reports/2025-03-starknet-perpetual), 39 Cairo contracts, 3,846 lines*
+
+- **H-01 — Malicious signed price injection:** `_validate_oracle_signature` reads `asset_oracle` storage for a public key but doesn't panic on non-existent key (returns zero). Attacker generates signature over zeroed-out packed values and injects arbitrary price. Fix: panic if `packed_asset_oracle` is zero.
+- **H-02 — `_execute_transfer` wrong order of operations:** State diff applied before health check, so the check re-applies the diff and rejects valid transfers. Classic checks-effects-interactions violation.
+- **M-01 — Deleveragable positions can't be fully liquidated:** When a position is fully liquidated (`TR == 0`), the `assert_healthy_or_healthier` check panics on `total_risk.is_zero()`, blocking liquidation of insolvent positions.
+- **M-02 — Liquidatable positions forced into opposite:** Long positions can be forced into short during liquidation and vice versa.
+- **M-03 — Stale prices in `funding_tick()`:** Inactive price data used for funding calculations.
+- **L-03 — Owner account overwrite:** Missing validation allows owner to be overwritten without proper authorization flow.
+- **L-04 — Missing curve validation for public keys:** Public keys in `new_position` not validated against the Stark curve. Always verify that public keys lie on the STARK curve; an invalid key creates permanently unusable state.
+- **L-05 — Liquidation blocked by pause:** Applying `assert_not_paused()` to liquidation blocked risk management during emergencies. Liquidation must always be available. (See Section 11, "Pause Mechanism — Don't Pause Liquidations.")
+- **L-06 — Global validation DoS:** `validate_assets_integrity()` checks ALL active assets, blocking operations on unrelated assets when one has stale data. (See Section 18, "DeFi Protocol Security Patterns.")
+- **L-07 — Stale prices for inactive assets:** Inactive assets can't have prices updated but their last price is still used for settlement with no freshness check.
+- **L-08 — Collateral-only users blocked:** Users with zero synthetic exposure blocked from withdrawing collateral because global validation ran unconditionally.
+
+**Pattern:** Storage reads that return default values (zero) on missing keys are a Cairo-specific footgun. Always explicitly check that a storage read returned a non-default value.
+
+### Code4rena Opus (Jan 2024) — 4 High, 9 Medium
+
+*Source: [Code4rena Opus Report](https://code4rena.com/reports/2024-01-opus), 15 Cairo contracts, 4,056 lines*
+
+The first major Cairo DeFi competitive audit on Code4rena. Key findings:
+
+- **H-02 — Wad precision truncation for low-decimal tokens:** `convert_to_yang_helper()` lost precision for tokens with < 18 decimals due to intermediate Wad multiplication truncating to zero. A BTC deposit worth $36 resulted in 0 shares. (See Section 3, "Wad Precision Truncation.")
+- **H-03 — Redistribution array index mismatch:** `redistribute_helper` maintained two arrays (`updated_trove_yang_balances` and `new_yang_totals`) but a `continue` statement caused them to go out of sync. Attacker could keep collateral while having debt redistributed away — debt zeroed, yangs kept.
+- **H-04 — Recovery mode manipulation within single transaction:** Attacker opens a large enough position to push the system into recovery mode, which lowers liquidation thresholds, then liquidates healthy troves — all in one tx. Flash-loan amplifiable.
+- **M-03 — ERC-4626 inflate mitigation insufficient:** The first-depositor share inflation attack was not fully mitigated, reinforcing the need for minimum liquidity locks.
+
+**Pattern:** DeFi protocols using custom fixed-point types (Wad, Ray) must test with tokens of varying decimals. Array synchronization bugs in loop-with-continue are a Cairo-specific code smell. Recovery mode / global state changes must not be triggerable and exploitable within a single transaction.
+
+### ChainSecurity — Starknet Perpetual (2025)
+
+*Source: [ChainSecurity Report](https://www.chainsecurity.com/security-audit/starkware-starknet-perpetual)*
+
+Independent audit alongside Code4rena. Key findings:
+
+- **Rounding Is Not Always in Favor of the System:** Arithmetic rounding in settlement/funding calculations sometimes favored the user instead of the protocol, allowing slow value extraction over many transactions.
+- **Insurance Fund Cannot Always Be the Deleverager:** Edge cases where the insurance fund could not fulfill its role as deleverager for insolvent positions.
+- **Loosely Restricted Liquidations:** Operator had more latitude than documented to execute liquidations.
+
+**Pattern:** Always round in favor of the protocol/pool/system, never the user. Verify this direction for every division in financial math. Insurance fund/backstop logic must handle edge cases (zero balance, concurrent liquidations).
+
+### chipi-pay Session Contract — 18 Findings, 4 Nethermind Scans
+
+*Source: [chipi-pay/sessions-smart-contract](https://github.com/chipi-pay/sessions-smart-contract)*
+
+- Scan 1: 10 findings (3 High — unrestricted `__execute__` caller, whitelist bypass in `is_valid_signature`, call-limit bypass via `calls_used` reset)
+- Scan 2: 3 findings (1 High — nested `__execute__` privilege escalation)
+- Scan 3: 5 findings (2 High — `set_public_key`/`setPublicKey` not in blocklist)
+- Scan 4: 0 findings — clean report after self-call block + expanded blocklist
+
+**Pattern:** Every scan found new privileged selectors exposed by OZ embedded implementations. The self-call block (scan 4) eliminated the entire vulnerability class.
+
+### Nethermind Public Cairo/Starknet Audit Catalogue
+
+*Source: [NethermindEth/PublicAuditReports](https://github.com/NethermindEth/PublicAuditReports)*
+
+Nethermind has published 25+ Cairo/Starknet-specific audit reports covering core ecosystem protocols:
+
+| Report | Protocol | Focus |
+|--------|----------|-------|
+| NM0050, NM0064 | StarkGate | L1/L2 token bridge |
+| NM0052 | Argent Account | Starknet smart wallet |
+| NM0054 | Aave L2 | Lending protocol on Starknet |
+| NM0056, NM0120 | ZKX | Perpetual DEX |
+| NM0058, NM0097, NM0161, NM0392, NM0462 | zkLend | Lending, zkToken, liquid staking, recovery |
+| NM0060 | MySwap / Braavos | AMM / wallet |
+| NM0061 | Cartridge | Gaming account |
+| NM0135 | Starknet ID | Identity / naming |
+| NM0141, NM0578 | AVNU | DEX aggregator, forwarder |
+| NM0147 | Pragma | Oracle network |
+| NM0153 | Carmine | Options protocol |
+| NM0159 | Dojo | Gaming engine |
+| NM0180 | JediSwap | AMM |
+| NM0194 | Starknet Token Distributor | STRK distribution |
+| NM0237 | LayerAkira | Order book DEX |
+| NM0259 | Starknet Nova | Core protocol |
+| NM0337 | StakeStark | STRK staking |
+| NM0544A, NM0544B | Piltover, Token Bridge | Core Starknet bridge |
+
+**Use these as reference when building similar protocol types.** Each report PDF is available at the Nethermind repo.
+
+### Code4rena LayerZero Starknet Endpoint (Oct–Nov 2025) — 0 High, 0 Medium, 6 Low
+
+*Source: [Code4rena Report](https://code4rena.com/reports/2025-10-layerzero-starknet-endpoint), 46 Cairo files*
+
+Cross-chain messaging endpoint in Cairo. No H/M findings, but Low findings contain useful patterns:
+
+- **L-02 — Allowance-sweeping refund DoS:** `_refund_native()` tried to refund `allowance - fee` instead of `min(allowance - fee, balance)`. Users with standard large ERC20 approvals couldn't send messages. **Pattern:** When refunding excess tokens via `transferFrom`, cap the refund to `min(excess, sender_balance)`. Never assume `balance >= allowance`.
+- **L-03 — Nilified messages re-committable:** `commit()` could overwrite `NIL_PAYLOAD_HASH` because `_has_payload_hash()` only checked `!= EMPTY_PAYLOAD_HASH`. **Pattern:** State invalidation (nilification/burning/blacklisting) must be checked explicitly before any state overwrite. Don't rely on "not empty" as a proxy for "valid."
+
+### Cairo Security Clan — 30+ Cairo Audit Reports
+
+*Source: [Cairo-Security-Clan/Audit-Portfolio](https://github.com/Cairo-Security-Clan/Audit-Portfolio)*
+
+Starknet-native audit firm with 30+ public Cairo audit PDFs covering major ecosystem protocols:
+
+| Protocol | Report |
+|----------|--------|
+| Ekubo | `Ekubo_Audit_Report.pdf` |
+| Vesu | 7 reports (Core, Extensions, Liquidate, Multiply, Periphery, Updates) |
+| Opus | `Opus_Audit_Report.pdf` |
+| Paradex | `Paradex_Audit_Report.pdf` |
+| Hyperlane | `Hyperlane_Audit_Report.pdf` + update |
+| Clober | `Clober_Audit_Report.pdf` |
+| Layer Akira | `Layer_Akira_Audit_Report.pdf` |
+| Nimbora | `Nimbora Audit Report.pdf` |
+| Nostra Pools | `Nostra Pools Security Review by 0xerim.pdf` |
+| AVNU DCA | `Avnu_DCA_Audit_Report.pdf` |
+| Argent Gifting | `Argent_Gifting_Audit_Report.pdf` |
+| Starknet ID | `Starknet_ID_Audit_Report.pdf` |
+
+**Use these as reference when building similar protocol types.** All PDFs are in the GitHub repo.
+
+### ChainSecurity — Vesu Protocol (2024)
+
+*Source: [ChainSecurity Report](https://www.chainsecurity.com/security-audit/vesu-protocol-smart-contracts)*
+
+Permissionless DeFi lending protocol audit. All issues were fixed, but ChainSecurity noted **elevated residual risk** due to project complexity and limited internal QA (single developer). Key covered areas: pool isolation, asset solvency, oracle security, access control.
+
+**Pattern:** For complex DeFi protocols, a single audit is not sufficient. ChainSecurity explicitly flagged that novel issues and regressions appeared during the last review cycle despite earlier fixes. Budget for multiple audit cycles and invest in internal security-focused QA (thorough unit/regression testing).
+
+---
+
+## 17. OpenZeppelin Cairo Security Components
+
+*Source: [OZ Cairo 3.0 Security Docs](https://docs.openzeppelin.com/contracts-cairo/3.0.0-alpha.1/security)*
+
+OZ Cairo provides core security components. Use them instead of rolling your own.
+
+> **OZ v3.0.0 Import Path Migration (breaking):** In v3.0.0, `execute_single_call`, `execute_calls`, and `assert_valid_signature` moved from `openzeppelin_account::utils` to `openzeppelin_utils::execution`. If you're upgrading from v2.x, update these imports or compilation will fail. The `openzeppelin_interfaces` package versioning is now decoupled from the main umbrella package.
+
+**Exact import paths (OZ Cairo 3.0.0):**
+```cairo
+use openzeppelin_security::InitializableComponent;
+use openzeppelin_security::PausableComponent;
+use openzeppelin_security::ReentrancyGuardComponent;
+use openzeppelin_access::ownable::OwnableComponent;
+use openzeppelin_access::accesscontrol::AccessControlComponent;
+use openzeppelin_access::accesscontrol::default_admin_rules::AccessControlDefaultAdminRulesComponent;
+use openzeppelin_upgrades::UpgradeableComponent;
+use openzeppelin_utils::execution::{execute_single_call, execute_calls, assert_valid_signature};
+```
+
+### Initializable — One-Shot Constructor
+
+For contracts where initialization must happen post-deploy (upgradeable patterns):
+
+```cairo
+use openzeppelin_security::InitializableComponent;
+
+component!(path: InitializableComponent, storage: initializable, event: InitializableEvent);
+impl InternalImpl = InitializableComponent::InternalImpl<ContractState>;
+
+fn initializer(ref self: ContractState, owner: ContractAddress) {
+    self.initializable.initialize(); // Panics on second call
+    self.ownable.initializer(owner);
+}
+```
+
+**Rule:** Only use `initialize()` in ONE function. If multiple init steps are needed, put them all in one initializer.
+
+### Pausable — Emergency Stop
+
+```cairo
+use openzeppelin_security::PausableComponent;
+use openzeppelin_access::ownable::OwnableComponent;
+
+// Embed both components
+#[abi(embed_v0)]
+impl PausableImpl = PausableComponent::PausableImpl<ContractState>;
+impl PausableInternalImpl = PausableComponent::InternalImpl<ContractState>;
+
+#[external(v0)]
+fn pause(ref self: ContractState) {
+    self.ownable.assert_only_owner();
+    self.pausable.pause();   // Emits Paused(account)
+}
+
+#[external(v0)]
+fn unpause(ref self: ContractState) {
+    self.ownable.assert_only_owner();
+    self.pausable.unpause(); // Emits Unpaused(account)
+}
+
+// In protected functions:
+fn transfer(ref self: ContractState, to: ContractAddress, amount: u256) {
+    self.pausable.assert_not_paused(); // Blocks when paused
+    // ... transfer logic
+}
+```
+
+### ReentrancyGuard — Cross-Function Protection
+
+Unlike Solidity modifiers, Cairo uses explicit `start()`/`end()` calls:
+
+```cairo
+use openzeppelin_security::ReentrancyGuardComponent;
+
+component!(path: ReentrancyGuardComponent, storage: reentrancy_guard, event: ReentrancyGuardEvent);
+impl InternalImpl = ReentrancyGuardComponent::InternalImpl<ContractState>;
+
+#[external(v0)]
+fn withdraw(ref self: ContractState, amount: u256) {
+    self.reentrancy_guard.start();  // Panics if already entered
+
+    let caller = get_caller_address();
+    let balance = self.balances.read(caller);
+    assert(balance >= amount, 'Insufficient');
+    self.balances.write(caller, balance - amount);
+    IERC20Dispatcher { contract_address: self.token.read() }.transfer(caller, amount);
+
+    self.reentrancy_guard.end();    // Reset guard
+}
+```
+
+**Rule:** `start()` must be the first statement, `end()` must be before `return`. The guard protects across ALL functions that use it — if `withdraw` is entered, `swap` (also guarded) cannot be called by the same tx.
+
+### Pausable — Critical Note on Liquidations
+
+Do NOT apply `assert_not_paused()` to liquidation or risk-management functions (see Section 11 "Pause Mechanism — Don't Pause Liquidations"). Emergency pause must still allow insolvent positions to be closed.
+
+### OZ Governance Components
+
+OZ Cairo 3.x includes a full governance suite. Key security patterns:
+
+- **`GovernorComponent`** — on-chain voting with timelock executor. The executor address must be carefully controlled (set to the Timelock, not an EOA).
+- **`TimelockControllerComponent`** — enforces delay between proposal and execution. PROPOSER / CANCELLER / EXECUTOR roles must be granted carefully. Set a meaningful minimum delay (gives users time to exit before governance changes take effect).
+- **`MultisigComponent`** — multi-signature operations. Quorum must be set carefully (too low = insecure, too high = governance deadlock). OZ fixed a quorum-related bug in v0.18.0.
+- **`VotesComponent`** — ERC20/ERC721 token voting with delegation and checkpoints.
+
+**Governance security rules:**
+1. `DEFAULT_ADMIN_ROLE` should be **renounced** after initial role setup (otherwise the admin can bypass governance).
+2. Timelock minimum delay should be non-trivial (24-48h minimum) to give users time to react.
+3. Governor executor must be the Timelock contract, NOT an arbitrary address.
+4. For upgradeable contracts, the upgrade function should be behind the Timelock, not a single owner.
+5. `GovernorComponent` proposal state at snapshot timepoint changed from Active to **Pending** in v3.0.0 — verify your governance UIs match this.
+6. `VotesComponent` now supports customizable clock mechanisms via `ERC6372Clock` — ensure your voting token implements the correct clock source.
+
+### AccessControlDefaultAdminRulesComponent (OZ v3.0.0)
+
+*Source: [OZ v3.0.0 Release](https://github.com/OpenZeppelin/cairo-contracts/releases/tag/v3.0.0)*
+
+New in v3.0.0. Enforces a **transfer delay** on `DEFAULT_ADMIN_ROLE`, preventing instant admin transfers that could be exploited in governance attacks. This is the recommended way to handle admin roles in production.
+
+```cairo
+use openzeppelin_access::accesscontrol::default_admin_rules::AccessControlDefaultAdminRulesComponent;
+
+// Key features:
+// - Admin transfer requires a two-step process with a configurable delay
+// - MAXIMUM_DEFAULT_ADMIN_TRANSFER_DELAY exposed in ImmutableConfig
+// - Prevents social engineering attacks where admin is transferred in a single tx
+```
+
+**Rule:** For any contract with `AccessControlComponent`, prefer `AccessControlDefaultAdminRulesComponent` for the admin role to enforce transfer delays.
+
+### MetaTransactionV0 Preset (OZ v3.0.0)
+
+New in v3.0.0. Provides a meta-transaction preset with built-in replay protection. Relevant for relayer architectures and paymaster integrations. Uses SNIP-12 for signature validation. If you're building a meta-transaction relay, use this instead of rolling your own.
+
+---
+
+## 18. DeFi Protocol Security Patterns
+
+*Source: [Code4rena Starknet Perpetual (2025)](https://code4rena.com/reports/2025-03-starknet-perpetual)*
+
+These patterns are specific to DeFi protocols (DEXes, lending, perpetuals, vaults) and emerge from the largest Cairo-specific competitive audit to date.
+
+### Global Validation DoS (C4 L-06, L-08)
+
+**Pattern:** A global validation function that checks ALL state (all asset prices, all funding rates) blocks operations that only involve a subset of state. If one unrelated asset has stale data, ALL operations fail — including unrelated withdrawals.
+
+```cairo
+// BAD — global validation blocks unrelated operations
+fn reduce_position(ref self: ContractState, asset_id: felt252) {
+    self._validate_all_assets_integrity(); // Checks ALL assets, fails if ANY is stale
+    // User can't reduce their position because an unrelated asset has stale data
+}
+
+// GOOD — scope validation to affected assets only
+fn reduce_position(ref self: ContractState, asset_id: felt252) {
+    self._validate_asset_integrity(asset_id); // Only checks the relevant asset
+    // User can proceed even if unrelated assets are stale
+}
+```
+
+**Also from L-08:** Users with zero synthetic exposure were blocked from withdrawing collateral because validation ran unconditionally. **Rule:** Scope validation to the user's actual exposure — don't gate collateral-only operations on synthetic asset health.
+
+### Stale Prices for Inactive Assets (C4 L-07)
+
+When deactivating assets, ensure settlement/wind-down functions either: (a) allow governance to update inactive prices, or (b) validate price freshness explicitly. In the C4 finding, inactive assets couldn't have prices updated (the setter rejected them), but their last price was still used for settlement calculations with no freshness check.
+
+### Liquidation Must Not Flip Position Direction (C4 M-02)
+
+A liquidator can purchase more synthetic than the liquidated user holds, forcing them from long to short (or vice versa) without consent. **Rule:** Cap liquidation amounts at the existing synthetic balance. Use the same `_validate_imposed_reduction_trade()` pattern as deleverage to prevent direction flips.
+
+### Per-Asset Parameterization (C4 L-01, L-02)
+
+Using a single global `max_price_interval` or `max_funding_rate` for all synthetic assets is a design anti-pattern. Different asset classes have different volatility profiles. BTC and a long-tail memecoin should not share the same staleness threshold.
+
+**Rule:** All risk parameters (price staleness windows, funding rate caps, collateral factors, liquidation thresholds) must be configurable per asset.
+
+---
+
+## 19. Security Tooling
+
+*Source: [Caracal](https://github.com/crytic/caracal), [FuzzingLabs](https://github.com/FuzzingLabs), [Cairo Book ch104-03](https://book.cairo-lang.org/ch104-03-static-analysis-tools.html)*
+
+### Primary Tool: snforge Fuzz Testing (Starknet Foundry)
+
+**This is the only actively maintained, Cairo-2.12+-compatible security testing tool.** Use `snforge test` with fuzz testing as your primary automated security tool.
+
+```bash
+# Run all tests with fuzzing (default 256 runs)
+snforge test
+
+# Increase fuzz iterations for security-sensitive functions
+snforge test --fuzzer-runs 1000
+
+# Run specific test
+snforge test test_deposit_withdraw_invariant
+```
+
+Write property-based fuzz tests for all arithmetic and state-transition logic:
+
+```cairo
+#[test]
+#[fuzzer(runs: 500, seed: 42)]
+fn fuzz_transfer_preserves_total_supply(amount: u128) {
+    // Setup
+    let initial_supply = token.total_supply();
+    // Act
+    token.transfer(recipient, amount.into());
+    // Assert: total supply never changes
+    assert(token.total_supply() == initial_supply, 'SUPPLY_CHANGED');
+}
+```
+
+### Caracal — Static Analyzer (Trail of Bits / Crytic)
+
+> **WARNING: Caracal v0.2.3 (released Jan 2024) only supports Cairo up to 2.5.0 and is effectively unusable for any project on Cairo 2.7+, which includes essentially every Starknet project since mid-2024.** Check the [releases page](https://github.com/crytic/caracal/releases) for updates. Until a new release ships, use `snforge` fuzz testing as your primary automated security tool.
+
+If you are on Cairo ≤ 2.5.0 (legacy projects):
+
+```bash
+cargo install caracal
+cd my_project && caracal .
+caracal . --detectors reentrancy,unchecked_return
+```
+
+### FuzzingLabs Tools (Archived / No Longer Maintained)
+
+> **WARNING:** All three FuzzingLabs tools — `cairo-fuzzer`, `sierra-analyzer`, and `Thoth` — are explicitly marked **"This repository is no longer maintained"** by FuzzingLabs. Additionally, `cairo-fuzzer` does not support Cairo 2.0+ contracts. **Do not rely on any of these for current projects.**
+
+These tools made important contributions to the Cairo security ecosystem and their research remains valuable for understanding vulnerability classes, but they should not be part of your active toolchain:
+
+- **sierra-analyzer** — Sierra decompiler with felt252 overflow detectors. [Archived](https://github.com/FuzzingLabs/sierra-analyzer)
+- **cairo-fuzzer** — Smart contract fuzzer (Cairo 0.x only). [Archived](https://github.com/FuzzingLabs/cairo-fuzzer)
+- **Thoth** — Bytecode disassembler, decompiler, symbolic execution. [Archived](https://github.com/FuzzingLabs/thoth)
+
+### Recommended CI Pipeline
+
+```yaml
+# In .github/workflows/security.yml
+- name: Build
+  run: scarb build
+- name: Test (with fuzzing)
+  run: snforge test --fuzzer-runs 500
+# Note: no static analyzer is currently compatible with Cairo 2.12+
+# Monitor Caracal releases for updates
+```
+
+---
+
+## 20. Upgrade Safety
+
+### Before Upgrading
+
+1. New class hash should be declared and verified on explorer
+2. Test upgrade on Sepolia first
+3. Verify storage layout compatibility
+4. Have a rollback plan (old class hash declared, ready to re-upgrade)
+
+### Storage Layout Rules
+
+- Never remove or reorder existing storage fields
+- Only append new fields at the end
+- Component substorage names must stay the same
+- Map key types must not change
+
+---
+
+## 21. Audit Preparation
+
+### What Auditors Look For
+
+1. **Access control completeness** — every external `ref self` function has authorization
+2. **Input validation** — all user inputs checked before use
+3. **State consistency** — no paths where state becomes inconsistent
+4. **Economic invariants** — total supply == sum of balances, etc.
+5. **Upgrade governance** — who can upgrade, timelocks
+6. **Event completeness** — all state changes emit events
+7. **Error messages** — all asserts have descriptive messages
+8. **L1/L2 message safety** — from_address validated, replay protected
+9. **Unbounded iteration** — no user-growable loops
+10. **Boolean return checks** — ERC20 transfer/approve returns checked
+
+### Documentation for Auditors
+
+Provide:
+- Architecture diagram (contracts + interactions)
+- Invariants the system should maintain
+- Known trust assumptions
+- Admin capabilities and their risks
+- Expected call flows for each user type
+- L1/L2 message flow diagrams (if applicable)
+
+---
+
+## 22. Production Operations
+
+### Monitoring
+
+- Watch for unexpected `upgrade` calls
+- Monitor admin role grants/revocations
+- Track session key creation and revocation patterns
+- Alert on large transfers or unusual call patterns
+- Monitor L1/L2 message consumption (stuck messages)
+
+### Incident Response
+
+1. **Kill switch** — ability to pause the contract
+2. **Session revocation** — revoke all active sessions immediately
+3. **Upgrade path** — deploy fix, declare, upgrade
+4. **Communication** — notify users via events and off-chain channels
+
+---
+
+## Sources
+
+### Official Documentation
+- [Cairo Book — General Recommendations (ch104)](https://book.cairo-lang.org/ch104-01-general-recommendations.html)
+- [Cairo Book — Static Analysis Tools (ch104-03)](https://book.cairo-lang.org/ch104-03-static-analysis-tools.html)
+- [OpenZeppelin Cairo Security Docs (3.0)](https://docs.openzeppelin.com/contracts-cairo/3.0.0-alpha.1/security)
+- [OpenZeppelin Cairo Contracts Advisories](https://advisories.gitlab.com/pkg/pypi/openzeppelin-cairo-contracts)
+
+### Audit Reports
+- [Code4rena — Starknet Perpetual (2025), 2H/3M/14L](https://code4rena.com/reports/2025-03-starknet-perpetual)
+- [Code4rena — Opus (Jan 2024), 4H/9M — first major Cairo DeFi audit](https://code4rena.com/reports/2024-01-opus)
+- [ChainSecurity — Starknet Perpetual (2025)](https://www.chainsecurity.com/security-audit/starkware-starknet-perpetual)
+- [ChainSecurity — MakerDAO StarkNet-DAI-Bridge (2021), 1 Critical](https://chainsecurity.com/wp-content/uploads/2021/12/ChainSecurity_MakerDAO_StarkNet-DAI-Bridge_audit.pdf)
+- [ConsenSys Diligence — Argent Account V3 (Jan 2024)](https://diligence.consensys.io/audits/2024/01/argent-account-argent-multisig-starknet-transaction-v3-updates/)
+- [Nethermind — 25+ Cairo/Starknet Audit Reports](https://github.com/NethermindEth/PublicAuditReports)
+- [chipi-pay — Session Key Contract + SNIP Draft + 4 Nethermind AuditAgent scans](https://github.com/chipi-pay/sessions-smart-contract)
+- [Code4rena — LayerZero Starknet Endpoint (Oct 2025), 0H/0M/6L](https://code4rena.com/reports/2025-10-layerzero-starknet-endpoint)
+- [Cairo Security Clan — 30+ Cairo Audit Reports (Ekubo, Vesu, Opus, Paradex, etc.)](https://github.com/Cairo-Security-Clan/Audit-Portfolio)
+- [ChainSecurity — Vesu Protocol Smart Contracts](https://www.chainsecurity.com/security-audit/vesu-protocol-smart-contracts)
+
+### Exploit Post-Mortems
+- [BlockSec — zkLend $10M Exploit Post-Mortem (Feb 2025)](https://blocksec.com/blog/zklend-exploit-post-mortem)
+- [SolidityScan — zkLend Hack Analysis](https://blog.solidityscan.com/zklend-hack-analysis)
+- [FuzzingLabs — Rediscovery of the zkLend Hack](https://fuzzinglabs.com/rediscovery-zklend-hack/)
+
+### Vulnerability Research
+- [Crytic — Not So Smart Contracts (Cairo)](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/cairo)
+- [0xEniotna — Starknet Contract Vulnerabilities](https://github.com/0xEniotna/Starknet-contracts-vulnerabilities)
+- [Oxor.io — Cairo Security Flaws (Aug 2024)](https://oxor.io/blog/2024-08-16-cairo-security-flaws/)
+- [Oxor.io — Overflow and Underflow Vulnerabilities in Cairo](https://oxor.io/blog/2024-08-16-overflow-and-underflow-vulnerabilities-in-cairo/)
+- [FuzzingLabs — Top 4 Vulnerabilities in Cairo/Starknet (Nov 2024)](https://fuzzinglabs.com/top-4-vulnerability-cairo-starknet-smart-contract/)
+- [amanusk — Awesome Starknet Security](https://github.com/amanusk/awesome-starknet-security)
+
+### Standards & Specifications
+- [SNIP-9 — Outside Execution (meta-transactions)](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md)
+- [SNIP-12 — Typed Structured Data Signing](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md)
+- [OZ SNIP-12 Guide](https://docs.openzeppelin.com/contracts-cairo/3.x/guides/snip12)
+
+### OpenZeppelin Components
+- [OZ Cairo Governance Docs (3.x)](https://docs.openzeppelin.com/contracts-cairo/3.x/api/governance)
+- [OZ Cairo ERC20Permit](https://docs.openzeppelin.com/contracts-cairo/3.x/api/erc20#ERC20Permit)
+- [OZ Cairo NoncesComponent](https://docs.openzeppelin.com/contracts-cairo/3.x/api/utilities#NoncesComponent)
+
+### Account Abstraction & Paymasters
+- [Starknet Docs — Account Abstraction](https://docs.starknet.io/build/starknet-by-example/advanced/account-abstraction)
+- [Starknet Docs — Paymaster](https://docs.starknet.io/build/applications/paymaster)
+
+### Protocol Security Disclosures
+- [Zellic — Sequencer-Prover Inconsistency in Cairo VM (Starknet Community Forum)](https://community.starknet.io/t/remediating-a-potential-sequencer-prover-inconsistency-in-the-cairo-vm/115313)
+
+### Formal Verification
+- [StarkWare — Cairo VM Formal Proofs (Lean)](https://github.com/starkware-libs/formal-proofs) — formal verification of Cairo VM semantics, AIR encoding correctness, and elliptic curve operations (secp256k1/r1)
+
+### Protocol Changes
+- [Starknet Version Notes (official, all versions)](https://docs.starknet.io/learn/cheatsheets/version-notes)
+- [Starknet v0.14.0 "Grinta" — Decentralized Sequencer](https://starknet.io/blog/starknet-grinta-the-architecture-of-a-more-decentralized-future)
+- [Starknet Version Releases](https://www.starknet.io/developers/version-releases/)
+- [Starknet Fees Documentation](https://docs.starknet.io/learn/protocol/fees)
+- [Starknet Compatibility Tables](https://docs.starknet.io/learn/cheatsheets/compatibility)
+- [Cairo v2.15.0 Release (edition 2025_12)](https://github.com/starkware-libs/cairo/releases/tag/v2.15.0)
+
+### Cairo Core Library
+- [Cairo Core Integer Module (overflow/wrapping/saturating)](https://docs.cairo-lang.org/core/core-integer.html)
+- [Cairo SaturatingAdd Trait](https://docs.cairo-lang.org/core/core-num-traits-ops-saturating-SaturatingAdd.html)
+
+### Security Tooling
+- [snforge — Starknet Foundry Testing & Fuzzing (primary tool)](https://foundry-rs.github.io/starknet-foundry/)
+- [Caracal — Static Analyzer (Cairo ≤ 2.5.0 only, last release Jan 2024)](https://github.com/crytic/caracal)
+- [FuzzingLabs — sierra-analyzer (ARCHIVED, no longer maintained)](https://github.com/FuzzingLabs/sierra-analyzer)
+- [FuzzingLabs — cairo-fuzzer (ARCHIVED, no longer maintained, Cairo 0.x only)](https://github.com/FuzzingLabs/cairo-fuzzer)
+- [FuzzingLabs — Thoth (ARCHIVED, no longer maintained)](https://github.com/FuzzingLabs/thoth)
+- [sqrlfirst — Cairo Security Checklist](https://github.com/sqrlfirst/cairo-checklist)

--- a/skills/cairo-testing/SKILL.md
+++ b/skills/cairo-testing/SKILL.md
@@ -1,186 +1,376 @@
 ---
 name: cairo-testing
-description: Cairo smart-contract testing with snforge. Trigger on "write tests", "add unit tests", "fuzz test", "integration test", "test this contract", "regression test". Guides test strategy, cheatcode usage, and coverage.
+description: Use when writing tests for Cairo smart contracts — snforge test structure, contract deployment in tests, cheatcodes, event testing, fuzzing, fork testing.
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"0.2.0","org":"keep-starknet-strange","source":"starknet-agentic"}
-keywords: [cairo, testing, snforge, starknet-foundry, fuzzing, integration]
+metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
+keywords: [cairo, testing, snforge, starknet-foundry, fuzzing, cheatcodes, integration-tests, unit-tests]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true
 ---
 
 # Cairo Testing
 
-You are a Cairo testing assistant. Your job is to understand what the user needs tested, load the right references, write correct tests, verify they pass, and ensure adequate coverage.
+Reference for testing Cairo smart contracts with Starknet Foundry (snforge).
 
 ## When to Use
 
-- Writing unit, integration, fuzz, or fork tests for Cairo contracts.
-- Designing regression tests for known findings.
-- Validating event emission, failure semantics, or access control.
-- Improving test coverage on an existing contract.
+- Writing unit tests for Cairo contract functions
+- Writing integration tests that deploy and interact with contracts
+- Using cheatcodes to manipulate block state, caller, timestamps
+- Testing events are emitted correctly
+- Fuzzing contract inputs
+- Fork-testing against live Starknet state
 
-## When NOT to Use
+**Not for:** Contract structure (use cairo-contracts), optimization (use cairo-optimization), deployment (use cairo-deploy)
 
-- Contract architecture decisions (`cairo-contract-authoring`).
-- Performance tuning (`cairo-optimization`).
-- Deployment operations (`cairo-deploy`).
-- Security audit of existing code (`cairo-auditor`).
+## Setup
 
-## Quick Start
+### Scarb.toml
 
-1. Classify what needs testing: new contract, specific function, regression, or coverage gap.
-2. Load references based on test type — see the table in [Orchestration](#orchestration).
-3. Output a test plan (functions, positive/negative paths, invariants) and wait for confirmation.
-4. Implement tests following snforge patterns, then run `snforge test`.
-5. Verify coverage: every external tested? auth paths? negative cases? events?
-6. Emit a handoff block using `../references/skill-handoff.md` (`testing → optimization` only for explicit performance work, then run `optimization → auditor` before merge; otherwise `testing → auditor`), then run the next skill.
+```toml
+[dev-dependencies]
+snforge_std = "0.56.0"
 
-## Rationalizations to Reject
-
-- "We only need happy-path tests."
-- "Access control tests are unnecessary — the contract handles it."
-- "Fuzz tests are overkill for this contract."
-- "We'll add regression tests after the next audit."
-
-## Mode Selection
-
-- **unit**: Test individual functions using `contract_state_for_testing()`. No deployment needed.
-- **integration**: Test deployed contracts via dispatchers. Multi-contract interactions.
-- **fuzz**: Property-based tests with `#[fuzzer]` for arithmetic, bounds, invariants.
-- **fork**: Test against live Starknet state with `#[fork]`.
-- **regression**: Turn a known finding into a failing-before/fixed-after test pair.
-
-## Orchestration
-
-**Turn 1 — Understand.** Classify the request:
-
-(a) Determine mode: `unit`, `integration`, `fuzz`, `fork`, or `regression`.
-
-(b) Read the contract under test. Use Glob to find `.cairo` files, then Read to inspect them. Identify:
-- All storage-mutating `#[abi(embed_v0)]` impl functions and `#[external(v0)]` functions (these must be tested).
-- Storage fields and their types.
-- Events that should be emitted.
-- Access control patterns (owner checks, role checks).
-
-(c) Check for existing tests. Use Glob to find `tests/` directories and test files.
-
-(d) Load references based on what's needed:
-
-| Request involves | Load reference |
-|-----------------|---------------|
-| Basic test structure, deployment, assertions | `{skill_dir}/references/legacy-full.md` (Basic Test Structure, Contract Deployment) |
-| Cheatcodes (caller, timestamp, block number) | `{skill_dir}/references/legacy-full.md` (Cheatcodes section) |
-| Event testing, spy_events | `{skill_dir}/references/legacy-full.md` (Event Testing section) |
-| Fuzz / property tests | `{skill_dir}/references/legacy-full.md` (Fuzzing section) |
-| Fork testing against mainnet | `{skill_dir}/references/legacy-full.md` (Fork Testing section) |
-| Security regression recipes | `../cairo-auditor/references/vulnerability-db/` |
-
-Where `{skill_dir}` is the directory containing this SKILL.md. Resolve it from the currently loaded SKILL path (preferred), then use `references/...` relative paths from that directory.
-
-**Turn 2 — Plan.** Before writing any test code, output a brief plan:
-
-1. **Functions to test** — list each external function and whether it gets a positive test, negative test, or both.
-2. **Access control tests** — for each guarded function, test: authorized caller succeeds, unauthorized caller reverts.
-3. **Event tests** — list events that should be verified with `spy_events`.
-4. **Edge cases** — zero values, max values, duplicate calls, reentrancy attempts.
-5. **Fuzz targets** — identify functions with numeric inputs that should get `#[fuzzer]` tests.
-6. **Regression tests** — if fixing a known finding, describe the failing-before scenario.
-
-Keep the plan under 30 lines. Wait for user confirmation before implementing.
-
-**Turn 3 — Implement.** Write tests following these rules:
-
-*Structure rules:*
-- Use `#[cfg(test)] mod tests { ... }` for unit tests in the same file, or separate `tests/` directory for integration tests.
-- Create a shared `helpers` module for `deploy_contract()`, address constants (`OWNER()`, `USER()`, `ZERO()`).
-- Name tests descriptively: `test_<function>_<scenario>` (e.g., `test_transfer_non_owner_rejected`).
-
-*Coverage rules (mandatory):*
-- Every state-mutating external entrypoint MUST have a success-path test.
-- Add negative-path tests for entrypoints with explicit authorization, validation, or other rejection conditions.
-- Every access-controlled function MUST be tested with: (1) authorized caller succeeds, (2) unauthorized caller panics with expected message.
-- Constructors MUST be tested for correct initial state, plus zero-address rejection when the constructor explicitly forbids zero addresses.
-- Read-only externals (`self: @ContractState`) MUST verify return correctness; revert tests are optional unless the function defines a failure path.
-- Every event-emitting function MUST verify the event with `spy_events` + `assert_emitted`.
-
-*Cheatcode rules:*
-- Use `start_cheat_caller_address` / `stop_cheat_caller_address` to impersonate callers.
-- Use `start_cheat_block_timestamp` for timelock tests — never hardcode timestamps.
-- Always call the matching `stop_cheat_*` after assertions to avoid leaking state.
-
-*Fuzz rules:*
-- Use `#[fuzzer(runs: 256, seed: 12345)]` with a fixed seed for reproducibility.
-- Constrain inputs with guard clauses or bounded types, not by ignoring invalid inputs.
-
-After writing tests, run `snforge test` to verify they pass. If any fail, fix and re-run.
-
-**Turn 4 — Verify.** After tests pass:
-
-(a) Coverage checklist — mentally walk through every external function:
-- Has a success-path test?
-- Has a failure-path test (wrong caller, bad input, overflow)?
-- Emits correct events?
-- Fuzz target if numeric inputs?
-
-(b) Report any untested functions or missing edge cases to the user.
-
-(c) If the user's project uses `cairo-auditor`, suggest running it to find additional test targets.
-
-(d) Suggest next steps:
-- "Run `cairo-auditor` for a security review — it may surface additional test cases."
-- "Consider adding fork tests if this contract interacts with deployed protocols."
-
-## Runnable Example (starknet.js)
-
-```ts
-import { Account, Contract, RpcProvider } from "starknet";
-
-const provider = new RpcProvider({ nodeUrl: process.env.STARKNET_RPC! });
-const account = new Account(provider, process.env.ACCOUNT_ADDRESS!, process.env.PRIVATE_KEY!);
-const contract = new Contract(abi, process.env.CONTRACT_ADDRESS!, provider).connect(account);
-
-// Execute path (state mutation)
-const tx = await contract.invoke("transfer", [process.env.USER_ADDRESS!, 100, 0]);
-await provider.waitForTransaction(tx.transaction_hash);
-
-// Read path (view assertion)
-const balance = await contract.call("balance_of", [process.env.USER_ADDRESS!]);
-console.log({ balance });
+[[target.starknet-contract]]
+sierra = true
+casm = true
 ```
 
-## Error Codes and Recovery
+> **Note:** snforge 0.56.0 requires Scarb >= 2.12.0. Check [scarbs.dev/packages/snforge_std](https://scarbs.dev/packages/snforge_std) for the latest version.
 
-| Code | Condition | Recovery |
-| --- | --- | --- |
-| `TEST-001` | `snforge test` fails to compile | Fix imports/dependencies in `Scarb.toml`, then rerun full suite. |
-| `TEST-002` | Access-control negative test missing | Add unauthorized caller case with expected panic message. |
-| `TEST-003` | Event assertion mismatch | Use `spy_events` + `assert_emitted` with full event payload ordering. |
-| `TEST-004` | Flaky fuzz results | Pin `#[fuzzer(seed: ...)]`, constrain inputs, and rerun deterministic seed. |
+### Running Tests
 
-## Security-Critical Rules
+```bash
+# Run all tests
+snforge test
 
-These are non-negotiable. Every test suite you write must satisfy all of them:
+# Run specific test by name
+snforge test test_transfer
 
-1. Every state-mutating external function has a positive test, plus negative tests for explicit rejection conditions.
-2. Every access-controlled function is tested with authorized and unauthorized callers.
-3. Expected panic messages are asserted with `#[should_panic(expected: '...')]` — not bare `#[should_panic]`.
-4. Event assertions use `spy_events` + `assert_emitted` with full event data — not just event count.
-5. Fuzz tests use fixed seeds for reproducibility.
+# Run tests matching a pattern
+snforge test test_erc20
 
-## References
+# Filter to a single test function (exact match)
+snforge test --exact test_erc20_transfer
 
-- Testing patterns and snforge API: [legacy-full.md](references/legacy-full.md)
-- Cross-skill handoff format: `../references/skill-handoff.md`
-- Module index: [references/README.md](references/README.md)
-- Security regression recipes: `../cairo-auditor/references/vulnerability-db/`
+# Run with gas reporting
+snforge test --detailed-resources
+```
 
-## Workflow
+> **Tip:** Use `snforge test --filter <pattern>` or `snforge test <pattern>` to run a subset of tests during development. `--exact` matches the full test name when you need precision.
 
-- Main testing flow: [default workflow](workflows/default.md)
+## Basic Test Structure
 
-## Eval Gate
+```cairo
+#[cfg(test)]
+mod tests {
+    use super::MyContract;
+    use starknet::ContractAddress;
+    use starknet::contract_address_const;
 
-When testing/security rules in this skill or its references change, update at least one case in:
+    fn OWNER() -> ContractAddress {
+        contract_address_const::<'OWNER'>()
+    }
 
-- `evals/cases/contract_skill_benchmark.jsonl`
-- `evals/cases/contract_skill_generation_eval.jsonl`
+    fn USER() -> ContractAddress {
+        contract_address_const::<'USER'>()
+    }
+
+    #[test]
+    fn test_constructor() {
+        let mut state = MyContract::contract_state_for_testing();
+        MyContract::constructor(ref state, OWNER());
+        assert(state.get_owner() == OWNER(), 'wrong owner');
+    }
+}
+```
+
+## Contract Deployment in Tests
+
+For integration tests that need actual contract deployment:
+
+```cairo
+use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
+
+fn deploy_contract() -> ContractAddress {
+    let contract = declare("MyContract").unwrap().contract_class();
+    let constructor_calldata = array![OWNER().into()];
+    let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
+    contract_address
+}
+
+#[test]
+fn test_deployed_contract() {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+    assert(dispatcher.get_balance() == 0, 'initial balance should be 0');
+}
+```
+
+## Cheatcodes
+
+### Caller Address
+
+```cairo
+use snforge_std::{start_cheat_caller_address, stop_cheat_caller_address};
+
+#[test]
+fn test_only_owner() {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    // Impersonate OWNER
+    start_cheat_caller_address(contract_address, OWNER());
+    dispatcher.owner_only_function();  // should succeed
+    stop_cheat_caller_address(contract_address);
+
+    // Impersonate USER — should fail
+    start_cheat_caller_address(contract_address, USER());
+    // This should panic
+}
+```
+
+### Block Timestamp
+
+```cairo
+use snforge_std::{start_cheat_block_timestamp, stop_cheat_block_timestamp};
+
+#[test]
+fn test_time_locked() {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    // Set block timestamp to future
+    start_cheat_block_timestamp(contract_address, 1000000);
+    dispatcher.time_sensitive_function();
+    stop_cheat_block_timestamp(contract_address);
+}
+```
+
+### Block Number
+
+```cairo
+use snforge_std::{start_cheat_block_number, stop_cheat_block_number};
+
+start_cheat_block_number(contract_address, 500);
+// ... test logic
+stop_cheat_block_number(contract_address);
+```
+
+### Sequencer Address
+
+```cairo
+use snforge_std::{start_cheat_sequencer_address, stop_cheat_sequencer_address};
+
+start_cheat_sequencer_address(contract_address, sequencer);
+// ... test logic
+stop_cheat_sequencer_address(contract_address);
+```
+
+## Expected Failures
+
+### Expected Panic
+
+```cairo
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_unauthorized_access() {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    start_cheat_caller_address(contract_address, USER());
+    dispatcher.owner_only_function();  // should panic
+}
+```
+
+### Expected Failure (any panic)
+
+```cairo
+#[test]
+#[should_panic]
+fn test_overflow() {
+    let dispatcher = IMyContractDispatcher { contract_address: deploy_contract() };
+    dispatcher.function_that_overflows();
+}
+```
+
+## Event Testing
+
+```cairo
+use snforge_std::{spy_events, EventSpyAssertionsTrait, EventSpyTrait};
+
+#[test]
+fn test_transfer_emits_event() {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    let mut spy = spy_events();
+
+    start_cheat_caller_address(contract_address, OWNER());
+    dispatcher.transfer(USER(), 100);
+
+    spy.assert_emitted(@array![
+        (
+            contract_address,
+            MyContract::Event::Transfer(
+                MyContract::Transfer {
+                    from: OWNER(),
+                    to: USER(),
+                    amount: 100,
+                }
+            )
+        )
+    ]);
+}
+```
+
+### Checking Event Count
+
+```cairo
+#[test]
+fn test_event_count() {
+    let mut spy = spy_events();
+
+    // ... trigger events
+
+    let events = spy.get_events();
+    assert(events.events.len() == 2, 'expected 2 events');
+}
+```
+
+## Fuzzing
+
+```cairo
+#[test]
+#[fuzzer(runs: 256, seed: 12345)]
+fn test_deposit_any_amount(amount: u256) {
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    // Fund the user first (if needed)
+    start_cheat_caller_address(contract_address, USER());
+    dispatcher.deposit(amount);
+
+    assert(dispatcher.get_balance(USER()) == amount, 'balance mismatch');
+}
+```
+
+### Bounded Fuzzing
+
+Use `assume` to constrain fuzz inputs:
+
+```cairo
+#[test]
+#[fuzzer(runs: 100)]
+fn test_transfer_bounded(amount: u256) {
+    // Skip values that would overflow
+    if amount == 0 || amount > 1000000 {
+        return;
+    }
+
+    let contract_address = deploy_contract();
+    let dispatcher = IMyContractDispatcher { contract_address };
+
+    start_cheat_caller_address(contract_address, OWNER());
+    dispatcher.transfer(USER(), amount);
+}
+```
+
+## Fork Testing
+
+Test against live Starknet state:
+
+```cairo
+use snforge_std::BlockTag;
+
+#[test]
+#[fork(url: "https://starknet-mainnet.g.alchemy.com/v2/YOUR_KEY", block_tag: latest)]
+fn test_against_mainnet() {
+    let usdc_address = contract_address_const::<0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8>();
+    let dispatcher = IERC20Dispatcher { contract_address: usdc_address };
+
+    let supply = dispatcher.total_supply();
+    assert(supply > 0, 'USDC should have supply');
+}
+```
+
+### Fork with Specific Block
+
+```cairo
+#[test]
+#[fork(url: "https://starknet-mainnet.g.alchemy.com/v2/YOUR_KEY", block_number: 500000)]
+fn test_at_specific_block() {
+    // ... test against historical state
+}
+```
+
+## Multi-Contract Tests
+
+```cairo
+fn setup() -> (ContractAddress, ContractAddress) {
+    // Deploy token
+    let token_class = declare("ERC20Token").unwrap().contract_class();
+    let (token_addr, _) = token_class.deploy(@array![
+        'MyToken'.into(), 'MTK'.into(), OWNER().into()
+    ]).unwrap();
+
+    // Deploy AMM that uses the token
+    let amm_class = declare("AMM").unwrap().contract_class();
+    let (amm_addr, _) = amm_class.deploy(@array![token_addr.into()]).unwrap();
+
+    (token_addr, amm_addr)
+}
+
+#[test]
+fn test_amm_swap() {
+    let (token_addr, amm_addr) = setup();
+    let token = IERC20Dispatcher { contract_address: token_addr };
+    let amm = IAMMDispatcher { contract_address: amm_addr };
+
+    // Approve AMM to spend tokens
+    start_cheat_caller_address(token_addr, OWNER());
+    token.approve(amm_addr, 1000);
+
+    // Execute swap
+    start_cheat_caller_address(amm_addr, OWNER());
+    amm.swap(token_addr, 100);
+}
+```
+
+## Test Organization
+
+```
+tests/
+  test_unit.cairo        # unit tests (contract_state_for_testing)
+  test_integration.cairo # integration tests (deploy + dispatch)
+  test_fuzz.cairo        # fuzz tests
+  helpers.cairo          # shared setup, deploy helpers, constants
+```
+
+### Shared Helpers Module
+
+```cairo
+// tests/helpers.cairo
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+
+fn OWNER() -> ContractAddress { contract_address_const::<'OWNER'>() }
+fn USER() -> ContractAddress { contract_address_const::<'USER'>() }
+fn ZERO() -> ContractAddress { contract_address_const::<0>() }
+
+fn deploy_my_contract() -> ContractAddress {
+    let contract = declare("MyContract").unwrap().contract_class();
+    let (addr, _) = contract.deploy(@array![OWNER().into()]).unwrap();
+    addr
+}
+```
+
+## Gas Reporting
+
+```bash
+# Show gas usage per test
+snforge test --detailed-resources
+
+# Compare gas between runs (save output, diff manually)
+snforge test --detailed-resources > gas-report.txt
+```

--- a/skills/controller-cli/SKILL.md
+++ b/skills/controller-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: controller-cli
-description: "Guidance for installing and operating the Cartridge Controller CLI (`controller`) to create human-approved sessions and execute Starknet transactions with JSON output, explicit network selection, scoped policies, paymaster control, and error recovery."
+description: "Use when installing and operating the Cartridge Controller CLI (`controller`) to create human-approved sessions and execute Starknet transactions (JSON-only, explicit network selection, least-privilege policy scoping, paymaster control, and error recovery)."
 license: Apache-2.0
 metadata:
   author: keep-starknet-strange
@@ -27,18 +27,6 @@ user-invocable: true
 
 Use this skill when you need to run the Cartridge Controller CLI (`controller-cli`) to create a scoped session (human-approved) and then execute Starknet transactions via that session.
 
-## When to Use
-
-- Operating Cartridge Controller sessions with explicit network and least-privilege policies.
-- Running `controller` or `controller_safe.py` for human-approved Starknet transactions.
-
-## When NOT to Use
-
-- General Starknet scripting that does not rely on Cartridge Controller.
-- Contract authoring, testing, deployment, or security audit workflows.
-
-Related modules: [skills catalog](../README.md).
-
 ## Non-Negotiable Rules
 
 - Always pass `--json` and treat outputs as JSON.
@@ -51,7 +39,7 @@ Related modules: [skills catalog](../README.md).
   - Mainnet: `https://voyager.online/tx/0x...`
   - Sepolia: `https://sepolia.voyager.online/tx/0x...`
 
-## Quick Start
+## Quick Start (Install)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh | bash

--- a/skills/huginn-onboard/SKILL.md
+++ b/skills/huginn-onboard/SKILL.md
@@ -13,18 +13,6 @@ user-invocable: true
 **Goal**: Enable any agent on any EVM chain to onboard to Starknet and register
 their identity with the HuginnRegistry.
 
-## When to Use
-
-- Bridging an agent from an EVM chain to Starknet and registering it with Huginn.
-- Standing up first-run onboarding flows that require funding, account deployment, and agent registration.
-
-## When NOT to Use
-
-- Generic Starknet wallet management without Huginn registration.
-- Cairo contract authoring, deployment-only runbooks, or security audits.
-
-Related modules: [skills catalog](../README.md).
-
 ## Prerequisites
 
 - Agent has ETH or USDC on source chain (Ethereum, Base, or Arbitrum)

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -3,31 +3,15 @@
   "repo": "keep-starknet-strange/starknet-agentic",
   "skills": [
     {
-      "description": "Starknet account abstraction correctness and security guidance for validate/execute paths, nonces, signatures, and session policies.",
-      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/account-abstraction",
-      "name": "account-abstraction",
-      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/account-abstraction/SKILL.md",
-      "repo_path": "skills/account-abstraction",
-      "skill_md_path": "skills/account-abstraction/SKILL.md"
+      "description": "Use when writing Cairo smart contracts on Starknet \u2014 contract structure, storage, events, interfaces, components, OpenZeppelin v3 patterns, and common contract templates.",
+      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-contracts",
+      "name": "cairo-contracts",
+      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-contracts/SKILL.md",
+      "repo_path": "skills/cairo-contracts",
+      "skill_md_path": "skills/cairo-contracts/SKILL.md"
     },
     {
-      "description": "Security audit of Cairo/Starknet code. Trigger on \"audit\", \"check this contract\", \"review for security\". Modes - default (full repo), deep (+ adversarial reasoning), or specific filenames.",
-      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-auditor",
-      "name": "cairo-auditor",
-      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/SKILL.md",
-      "repo_path": "skills/cairo-auditor",
-      "skill_md_path": "skills/cairo-auditor/SKILL.md"
-    },
-    {
-      "description": "Cairo smart-contract authoring on Starknet. Trigger on \"write a contract\", \"create a contract\", \"implement this in Cairo\", \"add storage/events/interface\", \"compose components\". Guides structure, security patterns, and component wiring.",
-      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-contract-authoring",
-      "name": "cairo-contract-authoring",
-      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-contract-authoring/SKILL.md",
-      "repo_path": "skills/cairo-contract-authoring",
-      "skill_md_path": "skills/cairo-contract-authoring/SKILL.md"
-    },
-    {
-      "description": "Deployment guidance for Cairo contracts on Starknet covering sncast commands, account setup, declare/deploy workflow, network configuration, and contract verification.",
+      "description": "Use when deploying Cairo contracts to Starknet \u2014 sncast commands, account setup, declare/deploy workflow, network configuration, contract verification.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-deploy",
       "name": "cairo-deploy",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-deploy/SKILL.md",
@@ -35,7 +19,7 @@
       "skill_md_path": "skills/cairo-deploy/SKILL.md"
     },
     {
-      "description": "Improves Cairo performance after correctness is established. Trigger on \"optimize\", \"gas usage\", \"reduce steps\", \"profile\", \"BoundedInt\", \"storage packing\", \"benchmark\". Guides profiling, arithmetic optimization, and bounded-int hardening.",
+      "description": "Use as an explicit post-test optimization pass \u2014 fixing slow loops, expensive arithmetic, integer splitting or limb assembly, modular reduction, storage slot packing, or BoundedInt type bounds. Invoke after implementation and tests pass.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-optimization",
       "name": "cairo-optimization",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-optimization/SKILL.md",
@@ -43,7 +27,15 @@
       "skill_md_path": "skills/cairo-optimization/SKILL.md"
     },
     {
-      "description": "Cairo smart-contract testing with snforge. Trigger on \"write tests\", \"add unit tests\", \"fuzz test\", \"integration test\", \"test this contract\", \"regression test\". Guides test strategy, cheatcode usage, and coverage.",
+      "description": "Use when reviewing Cairo contracts for security \u2014 common vulnerabilities, audit patterns, production hardening, Cairo-specific pitfalls, L1/L2 bridging safety, session key security, precision/rounding bugs, static analysis tooling. Sourced from 50+ public audits and the Cairo Book.",
+      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-security",
+      "name": "cairo-security",
+      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-security/SKILL.md",
+      "repo_path": "skills/cairo-security",
+      "skill_md_path": "skills/cairo-security/SKILL.md"
+    },
+    {
+      "description": "Use when writing tests for Cairo smart contracts \u2014 snforge test structure, contract deployment in tests, cheatcodes, event testing, fuzzing, fork testing.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-testing",
       "name": "cairo-testing",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-testing/SKILL.md",
@@ -51,7 +43,7 @@
       "skill_md_path": "skills/cairo-testing/SKILL.md"
     },
     {
-      "description": "Guidance for installing and operating the Cartridge Controller CLI (`controller`) to create human-approved sessions and execute Starknet transactions with JSON output, explicit network selection, scoped policies, paymaster control, and error recovery.",
+      "description": "Use when installing and operating the Cartridge Controller CLI (`controller`) to create human-approved sessions and execute Starknet transactions (JSON-only, explicit network selection, least-privilege policy scoping, paymaster control, and error recovery).",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/controller-cli",
       "name": "controller-cli",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/controller-cli/SKILL.md",
@@ -99,7 +91,7 @@
       "skill_md_path": "skills/starknet-identity/SKILL.md"
     },
     {
-      "description": "Reference for building Starknet applications using starknet.js v9.x SDK, including contract interaction, account management, transaction handling, fee estimation, wallet integration, and paymaster flows.",
+      "description": "Guide for building Starknet applications using starknet.js v9.x SDK. Use when developing Starknet dApps, interacting with smart contracts, managing accounts, handling transactions, estimating fees, integrating browser wallets, or working with Paymaster for sponsored/alternative gas token transactions.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/starknet-js",
       "name": "starknet-js",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-js/SKILL.md",
@@ -113,14 +105,6 @@
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-mini-pay/SKILL.md",
       "repo_path": "skills/starknet-mini-pay",
       "skill_md_path": "skills/starknet-mini-pay/SKILL.md"
-    },
-    {
-      "description": "Starknet network-level constraints and protocol facts that impact contract safety and agent reasoning.",
-      "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/starknet-network-facts",
-      "name": "starknet-network-facts",
-      "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-network-facts/SKILL.md",
-      "repo_path": "skills/starknet-network-facts",
-      "skill_md_path": "skills/starknet-network-facts/SKILL.md"
     },
     {
       "description": "Confidential ERC20 payments on Starknet using Tongo protocol. Fund, transfer, withdraw, and rollover encrypted token balances with zero-knowledge proofs. Use when the user needs privacy-preserving transactions, confidential payments, encrypted balances, or auditable private transfers on Starknet.",
@@ -139,7 +123,7 @@
       "skill_md_path": "skills/starknet-wallet/SKILL.md"
     },
     {
-      "description": "Reference for integrating or maintaining applications built with keep-starknet-strange/starkzap, including StarkSDK setup, onboarding, wallet lifecycle, sponsored transactions, ERC20 flows, staking, and transaction builder usage.",
+      "description": "Use when integrating or maintaining applications built with keep-starknet-strange/starkzap. Covers StarkSDK setup, onboarding (Signer/Privy/Cartridge), wallet lifecycle, sponsored transactions, ERC20 transfers, staking flows, tx builder batching, examples, tests, and generated presets.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/starkzap-sdk",
       "name": "starkzap-sdk",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starkzap-sdk/SKILL.md",

--- a/skills/starknet-anonymous-wallet/SKILL.md
+++ b/skills/starknet-anonymous-wallet/SKILL.md
@@ -17,20 +17,8 @@ This skill provides **agent-facing scripts** for:
 - Preflight (simulate + fee estimate)
 - Allowance checks with human amounts
 
-## When to Use
-
-- Creating or operating privacy-focused Starknet accounts through the Typhoon flow.
-- Running agent-side contract reads, writes, preflight simulation, or allowance checks from an anonymous wallet context.
-
-## When NOT to Use
-
-- Standard non-private wallet management, DeFi routing, or payment-link flows.
-- Cairo contract authoring, deployment operations, or security audits.
-
-## Quick Start
-
+## Quick Reference
 - Deep dives: `references/` (ABI discovery, Typhoon account flow, preflight/fee simulation notes)
-- Adjacent modules: [skills catalog](../README.md)
 - Account flow examples: `scripts/create-account.js`, `scripts/parse-smart.js`, `scripts/resolve-smart.js`
 - Read/write examples: `scripts/read-smart.js`, `scripts/invoke-contract.js`, `scripts/avnu-swap.js`
 - Allowance checks example: `scripts/read-smart.js` (call ERC20 `allowance(owner, spender)`)

--- a/skills/starknet-defi/SKILL.md
+++ b/skills/starknet-defi/SKILL.md
@@ -12,21 +12,6 @@ user-invocable: true
 
 Execute DeFi operations on Starknet using avnu aggregator and native protocols.
 
-## When to Use
-
-- Swaps, DCA orders, staking, and lending or borrowing flows on Starknet.
-- Agent workflows that need AVNU routing, paymaster support, or protocol-specific DeFi execution.
-
-## When NOT to Use
-
-- Plain wallet management without DeFi intent.
-- Cairo contract authoring, deployment operations, or security auditing.
-
-## Quick Start
-
-1. Install the AVNU + starknet.js dependencies and point the skill at a funded Starknet account.
-2. Use [skills catalog](../README.md) when the flow expands into wallet setup, deployment, or auditing.
-
 ## Prerequisites
 
 ```bash

--- a/skills/starknet-identity/SKILL.md
+++ b/skills/starknet-identity/SKILL.md
@@ -12,21 +12,6 @@ user-invocable: true
 
 Register and manage AI agent identities on Starknet using the ERC-8004 standard.
 
-## When to Use
-
-- Registering agents on-chain, updating agent metadata, or managing reputation and validation flows.
-- Building features that depend on ERC-8004 identity, feedback, or validator attestations.
-
-## When NOT to Use
-
-- Simple wallet, payment, or DeFi flows that do not depend on ERC-8004 registries.
-- Cairo contract authoring, deployment-only tasks, or security auditing.
-
-## Quick Start
-
-1. Install `starknet` and connect a funded account to the target ERC-8004 registry deployment.
-2. Use [skills catalog](../README.md) if the flow also needs wallet setup, deployment, or contract auditing.
-
 ## Overview
 
 ERC-8004 defines three interconnected on-chain registries for AI agents:
@@ -303,16 +288,6 @@ Serve at `/.well-known/agent.json` for A2A discovery.
 - Self-validation is prevented (agent owner cannot validate own agent)
 - Signatures include chain ID and expiry to prevent replay attacks
 - Agent identity (NFT) is transferable -- new owner inherits reputation
-
-## Error Codes
-
-| Code | Meaning | Likely causes | Recovery | User-facing message |
-|-----|---------|---------------|----------|---------------------|
-| `REGISTRATION_FAILED` | Initial ERC-8004 registration or metadata write reverted. | Missing fees, duplicate registration, invalid calldata, or stale contract state. | Retry after checking wallet balance, contract state, and constructor/registration inputs. | "Registration failed. Check wallet state and retry." |
-| `AUTHORIZATION_DENIED` | Ownership or feedback authorization proof was rejected. | Wrong signer, bad nonce, missing permission, or outdated owner state. | Re-fetch owner/nonce state, verify permissions, and re-sign with the current account. | "Authorization denied. Verify signer permissions and retry." |
-| `VALIDATION_TIMEOUT` | Off-chain validation or watcher flow did not complete before the deadline. | Slow relayer, RPC degradation, or downstream A2A service lag. | Retry with a longer timeout after checking chain health, relayer status, and RPC latency. | "Validation timed out. Retry after checking network health." |
-| `SIGNATURE_EXPIRED` | Signed payload expired before submission. | Expiry window too short or user approval arrived too late. | Generate a fresh signature with a new expiry and resubmit immediately. | "Signature expired. Re-sign and submit again." |
-| `OWNER_TRANSFERRED` | Agent NFT ownership changed while a write or feedback flow was in flight. | NFT transfer, marketplace sale, or custodial wallet rotation. | Refresh ownership state, re-authorize with the new owner, and explain that reputation follows the NFT. | "Ownership changed. Refresh owner state and retry with the new owner." |
 
 ## References
 

--- a/skills/starknet-js/SKILL.md
+++ b/skills/starknet-js/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: starknet-js
-description: "Reference for building Starknet applications using starknet.js v9.x SDK, including contract interaction, account management, transaction handling, fee estimation, wallet integration, and paymaster flows."
+description: "Guide for building Starknet applications using starknet.js v9.x SDK. Use when developing Starknet dApps, interacting with smart contracts, managing accounts, handling transactions, estimating fees, integrating browser wallets, or working with Paymaster for sponsored/alternative gas token transactions."
 license: Apache-2.0
 metadata:
   author: 0xlny
@@ -34,16 +34,6 @@ user-invocable: true
 ---
 
 # starknet.js v9.x SDK
-
-Related modules: [skills catalog](../README.md).
-
-## When to Use
-
-- Building Starknet apps with provider, account, contract, wallet, or paymaster flows.
-
-## When NOT to Use
-
-- Cairo contract authoring, deployment-only runbooks, or security audits.
 
 ## Quick Start
 

--- a/skills/starknet-mini-pay/SKILL.md
+++ b/skills/starknet-mini-pay/SKILL.md
@@ -1,28 +1,38 @@
 ---
 name: starknet-mini-pay
-description: Simple P2P payments on Starknet. Generate QR codes, payment links, invoices, and transfer ETH/STRK/USDC. Like Lightning, but native.
+description: >
+  Simple P2P payments on Starknet. Like Lightning, but native.
+  Generate QR codes, payment links, invoices, and transfer ETH/STRK/USDC.
+keywords:
+  - starknet
+  - payments
+  - qr-code
+  - payment-links
+  - lightning
+  - p2p
+  - transfer
+  - invoice
+  - strk
+  - eth
+  - usdc
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Task
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"1.0.0","org":"keep-starknet-strange"}
-keywords: [starknet, payments, qr-code, payment-links, lightning, p2p, transfer, invoice, strk, eth, usdc]
-allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
+metadata:
+  author: starknet-agentic
+  version: 1.0.0
+  org: keep-starknet-strange
 user-invocable: true
 ---
 
 # Starknet Mini-Pay Skill
 
 Simple P2P payments on Starknet. Like Lightning, but native.
-
-Related modules: [skills catalog](../README.md).
-
-## When to Use
-
-- Generating payment links, QR codes, invoices, or Telegram payment flows on Starknet.
-- Sending simple user-to-user ETH, STRK, or USDC transfers with payment UX around them.
-
-## When NOT to Use
-
-- DeFi-specific swaps, staking, or lending flows.
-- Cairo contract authoring, deployment-only tasks, or security auditing.
 
 ## Overview
 
@@ -86,6 +96,35 @@ python3.12 scripts/cli.py status 0xabcdef...
 python3.12 scripts/cli.py balance 0x123...
 ```
 
+### JavaScript (starknet.js)
+
+```typescript
+import { RpcProvider, Account, Contract, uint256 } from 'starknet';
+
+const provider = new RpcProvider({ 
+  nodeUrl: process.env.STARKNET_RPC || 'https://rpc.starknet.lava.build' 
+});
+
+// starknet.js v5+ uses positional args: new Account(provider, address, signer)
+const account = new Account(
+  provider,
+  process.env.ADDRESS,
+  process.env.PRIVATE_KEY
+);
+
+// USDC contract (StarkGate bridged - USDC.e)
+const USDC_ADDRESS = '0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8';
+
+const usdc = new Contract(USDC_ABI, USDC_ADDRESS, account);
+
+// Send 10 USDC
+const tx = await usdc.transfer(
+  recipient_address,
+  uint256.bnToUint256(10n * 10n ** 6n)
+);
+await provider.waitForTransaction(tx.transaction_hash);
+```
+
 ### Payment Link Format
 
 ```
@@ -94,7 +133,7 @@ starknet:<address>?amount=<value>&memo=<text>&token=<ETH|STRK|USDC>
 
 **Example:**
 ```
-starknet:0x053c91253bc9682c04929ca02ed00b3e423f6714d2ea42d73d1b8f3f8d400005?amount=0.01&memo=coffee&token=ETH
+starknet:0x1234567890abcdef1234567890abcdef12345678?amount=0.01&memo=coffee&token=USDC
 ```
 
 ### Telegram Bot Commands
@@ -179,7 +218,7 @@ from qr_generator import QRGenerator
 
 qr = QRGenerator()
 qr.generate(
-    address="0x053c91253bc9682c04929ca02ed00b3e423f6714d2ea42d73d1b8f3f8d400005",
+    address="0x1234567890abcdef1234567890abcdef12345678",
     amount=None,  # Optional amount
     memo=None,     # Optional memo
     output_file="address_qr.png"

--- a/skills/starknet-mini-pay/scripts/mini_pay.py
+++ b/skills/starknet-mini-pay/scripts/mini_pay.py
@@ -10,6 +10,7 @@ Token addresses from official sources:
 
 import asyncio
 import logging
+import os
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass
 from enum import Enum
@@ -36,8 +37,9 @@ class Token(Enum):
 MAINNET_TOKENS = {
     "ETH": 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7,
     "STRK": 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d,
-    # USDC: https://github.com/starknet-io/starknet-addresses/blob/master/bridged_tokens/mainnet.json
-    "USDC": 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8,
+    # USDC: Native USDC from Circle (deployed December 2025+)
+    # https://www.circle.com/blog/native-usdc-now-available-on-starknet
+    "USDC": 0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb,
 }
 
 # Sepolia Testnet Token Addresses  
@@ -270,7 +272,7 @@ class MiniPay:
 
 async def example():
     """Example usage."""
-    RPC = "https://starknet-mainnet.g.alchemy.com/v2/lq2wTFNVuh1mmqC7oPcYw"
+    RPC = os.environ.get("STARKNET_RPC", "https://rpc.starknet.lava.build")
     pay = MiniPay(RPC)
     
     addr = "0x068047beadC45aFF253839D4DD7c2cD1c27D502738BAd0AF935D402bdf9244ED"

--- a/skills/starknet-mini-pay/scripts/telegram_bot.py
+++ b/skills/starknet-mini-pay/scripts/telegram_bot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3.12
+import urllib.parse
 """
 Starknet Mini-Pay Telegram Bot (Non-Custodial)
 Send and receive payments via Telegram using deep links
@@ -50,7 +51,7 @@ from mini_pay import MiniPay
 # Configuration
 TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 STARKNET_RPC = os.environ.get("STARKNET_RPC", "https://rpc.starknet.lava.build:443")
-WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "your_secret_here")
+WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET")  # Must be set for production
 WEBHOOK_URL = os.environ.get("WEBHOOK_URL", "")  # For receiving tx confirmations
 
 # Logging
@@ -75,9 +76,16 @@ class StarknetMiniPayBot:
         self.pay = MiniPay(rpc_url=STARKNET_RPC)
         self.invoice_db = None  # Initialized in start()
         
-        # Webhook state
+        # Webhook state with security validation
         self.webhook_url = WEBHOOK_URL
         self.webhook_secret = WEBHOOK_SECRET
+        
+        # Security guard: if webhook URL is set, secret MUST be set
+        if self.webhook_url and not self.webhook_secret:
+            raise ValueError(
+                "SECURITY: WEBHOOK_URL is set but WEBHOOK_SECRET is not. "
+                "Set WEBHOOK_SECRET environment variable to prevent unauthorized callbacks."
+            )
         
         # Application
         self.app = Application.builder().token(token).build()
@@ -553,9 +561,9 @@ TX: <code>{tx_hash}</code>
         if amount:
             params.append(f"amount={amount}")
         if memo:
-            params.append(f"memo={memo}")
+            params.append(f"memo={urllib.parse.quote(memo)}")
         
-        payment_url = f"?{ '&'.join(params)}"
+        payment_url = f"?{'&'.join(params)}"
         
         return {
             "argent": f"argent://starknet/pay{payment_url}",
@@ -633,7 +641,21 @@ TX: <code>{tx_hash}</code>
     async def handle_webhook(self, request: web.Request):
         """Handle incoming webhook from payment system"""
         try:
-            data = await request.json()
+            # Verify HMAC signature if secret is configured
+            signature = request.headers.get("X-Webhook-Signature", "")
+            body = await request.read()
+            
+            if self.webhook_secret:
+                expected = hmac.new(
+                    self.webhook_secret.encode(),
+                    body,
+                    hashlib.sha256
+                ).hexdigest()
+                if not hmac.compare_digest(signature, expected):
+                    logger.warning("Invalid webhook signature")
+                    return web.json_response({"error": "Invalid signature"}, status=401)
+            
+            data = json.loads(body)
             
             tx_hash = data.get("tx_hash")
             status = data.get("status")

--- a/skills/starknet-tongo/SKILL.md
+++ b/skills/starknet-tongo/SKILL.md
@@ -12,21 +12,6 @@ user-invocable: true
 
 Confidential ERC20 payments on Starknet using the [Tongo protocol](https://github.com/fatlabsxyz/tongo). Tongo wraps any ERC20 token into encrypted balances using ElGamal encryption and zero-knowledge proofs. No trusted setup required.
 
-## When to Use
-
-- Confidential ERC20 payment flows that require encrypted balances or private transfers.
-- Compliance or auditor-enabled privacy flows built on top of Tongo accounts.
-
-## When NOT to Use
-
-- Standard transparent ERC20 transfers, swaps, or wallet management without privacy requirements.
-- Cairo contract authoring, deployment-only tasks, or security auditing of unrelated code.
-
-## Quick Start
-
-1. Install the Tongo SDK, configure the Starknet/Tongo keys, and connect a funded Starknet account.
-2. Use [skills catalog](../README.md) if the flow expands into wallet setup, deployment, or auditing.
-
 ## Prerequisites
 
 ```bash

--- a/skills/starknet-wallet/SKILL.md
+++ b/skills/starknet-wallet/SKILL.md
@@ -12,21 +12,6 @@ user-invocable: true
 
 Manage Starknet wallets for AI agents with native Account Abstraction support.
 
-## When to Use
-
-- Creating, funding, and operating Starknet accounts for agent workflows.
-- Checking balances, sending transfers, managing session keys, or invoking contracts from an agent wallet.
-
-## When NOT to Use
-
-- DeFi-specific routing, staking, or lending flows better covered by `starknet-defi`.
-- Cairo contract authoring, deployment-only operations, or security auditing.
-
-## Quick Start
-
-1. Install the SDK dependencies and set Starknet RPC/account environment variables.
-2. Use [skills catalog](../README.md) to pivot to adjacent modules like DeFi, deployment, or auditing.
-
 ## Prerequisites
 
 ```bash

--- a/skills/starkzap-sdk/SKILL.md
+++ b/skills/starkzap-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: starkzap-sdk
-description: "Reference for integrating or maintaining applications built with keep-starknet-strange/starkzap, including StarkSDK setup, onboarding, wallet lifecycle, sponsored transactions, ERC20 flows, staking, and transaction builder usage."
+description: "Use when integrating or maintaining applications built with keep-starknet-strange/starkzap. Covers StarkSDK setup, onboarding (Signer/Privy/Cartridge), wallet lifecycle, sponsored transactions, ERC20 transfers, staking flows, tx builder batching, examples, tests, and generated presets."
 license: Apache-2.0
 metadata:
   author: keep-starknet-strange
@@ -36,7 +36,7 @@ Project-focused guide for `https://github.com/keep-starknet-strange/starkzap`.
 
 Use this skill when requests involve Starkzap SDK code, examples, or docs.
 
-## When to Use
+## When To Use
 
 Trigger for tasks like:
 - "Add a new onboarding flow in Starkzap"
@@ -44,16 +44,6 @@ Trigger for tasks like:
 - "Update staking pool logic or validator presets"
 - "Patch Privy signer/server integration"
 - "Review Starkzap tests/docs/examples"
-
-## When NOT to Use
-
-- Generic Starknet SDK work outside the Starkzap codebase.
-- Cairo contract authoring, deployment operations, or security audits.
-
-## Quick Start
-
-1. Open the target Starkzap repository paths below and choose the smallest workflow surface first.
-2. Use [skills catalog](../README.md) when the task crosses into generic Starknet wallet, deployment, or audit flows.
 
 ## Repository Map
 


### PR DESCRIPTION

## Summary

Enhance P2P payment skill for Starknet with USDC support and webhook validation.

## Changes

- Fix USDC token address (mainnet)
- Add webhook secret validation
- Enhanced Telegram bot interface

## Testing

All tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for Cairo Components, Cairo Language, and Cairo Contracts; new reference/readme and scripts docs; expanded Mini Pay docs with structured metadata and examples.

* **New Features**
  * Mini Pay examples now demonstrate native USDC, include a StarkNet.js payment example, and support RPC selection via an environment variable.

* **Bug Fixes / Security**
  * Webhook now requires a configured secret in production and validates HMAC signatures; initialization guards added to prevent misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->