### PR TITLE
feat(security): enforce strict security proof gate for secure-defi-demo

### DIFF
--- a/.github/workflows/strict-security-proof.yml
+++ b/.github/workflows/strict-security-proof.yml
@@ -1,0 +1,34 @@
+name: Strict Security Proof Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_path:
+        description: "Path to secure-defi artifact JSON (repo-relative)"
+        required: false
+        default: "examples/secure-defi-demo/test/fixtures/strict-claims-pass.json"
+  push:
+    tags:
+      - "v*"
+      - "release-*"
+
+permissions:
+  contents: read
+
+jobs:
+  strict-proof-gate:
+    name: Strict Security Proof
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify strict claims artifact
+        env:
+          ARTIFACT_PATH: ${{ github.event.inputs.artifact_path || 'examples/secure-defi-demo/test/fixtures/strict-claims-pass.json' }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "$ARTIFACT_PATH" ]; then
+            echo "Artifact file not found: $ARTIFACT_PATH"
+            exit 1
+          fi
+          node scripts/security/verify-secure-defi-claims.mjs --artifact "$ARTIFACT_PATH" --require-strict

--- a/docs/demos/secure-agent-defi.md
+++ b/docs/demos/secure-agent-defi.md
@@ -47,6 +47,7 @@ The output artifact is validated by zod schema:
 - run metadata (`runId`, timestamps, mode, account)
 - optional signed base attestation verification record
 - step-by-step status + details
+- deterministic security claim map (`claims[]` with `proof_status`, `tx_hash`, `evidence_path`)
 - summary counts
 - recommendations
 - markdown companion summary file (`secure-defi-demo-<runId>.md`)
@@ -79,6 +80,9 @@ Before execute mode:
 7. Optional session evidence:
    - `DEMO_SESSION_ACCOUNT_ADDRESS`
    - `DEMO_SESSION_KEY_PUBLIC_KEY`
+8. Optional strict proof gate:
+   - `STRICT_SECURITY_PROOF=1`
+   - optional `DEMO_ENABLE_STARKZAP_PROOF=1` + `DEMO_STARKZAP_EVIDENCE_PATH=<path>`
 
 ## Acceptance for v1
 
@@ -87,6 +91,7 @@ Before execute mode:
 - Forbidden selector probe returns blocked-entrypoint denial.
 - Execute mode produces transfer transaction evidence; Vesu deposit evidence is required when Vesu pool contracts are available (otherwise Vesu steps are explicitly skipped).
 - Artifacts are generated and stored for audit trail.
+- Strict profile fails unless required claims are all `proved` in `artifact.claims`.
 
 ## Next v2 Extensions
 

--- a/examples/secure-defi-demo/.env.example
+++ b/examples/secure-defi-demo/.env.example
@@ -51,5 +51,11 @@ DEMO_VESU_TOKEN=STRK
 DEMO_VESU_DEPOSIT_AMOUNT=0.01
 # DEMO_VESU_WITHDRAW_AMOUNT=0.005
 
+# Strict security proof profile (fails run if required claims are missing)
+# STRICT_SECURITY_PROOF=1
+# Optional Starkzap proof claim (required only when enabled)
+# DEMO_ENABLE_STARKZAP_PROOF=1
+# DEMO_STARKZAP_EVIDENCE_PATH=../starkzap-onboard-transfer/demo-evidence.json
+
 # Optional override if MCP server is built elsewhere
 # DEMO_MCP_ENTRY=../../packages/starknet-mcp-server/dist/index.js

--- a/examples/secure-defi-demo/README.md
+++ b/examples/secure-defi-demo/README.md
@@ -73,6 +73,25 @@ DEMO_BASE_ATTESTATION_PATH=./artifacts/base-attestation-demo.json \
 pnpm --filter @starknet-agentic/secure-defi-demo run:execute
 ```
 
+Strict security proof profile (issue #315):
+
+```bash
+STRICT_SECURITY_PROOF=1 \
+DEMO_AUTO_REGISTER_AGENT=1 \
+DEMO_ANCHOR_BASE_TO_ERC8004=1 \
+STARKNET_SIGNER_MODE=proxy \
+DEMO_SESSION_ACCOUNT_ADDRESS=0x... \
+DEMO_SESSION_KEY_PUBLIC_KEY=0x... \
+pnpm --filter @starknet-agentic/secure-defi-demo run:execute
+```
+
+Optional Starkzap claim input:
+
+```bash
+DEMO_ENABLE_STARKZAP_PROOF=1 \
+DEMO_STARKZAP_EVIDENCE_PATH=../starkzap-onboard-transfer/demo-evidence.json
+```
+
 ## Output
 
 Artifacts are written to `DEMO_OUTPUT_DIR` (default `./artifacts`).
@@ -82,6 +101,7 @@ Each run returns:
 - JSON artifact path + markdown summary path
 - run id
 - per-step status (`ok`, `failed`, `skipped`)
+- deterministic `claims[]` map (`proof_status`, `tx_hash`, `evidence_path`)
 - rejection probe evidence
 - Vesu before/after position snapshots (when executed)
 - recommendations for missing requirements

--- a/examples/secure-defi-demo/package.json
+++ b/examples/secure-defi-demo/package.json
@@ -8,6 +8,7 @@
     "run": "npx tsx run.ts --mode dry-run",
     "run:execute": "npx tsx run.ts --mode execute",
     "run:withdraw": "npx tsx run.ts --mode execute --with-withdraw",
+    "run:strict": "STRICT_SECURITY_PROOF=1 npx tsx run.ts --mode execute",
     "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {

--- a/examples/secure-defi-demo/run.ts
+++ b/examples/secure-defi-demo/run.ts
@@ -13,6 +13,7 @@ import {
   SessionStateSchema,
   buildSummary,
   type DemoArtifact,
+  type SecurityClaim,
   type SessionState,
   type StepResult,
 } from "./src/types.js";
@@ -87,7 +88,9 @@ function isTimeoutError(error: unknown): boolean {
 
 function isPolicyRejectionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /policy violation|blocked by policy|not covered by policy|exceeds policy|is not in the allowed|denied by policy/i.test(message);
+  return /policy violation|blocked by policy|not covered by policy|exceeds policy|is not in the allowed|denied by policy|spending:.*exceeds|spending.*denied/i.test(
+    message,
+  );
 }
 
 function isSessionRejectionError(error: unknown): boolean {
@@ -128,6 +131,98 @@ function normalizeHexAddress(value: string): string {
 
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function extractTxHash(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const match = value.match(/0x[0-9a-fA-F]+/);
+  return match?.[0] ?? null;
+}
+
+function findStep(steps: StepResult[], id: string): StepResult | undefined {
+  return steps.find((step) => step.id === id);
+}
+
+function buildClaims(steps: StepResult[], artifactPath: string, strict: boolean, starkzapEnabled: boolean): SecurityClaim[] {
+  const claims: SecurityClaim[] = [];
+
+  const policyStep = findStep(steps, "policy_rejection_probe");
+  const policyExpected = policyStep?.status === "ok" && policyStep.details?.expectedRejection === true;
+  const policyOnchainRevert = policyExpected && policyStep.details?.onchainRevert === true;
+  const policyTxHash =
+    asNonEmptyString(policyStep?.details?.txHash) ?? extractTxHash(asNonEmptyString(policyStep?.details?.reason));
+  claims.push({
+    claimId: "oversized_spend_denied",
+    required: strict,
+    proof_status:
+      strict ? (policyOnchainRevert && policyTxHash ? "proved" : "missing") : policyExpected ? "proved" : "missing",
+    tx_hash: policyTxHash,
+    evidence_path: "steps.policy_rejection_probe",
+    note: strict
+      ? "Strict mode requires on-chain REVERTED evidence with transaction hash."
+      : "Preflight policy rejection evidence.",
+  });
+
+  const selectorStep = findStep(steps, "forbidden_selector_probe");
+  const selectorProved = selectorStep?.status === "ok" && selectorStep.details?.expectedRejection === true;
+  claims.push({
+    claimId: "forbidden_selector_denied",
+    required: strict,
+    proof_status: selectorProved ? "proved" : "missing",
+    tx_hash: extractTxHash(asNonEmptyString(selectorStep?.details?.reason)),
+    evidence_path: "steps.forbidden_selector_probe",
+  });
+
+  const sessionStep = findStep(steps, "expired_session_probe");
+  const sessionProved = sessionStep?.status === "ok" && sessionStep.details?.expectedRejection === true;
+  claims.push({
+    claimId: "revoked_or_expired_session_blocked",
+    required: strict,
+    proof_status: sessionProved ? "proved" : "missing",
+    tx_hash: extractTxHash(asNonEmptyString(sessionStep?.details?.reason)),
+    evidence_path: "steps.expired_session_probe",
+    note: "Requires proxy signer path with inactive/revoked session evidence.",
+  });
+
+  const identityStep = findStep(steps, "erc8004_identity");
+  const identityProved = identityStep?.status === "ok";
+  claims.push({
+    claimId: "erc8004_identity_path",
+    required: strict,
+    proof_status: identityProved ? "proved" : "missing",
+    tx_hash: null,
+    evidence_path: "steps.erc8004_identity",
+  });
+
+  const anchorStep = findStep(steps, "base_attestation_anchor");
+  const anchorTx = asNonEmptyString(anchorStep?.details?.transactionHash) ?? null;
+  const anchorProved =
+    anchorStep?.status === "ok" &&
+    anchorTx !== null &&
+    asNonEmptyString(anchorStep.details?.readBack) === asNonEmptyString(anchorStep.details?.value);
+  claims.push({
+    claimId: "base_to_starknet_anchor_verified",
+    required: strict,
+    proof_status: anchorProved ? "proved" : "missing",
+    tx_hash: anchorTx,
+    evidence_path: "steps.base_attestation_anchor",
+  });
+
+  const starkzapStep = findStep(steps, "starkzap_receipt");
+  const starkzapTx = asNonEmptyString(starkzapStep?.details?.transactionHash) ?? null;
+  const starkzapProved = starkzapStep?.status === "ok" && starkzapTx !== null;
+  claims.push({
+    claimId: "starkzap_execution_receipt",
+    required: strict && starkzapEnabled,
+    proof_status: starkzapEnabled ? (starkzapProved ? "proved" : "missing") : "not_applicable",
+    tx_hash: starkzapTx,
+    evidence_path: starkzapEnabled
+      ? asNonEmptyString(starkzapStep?.details?.evidencePath) ?? "steps.starkzap_receipt"
+      : artifactPath,
+    note: starkzapEnabled ? undefined : "Set DEMO_ENABLE_STARKZAP_PROOF=1 to require this claim.",
+  });
+
+  return claims;
 }
 
 async function fetchReceipt(rpcUrl: string, txHash: string): Promise<unknown> {
@@ -190,6 +285,7 @@ function renderMarkdownSummary(artifact: DemoArtifact): string {
     "",
     `- Run ID: \`${artifact.runId}\``,
     `- Mode: \`${artifact.mode}\``,
+    `- Strict security proof: \`${artifact.strictSecurityProof}\``,
     `- Network: \`${artifact.networkLabel}\``,
     `- Account: \`${artifact.accountAddress}\``,
     `- Signer mode: \`${artifact.signerMode}\``,
@@ -212,6 +308,15 @@ function renderMarkdownSummary(artifact: DemoArtifact): string {
   for (const step of artifact.steps) {
     const notes = step.error ?? (step.details ? JSON.stringify(step.details) : "");
     lines.push(`| ${step.id} | ${step.status} | ${notes.replaceAll("|", "\\|")} |`);
+  }
+
+  if (artifact.claims.length > 0) {
+    lines.push("", "## Claims", "", "| Claim | Required | Status | Tx Hash | Evidence |", "| --- | --- | --- | --- | --- |");
+    for (const claim of artifact.claims) {
+      lines.push(
+        `| ${claim.claimId} | ${claim.required} | ${claim.proof_status} | ${claim.tx_hash ?? ""} | ${claim.evidence_path.replaceAll("|", "\\|")} |`,
+      );
+    }
   }
 
   if (artifact.recommendations.length > 0) {
@@ -340,7 +445,7 @@ async function main(): Promise<void> {
 
           if (!agentId && transactionHash && config.identityRegistryAddress) {
             const receipt = await fetchReceipt(config.rpcUrl, transactionHash);
-            agentId = parseRegisteredAgentIdFromReceipt(receipt, config.identityRegistryAddress);
+            agentId = parseRegisteredAgentIdFromReceipt(receipt, config.identityRegistryAddress) ?? undefined;
           }
 
           if (!agentId) {
@@ -416,10 +521,14 @@ async function main(): Promise<void> {
         ),
       );
     } else {
+      const anchoredBaseAttestation = baseAttestation;
+      if (!anchoredBaseAttestation) {
+        throw new Error("Missing base attestation for anchor step.");
+      }
       steps.push(
         await runStep("base_attestation_anchor", "Anchor Base attestation hash on ERC-8004 metadata", async () => {
           const key = config.baseAnchorMetadataKey;
-          const value = baseAttestation.sha256;
+          const value = anchoredBaseAttestation.sha256;
 
           const setResult = (await sidecar.callTool("starknet_set_agent_metadata", {
             agent_id: resolvedAgentId,
@@ -536,10 +645,14 @@ async function main(): Promise<void> {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (isPolicyRejectionError(error)) {
+          const txHash = extractTxHash(message);
+          const onchainRevert = /status\s*=\s*REVERTED/i.test(message) && txHash !== null;
           return {
             expectedRejection: true,
             amount: config.rejectionProbeAmount,
             reason: message,
+            txHash,
+            onchainRevert,
           };
         }
         throw error;
@@ -627,7 +740,8 @@ async function main(): Promise<void> {
     (step) =>
       step.id === "policy_rejection_probe" &&
       step.status === "ok" &&
-      Boolean(step.details && step.details.expectedRejection === true),
+      Boolean(step.details && step.details.expectedRejection === true) &&
+      (!config.strictSecurityProof || step.details?.onchainRevert === true),
   );
 
   if (config.mode === "execute" && policyProbePassed) {
@@ -773,6 +887,73 @@ async function main(): Promise<void> {
     steps.push(skippedStep("vesu_withdraw", "Execute Vesu withdraw", "Run with --mode execute --with-withdraw"));
   }
 
+  if (config.starkzapProofEnabled) {
+    steps.push(
+      await runStep("starkzap_receipt", "Attach Starkzap execution receipt evidence", async () => {
+        const rawPath = config.starkzapEvidencePath;
+        if (!rawPath) {
+          throw new Error("Missing DEMO_STARKZAP_EVIDENCE_PATH");
+        }
+        const evidencePath = path.resolve(rawPath);
+        if (!fs.existsSync(evidencePath)) {
+          throw new Error(`Starkzap evidence file not found: ${evidencePath}`);
+        }
+        const raw = fs.readFileSync(evidencePath, "utf8");
+        const txHash = extractTxHash(raw);
+        if (!txHash) {
+          throw new Error(`No Starkzap transaction hash found in evidence file: ${evidencePath}`);
+        }
+        return { evidencePath, transactionHash: txHash };
+      }),
+    );
+  } else {
+    steps.push(
+      skippedStep(
+        "starkzap_receipt",
+        "Attach Starkzap execution receipt evidence",
+        "Set DEMO_ENABLE_STARKZAP_PROOF=1 and DEMO_STARKZAP_EVIDENCE_PATH to enforce Starkzap proof claim.",
+      ),
+    );
+  }
+
+  const claims = buildClaims(
+    steps,
+    path.resolve(config.outputDir),
+    config.strictSecurityProof,
+    config.starkzapProofEnabled,
+  );
+  const missingRequiredClaims = claims.filter(
+    (claim) => claim.required && claim.proof_status !== "proved",
+  );
+
+  if (config.strictSecurityProof) {
+    const stamp = nowIso();
+    if (missingRequiredClaims.length > 0) {
+      steps.push({
+        id: "strict_security_gate",
+        title: "Enforce strict security proof gate",
+        status: "failed",
+        startedAt: stamp,
+        endedAt: stamp,
+        error: `Missing required claims: ${missingRequiredClaims.map((claim) => claim.claimId).join(", ")}`,
+        details: {
+          missingClaims: missingRequiredClaims.map((claim) => claim.claimId),
+        },
+      });
+    } else {
+      steps.push({
+        id: "strict_security_gate",
+        title: "Enforce strict security proof gate",
+        status: "ok",
+        startedAt: stamp,
+        endedAt: stamp,
+        details: {
+          verifiedClaims: claims.filter((claim) => claim.required).map((claim) => claim.claimId),
+        },
+      });
+    }
+  }
+
   const summary = buildSummary(steps);
   const recommendations: string[] = [];
 
@@ -786,6 +967,14 @@ async function main(): Promise<void> {
 
   if (!baseAttestation) {
     recommendations.push("Provide DEMO_BASE_ATTESTATION_PATH to include Base reputation evidence in artifact.");
+  }
+
+  if (config.strictSecurityProof && missingRequiredClaims.length > 0) {
+    recommendations.push(
+      `Strict proof gate failed. Missing required claims: ${missingRequiredClaims
+        .map((claim) => claim.claimId)
+        .join(", ")}`,
+    );
   }
 
   if (
@@ -810,9 +999,11 @@ async function main(): Promise<void> {
     endedAt: nowIso(),
     accountAddress: config.accountAddress,
     signerMode: config.signerMode,
+    strictSecurityProof: config.strictSecurityProof,
     baseAttestation,
     steps,
     summary,
+    claims,
     recommendations,
   });
 
@@ -823,7 +1014,7 @@ async function main(): Promise<void> {
     `${JSON.stringify({ artifactPath, markdownSummaryPath, summary, recommendations }, null, 2)}\n`,
   );
 
-  if (summary.failed > 0) {
+  if (summary.failed > 0 || (config.strictSecurityProof && missingRequiredClaims.length > 0)) {
     process.exitCode = 1;
   }
   } finally {

--- a/examples/secure-defi-demo/src/config.ts
+++ b/examples/secure-defi-demo/src/config.ts
@@ -124,6 +124,9 @@ export function loadRunConfig(args: CliArgs): RunConfig {
     sessionAccountAddress: optionalEnv("DEMO_SESSION_ACCOUNT_ADDRESS"),
     sessionKeyPublicKey: optionalEnv("DEMO_SESSION_KEY_PUBLIC_KEY"),
     expiredSessionProbeAmount: optionalEnv("DEMO_EXPIRED_SESSION_PROBE_AMOUNT") ?? "0.000001",
+    strictSecurityProof: optionalBoolEnv("STRICT_SECURITY_PROOF", false),
+    starkzapProofEnabled: optionalBoolEnv("DEMO_ENABLE_STARKZAP_PROOF", false),
+    starkzapEvidencePath: optionalEnv("DEMO_STARKZAP_EVIDENCE_PATH"),
     outputDir: args.outputDir ?? optionalEnv("DEMO_OUTPUT_DIR") ?? path.resolve(getDemoRootDir(), "artifacts"),
   });
 

--- a/examples/secure-defi-demo/src/types.ts
+++ b/examples/secure-defi-demo/src/types.ts
@@ -7,6 +7,24 @@ const DecimalAmountSchema = z
   .string()
   .regex(/^(0|[1-9]\d*)(\.\d+)?$/, "Must be a non-negative decimal amount");
 
+export const SecurityClaimIdSchema = z.enum([
+  "oversized_spend_denied",
+  "forbidden_selector_denied",
+  "revoked_or_expired_session_blocked",
+  "erc8004_identity_path",
+  "base_to_starknet_anchor_verified",
+  "starkzap_execution_receipt",
+]);
+export const SecurityClaimStatusSchema = z.enum(["proved", "missing", "not_applicable"]);
+export const SecurityClaimSchema = z.object({
+  claimId: SecurityClaimIdSchema,
+  proof_status: SecurityClaimStatusSchema,
+  required: z.boolean(),
+  tx_hash: z.string().regex(/^0x[0-9a-fA-F]+$/).nullable(),
+  evidence_path: z.string().min(1),
+  note: z.string().min(1).optional(),
+});
+
 export const StepStatusSchema = z.enum(["ok", "failed", "skipped"]);
 
 export const StepResultSchema = z.object({
@@ -20,6 +38,7 @@ export const StepResultSchema = z.object({
 });
 
 export type StepResult = z.infer<typeof StepResultSchema>;
+export type SecurityClaim = z.infer<typeof SecurityClaimSchema>;
 
 export const RunConfigSchema = z
   .object({
@@ -48,6 +67,9 @@ export const RunConfigSchema = z
     sessionAccountAddress: StarknetAddressSchema.optional(),
     sessionKeyPublicKey: StarknetAddressSchema.optional(),
     expiredSessionProbeAmount: DecimalAmountSchema,
+    strictSecurityProof: z.boolean().default(false),
+    starkzapProofEnabled: z.boolean().default(false),
+    starkzapEvidencePath: z.string().min(1).optional(),
     outputDir: z.string().min(1),
   })
   .superRefine((cfg, ctx) => {
@@ -68,6 +90,22 @@ export const RunConfigSchema = z
         code: "custom",
         path: hasSessionAccountAddress ? ["sessionKeyPublicKey"] : ["sessionAccountAddress"],
         message: "sessionAccountAddress and sessionKeyPublicKey must be provided together",
+      });
+    }
+
+    if (cfg.strictSecurityProof && cfg.mode !== "execute") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["mode"],
+        message: "STRICT_SECURITY_PROOF requires --mode execute",
+      });
+    }
+
+    if (cfg.starkzapProofEnabled && !cfg.starkzapEvidencePath) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["starkzapEvidencePath"],
+        message: "DEMO_STARKZAP_EVIDENCE_PATH is required when DEMO_ENABLE_STARKZAP_PROOF=1",
       });
     }
   });
@@ -97,6 +135,7 @@ export const DemoArtifactSchema = z.object({
   endedAt: z.string().datetime(),
   accountAddress: StarknetAddressSchema,
   signerMode: z.enum(["direct", "proxy"]),
+  strictSecurityProof: z.boolean().default(false),
   baseAttestation: z
     .object({
       path: z.string().min(1),
@@ -118,6 +157,7 @@ export const DemoArtifactSchema = z.object({
     failed: z.number().int().nonnegative(),
     skipped: z.number().int().nonnegative(),
   }),
+  claims: z.array(SecurityClaimSchema).default([]),
   recommendations: z.array(z.string()),
 });
 

--- a/examples/secure-defi-demo/test/core.test.ts
+++ b/examples/secure-defi-demo/test/core.test.ts
@@ -114,3 +114,33 @@ test("loadRunConfig requires proxy credentials in proxy mode", () => {
   const args = parseCliArgs();
   assert.throws(() => loadRunConfig(args), /Missing required env var: KEYRING_PROXY_URL/);
 });
+
+test("loadRunConfig enforces execute mode for strict security proof", () => {
+  process.argv = ["node", "run.ts", "--mode", "dry-run"];
+  process.env.STARKNET_SIGNER_MODE = "direct";
+  process.env.STARKNET_RPC_URL = "https://starknet-sepolia-rpc.publicnode.com";
+  process.env.STARKNET_ACCOUNT_ADDRESS = "0x123";
+  process.env.STARKNET_PRIVATE_KEY = "0xabc";
+  process.env.DEMO_MCP_ENTRY = path.resolve("README.md");
+  process.env.STRICT_SECURITY_PROOF = "1";
+
+  const args = parseCliArgs();
+  assert.throws(() => loadRunConfig(args), /STRICT_SECURITY_PROOF requires --mode execute/);
+});
+
+test("loadRunConfig requires Starkzap evidence path when Starkzap proof is enabled", () => {
+  process.argv = ["node", "run.ts", "--mode", "execute"];
+  process.env.STARKNET_SIGNER_MODE = "direct";
+  process.env.STARKNET_RPC_URL = "https://starknet-sepolia-rpc.publicnode.com";
+  process.env.STARKNET_ACCOUNT_ADDRESS = "0x123";
+  process.env.STARKNET_PRIVATE_KEY = "0xabc";
+  process.env.DEMO_MCP_ENTRY = path.resolve("README.md");
+  process.env.DEMO_ENABLE_STARKZAP_PROOF = "1";
+  delete process.env.DEMO_STARKZAP_EVIDENCE_PATH;
+
+  const args = parseCliArgs();
+  assert.throws(
+    () => loadRunConfig(args),
+    /DEMO_STARKZAP_EVIDENCE_PATH is required when DEMO_ENABLE_STARKZAP_PROOF=1/,
+  );
+});

--- a/examples/secure-defi-demo/test/fixtures/strict-claims-pass.json
+++ b/examples/secure-defi-demo/test/fixtures/strict-claims-pass.json
@@ -1,0 +1,47 @@
+{
+  "strictSecurityProof": true,
+  "claims": [
+    {
+      "claimId": "oversized_spend_denied",
+      "required": true,
+      "proof_status": "proved",
+      "tx_hash": "0x1111",
+      "evidence_path": "steps.policy_rejection_probe"
+    },
+    {
+      "claimId": "forbidden_selector_denied",
+      "required": true,
+      "proof_status": "proved",
+      "tx_hash": null,
+      "evidence_path": "steps.forbidden_selector_probe"
+    },
+    {
+      "claimId": "revoked_or_expired_session_blocked",
+      "required": true,
+      "proof_status": "proved",
+      "tx_hash": null,
+      "evidence_path": "steps.expired_session_probe"
+    },
+    {
+      "claimId": "erc8004_identity_path",
+      "required": true,
+      "proof_status": "proved",
+      "tx_hash": null,
+      "evidence_path": "steps.erc8004_identity"
+    },
+    {
+      "claimId": "base_to_starknet_anchor_verified",
+      "required": true,
+      "proof_status": "proved",
+      "tx_hash": "0x2222",
+      "evidence_path": "steps.base_attestation_anchor"
+    },
+    {
+      "claimId": "starkzap_execution_receipt",
+      "required": false,
+      "proof_status": "not_applicable",
+      "tx_hash": null,
+      "evidence_path": "artifacts/secure-defi-demo.json"
+    }
+  ]
+}

--- a/scripts/security/verify-secure-defi-claims.mjs
+++ b/scripts/security/verify-secure-defi-claims.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const REQUIRED_CLAIM_IDS = [
+  "oversized_spend_denied",
+  "forbidden_selector_denied",
+  "revoked_or_expired_session_blocked",
+  "erc8004_identity_path",
+  "base_to_starknet_anchor_verified",
+  "starkzap_execution_receipt",
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    const name = key.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      args[name] = "true";
+      continue;
+    }
+    args[name] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function loadArtifact(path) {
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const artifactPath = args.artifact;
+  const requireStrict = args["require-strict"] === "true" || args["require-strict"] === true;
+
+  if (!artifactPath) {
+    console.error("Usage: node scripts/security/verify-secure-defi-claims.mjs --artifact <path> [--require-strict]");
+    process.exit(2);
+  }
+
+  const artifact = loadArtifact(artifactPath);
+  const claims = Array.isArray(artifact?.claims) ? artifact.claims : [];
+  const byId = new Map(claims.map((claim) => [String(claim?.claimId), claim]));
+
+  if (requireStrict && artifact?.strictSecurityProof !== true) {
+    console.error("strict-proof-gate: BLOCK");
+    console.error("- strictSecurityProof is not true in artifact");
+    process.exit(1);
+  }
+
+  const missingClaimEntries = REQUIRED_CLAIM_IDS.filter((id) => !byId.has(id));
+  if (missingClaimEntries.length > 0) {
+    console.error("strict-proof-gate: BLOCK");
+    for (const claimId of missingClaimEntries) {
+      console.error(`- missing claim entry: ${claimId}`);
+    }
+    process.exit(1);
+  }
+
+  const blocking = claims.filter(
+    (claim) => claim?.required === true && String(claim?.proof_status) !== "proved",
+  );
+  if (blocking.length > 0) {
+    console.error("strict-proof-gate: BLOCK");
+    for (const claim of blocking) {
+      console.error(
+        `- ${claim.claimId} failed (status=${claim.proof_status}, tx_hash=${claim.tx_hash ?? "null"}, evidence_path=${claim.evidence_path ?? "unknown"})`,
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log(`strict-proof-gate: PASS (${claims.length} claims validated from ${artifactPath})`);
+}
+
+main();


### PR DESCRIPTION
## Summary
Implements strict proof gating for the secure DeFi demo and adds CI verification plumbing.

Closes #315.

## What changed
- Added `STRICT_SECURITY_PROOF=1` profile to `examples/secure-defi-demo` config/runtime.
- Added deterministic `claims[]` in artifact with `proof_status`, `tx_hash`, and `evidence_path`.
- Added strict gate step (`strict_security_gate`) that fails the run when required claims are missing.
- Added optional Starkzap claim wiring via `DEMO_ENABLE_STARKZAP_PROOF` + `DEMO_STARKZAP_EVIDENCE_PATH`.
- Added strict claim verification script: `scripts/security/verify-secure-defi-claims.mjs`.
- Added strict CI workflow (manual dispatch + release-tag path): `.github/workflows/strict-security-proof.yml`.
- Updated secure demo docs/env/examples and tests for strict mode config validation.

## Validation
- `pnpm --filter @starknet-agentic/secure-defi-demo exec tsc --noEmit`
- `pnpm --filter @starknet-agentic/secure-defi-demo test`
- `node scripts/security/verify-secure-defi-claims.mjs --artifact examples/secure-defi-demo/test/fixtures/strict-claims-pass.json --require-strict`
- `pnpm run build`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict security proof gating for secure demo execution
  * Added security claims tracking with proof status verification in artifacts
  * Added optional Starkzap proof claim integration support
  * Added new `run:strict` npm script for stricter execution mode

* **Documentation**
  * Added environment variable documentation for strict security profile configuration
  * Added optional Starkzap claim input documentation

* **Tests**
  * Added validation tests for strict security configuration constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->