### PR TITLE
docs: align canonical cairo skills and migration guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,21 @@
 {
-  "name": "starknet-agentic",
+  "name": "starknet-agentic-skills",
   "owner": {
     "name": "keep-starknet-strange"
   },
   "metadata": {
-    "description": "Starknet skills for AI agents: wallets, DeFi, identity, payments, and more",
+    "description": "Canonical Starknet Agentic skills bundle for wallets, DeFi, identity, payments, privacy, and Cairo build/audit workflows",
     "version": "1.0.0"
   },
   "plugins": [
     {
-      "name": "starknet-skills",
+      "name": "starknet-agentic-skills",
       "source": "./",
-      "description": "Complete Starknet agent toolkit: wallet management, DeFi operations, on-chain identity, P2P payments, and anonymous transactions"
+      "version": "1.0.0",
+      "description": "Canonical Starknet Agentic skills bundle for wallets, DeFi, identity, payments, privacy, and Cairo build/audit workflows",
+      "author": {
+        "name": "keep-starknet-strange"
+      }
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,28 @@
 {
-  "name": "starknet-skills",
-  "description": "Starknet skills for AI agents: wallets, DeFi, identity, payments, and privacy",
+  "name": "starknet-agentic-skills",
+  "version": "1.0.0",
+  "description": "Canonical Starknet Agentic skills bundle for wallets, DeFi, identity, payments, privacy, and Cairo build/audit workflows",
   "author": {
     "name": "keep-starknet-strange",
     "email": "starknet-agentic@proton.me"
-  }
+  },
+  "skills": [
+    "skills/account-abstraction",
+    "skills/cairo-auditor",
+    "skills/cairo-contract-authoring",
+    "skills/cairo-deploy",
+    "skills/cairo-optimization",
+    "skills/cairo-testing",
+    "skills/controller-cli",
+    "skills/huginn-onboard",
+    "skills/starknet-anonymous-wallet",
+    "skills/starknet-defi",
+    "skills/starknet-identity",
+    "skills/starknet-js",
+    "skills/starknet-mini-pay",
+    "skills/starknet-network-facts",
+    "skills/starknet-tongo",
+    "skills/starknet-wallet",
+    "skills/starkzap-sdk"
+  ]
 }

--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,22 @@ A consolidated infrastructure layer that provides:
 5. **CLI scaffolding** (`create-starknet-agent`) for project bootstrapping
 6. **E2E onboarding examples** for cross-chain agent registration
 
+## Canonical Cairo Skills
+
+The canonical Cairo skill source is now this repository (`starknet-agentic/skills/**`).
+
+Core skill boundaries:
+
+- `skills/cairo-contract-authoring/`: contract architecture and secure implementation workflow
+- `skills/cairo-testing/`: test strategy, regression harnesses, and test-quality patterns
+- `skills/cairo-optimization/`: profiling + post-correctness optimization pass
+- `skills/cairo-deploy/`: operational declare/deploy/verify runbooks
+- `skills/cairo-auditor/`: workflow-first security review with structured findings
+- `skills/account-abstraction/`: validate/execute/session-key correctness model
+- `skills/starknet-network-facts/`: protocol constraints affecting security assumptions
+
+Maintainer migration notes: `docs/CAIRO_SKILLS_MIGRATION.md`.
+
 ## References
 
 The `references/` directory is your knowledge base for agentic development on Starknet. Always consult it before writing skills, contracts, or integrations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Infrastructure layer for AI agents on Starknet. Provides Cairo smart contracts (
 | DeFi aggregation | `@avnu/avnu-sdk` | ^4.0.1 |
 | Schema validation | zod | ^3.23.0 |
 | TS testing | Vitest | -- |
-| Cairo testing | snforge | 0.56.0 |
+| Cairo testing | snforge | 0.54.1 (contracts/*), 0.57.0 (eval fixtures) |
 | Skills format | SKILL.md (YAML frontmatter + markdown) | AgentSkills spec |
 | Website | Next.js 16 + React 19 + Tailwind | -- |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Infrastructure layer for AI agents on Starknet. Provides Cairo smart contracts (
 | DeFi aggregation | `@avnu/avnu-sdk` | ^4.0.1 |
 | Schema validation | zod | ^3.23.0 |
 | TS testing | Vitest | -- |
-| Cairo testing | snforge | 0.54.1 |
+| Cairo testing | snforge | 0.56.0 |
 | Skills format | SKILL.md (YAML frontmatter + markdown) | AgentSkills spec |
 | Website | Next.js 16 + React 19 + Tailwind | -- |
 
@@ -46,7 +46,14 @@ starknet-agentic/
 │   ├── starknet-anonymous-wallet/        # Privacy-focused wallet (COMPLETE)
 │   ├── starknet-defi/                    # DeFi operations skill (TEMPLATE)
 │   ├── starknet-identity/                # Identity & reputation skill (TEMPLATE)
-│   └── huginn-onboard/                   # Cross-chain onboarding skill (COMPLETE)
+│   ├── huginn-onboard/                   # Cross-chain onboarding skill (COMPLETE)
+│   ├── cairo-contract-authoring/         # Canonical Cairo authoring workflow
+│   ├── cairo-testing/                    # Canonical Cairo testing workflow
+│   ├── cairo-optimization/               # Canonical Cairo optimization workflow
+│   ├── cairo-deploy/                     # Canonical Cairo deployment workflow
+│   ├── cairo-auditor/                    # Canonical Cairo security audit workflow
+│   ├── account-abstraction/              # Account/session-key correctness guidance
+│   └── starknet-network-facts/           # Protocol constraints for secure design
 ├── examples/
 │   ├── hello-agent/                      # Minimal E2E proof (WORKING)
 │   ├── defi-agent/                       # Arbitrage bot example (~337 lines)
@@ -73,6 +80,8 @@ starknet-agentic/
 
 NOTE: The Agent Account contract at `contracts/agent-account/` (~570 lines main contract) has 110 tests across 4 test suites (test_agent_account, test_execute_validate, test_security, test_agent_account_factory).
 
+Cairo skill migration and ownership notes are maintained in `docs/CAIRO_SKILLS_MIGRATION.md`.
+
 </structure>
 
 <commands>
@@ -89,6 +98,9 @@ NOTE: The Agent Account contract at `contracts/agent-account/` (~570 lines main 
 | Dev mode (website) | `pnpm dev` | `website/` |
 | Deploy contracts (Sepolia) | `bash scripts/deploy_sepolia.sh` | `contracts/erc8004-cairo/` |
 | Scaffold new agent | `npx create-starknet-agent@latest` | any |
+| Validate marketplace metadata | `python3 scripts/quality/validate_marketplace.py` | repo root |
+| Run Cairo skill cutover boundary check | `python3 scripts/check_cairo_skill_cutover.py` | repo root |
+| Run deterministic Cairo auditor benchmark | `python3 scripts/quality/benchmark_cairo_auditor.py --cases evals/cases/cairo_auditor_benchmark.jsonl --output /tmp/cairo-auditor.md` | repo root |
 
 </commands>
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,23 @@ For production environments, use MCP proxy signer mode rather than raw in-proces
 
 Skill packs live in [`skills/`](./skills/). Browse full catalog and install flows in [`skills/README.md`](./skills/README.md).
 
+Canonical Cairo skill stack in this repository:
+
+- [`skills/cairo-contract-authoring`](./skills/cairo-contract-authoring/) - contract architecture, components, and secure authoring workflow
+- [`skills/cairo-testing`](./skills/cairo-testing/) - snforge testing strategy and regression patterns
+- [`skills/cairo-optimization`](./skills/cairo-optimization/) - post-correctness optimization and profiling
+- [`skills/cairo-deploy`](./skills/cairo-deploy/) - declare/deploy/verify operational workflows
+- [`skills/cairo-auditor`](./skills/cairo-auditor/) - workflow-first audit orchestration and false-positive gating
+- [`skills/account-abstraction`](./skills/account-abstraction/) - account/session-key correctness boundaries
+- [`skills/starknet-network-facts`](./skills/starknet-network-facts/) - protocol/network constraints for security decisions
+
 Install one skill:
 
 ```bash
 npx skills add keep-starknet-strange/starknet-agentic/skills/starknet-wallet
 ```
+
+Maintainer migration notes for the Cairo cutover are in [`docs/CAIRO_SKILLS_MIGRATION.md`](./docs/CAIRO_SKILLS_MIGRATION.md).
 
 ## Standards and Interop
 

--- a/agents.md
+++ b/agents.md
@@ -4,6 +4,12 @@
 Defines how multiple AI agents coordinate when working on this repository. Use this when tasks are complex enough to benefit from delegation or parallel execution.
 </purpose>
 
+## Canonical Skills Source
+
+- Treat `starknet-agentic/skills/**` as the only active source for Cairo/Starknet skills.
+- Do not add new feature content to `keep-starknet-strange/starknet-skills`; only deprecation/move notices are allowed during transition.
+- Use `docs/CAIRO_SKILLS_MIGRATION.md` when mapping legacy skill names or links.
+
 ## Roles
 
 <roles>
@@ -150,6 +156,12 @@ pending --> in_progress --> in_review --> done
 ### Skills Tasks
 - Read `references/agentskills/SPECS.md` for format requirements
 - Read existing skills in `skills/` for patterns
+- For Cairo work, prefer this boundary:
+  - `cairo-contract-authoring` -> write contracts
+  - `cairo-testing` -> test contracts
+  - `cairo-optimization` -> optimize after correctness
+  - `cairo-deploy` -> deployment runbooks
+  - `cairo-auditor` -> security review and findings
 - Frontmatter must include: name, description, keywords, allowed-tools, user-invocable
 - Include starknet.js code examples with real token addresses
 - Include error codes with recovery guidance

--- a/docs/CAIRO_SKILLS_MIGRATION.md
+++ b/docs/CAIRO_SKILLS_MIGRATION.md
@@ -1,0 +1,45 @@
+# Cairo Skills Migration Guide
+
+This repository is now the canonical source for Cairo/Starknet skills.
+
+- Canonical repository: `keep-starknet-strange/starknet-agentic`
+- Canonical path: `skills/`
+- Previous source (`keep-starknet-strange/starknet-skills`) is transition-only and will be archived.
+
+## Skill Mapping
+
+| Previous (`starknet-skills`) | Canonical (`starknet-agentic`) |
+| --- | --- |
+| `cairo-security` | `skills/cairo-auditor` |
+| `cairo-contract-authoring` | `skills/cairo-contract-authoring` |
+| `cairo-testing` | `skills/cairo-testing` |
+| `cairo-optimization` | `skills/cairo-optimization` |
+| `cairo-toolchain` concepts | `skills/cairo-deploy` |
+| `account-abstraction` | `skills/account-abstraction` |
+| `starknet-network-facts` | `skills/starknet-network-facts` |
+
+## Maintainer Checklist
+
+1. Add or update Cairo skill content only in `starknet-agentic/skills/**`.
+2. Do not add new feature content to `starknet-skills`; only deprecation/move notices are allowed.
+3. Keep plugin install docs pointing to `keep-starknet-strange/starknet-agentic`.
+4. Keep `cairo-auditor` remote version checks pointing to `starknet-agentic/skills/cairo-auditor/VERSION`.
+5. Run quality checks before merge:
+   - `python3 scripts/quality/validate_marketplace.py`
+   - `python3 scripts/skills_manifest.py --check`
+   - `python3 scripts/check_cairo_skill_cutover.py`
+   - `python3 scripts/quality/check_vulndb_parity.py --cases evals/cases/cairo_auditor_benchmark.jsonl --cases evals/cases/cairo_auditor_realworld_benchmark.jsonl`
+6. For PRs touching `skills/**/SKILL.md`, `skills/**/references/**`, `evals/**`, or `datasets/**`, ensure the `Cairo Skills Full Evals` workflow passes.
+
+## Install Path Migration
+
+- Old: `/plugin marketplace add keep-starknet-strange/starknet-skills`
+- New: `/plugin marketplace add keep-starknet-strange/starknet-agentic`
+
+- Old plugin id: `starknet-skills`
+- Canonical plugin id in this repo: `starknet-agentic-skills`
+
+## Notes
+
+- Attribution and upstream provenance remain in skill metadata and `THIRD_PARTY.md`.
+- Historical benchmark data remains under `evals/` for regression tracking.

--- a/docs/CAIRO_SKILLS_MIGRATION.md
+++ b/docs/CAIRO_SKILLS_MIGRATION.md
@@ -35,6 +35,7 @@ This repository is now the canonical source for Cairo/Starknet skills.
 
 - Old: `/plugin marketplace add keep-starknet-strange/starknet-skills`
 - New: `/plugin marketplace add keep-starknet-strange/starknet-agentic`
+- New install: `/plugin install starknet-agentic-skills@keep-starknet-strange-starknet-agentic`
 
 - Old plugin id: `starknet-skills`
 - Canonical plugin id in this repo: `starknet-agentic-skills`

--- a/scripts/audit-pipeline/ingest_catalog.py
+++ b/scripts/audit-pipeline/ingest_catalog.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 
-USER_AGENT = "starknet-skills-audit-ingest/1.0 (+https://github.com/keep-starknet-strange/starknet-skills)"
+USER_AGENT = "starknet-agentic-audit-ingest/1.0 (+https://github.com/keep-starknet-strange/starknet-agentic)"
 DEFAULT_TIMEOUT_SECONDS = 45
 EXTRACTOR_VERSION = "ingest_catalog.py@v1"
 

--- a/scripts/quality/parity_check.py
+++ b/scripts/quality/parity_check.py
@@ -76,13 +76,13 @@ def plugin_identifier() -> str:
         raw = plugin_path.read_text(encoding="utf-8")
         obj = json.loads(raw)
     except (OSError, json.JSONDecodeError):
-        return "starknet-skills"
+        return "starknet-agentic-skills"
 
     if isinstance(obj, dict):
         name = obj.get("name")
         if isinstance(name, str) and name:
             return name
-    return "starknet-skills"
+    return "starknet-agentic-skills"
 
 
 def is_missing_binary(result: subprocess.CompletedProcess[str]) -> bool:

--- a/scripts/quality/scan_external_repos.py
+++ b/scripts/quality/scan_external_repos.py
@@ -229,7 +229,7 @@ def main() -> int:
     parser.add_argument("--output-findings-jsonl", default="")
     parser.add_argument(
         "--workdir",
-        default=str(Path(tempfile.gettempdir()) / "starknet-skills-external-scan"),
+        default=str(Path(tempfile.gettempdir()) / "starknet-agentic-external-scan"),
     )
     parser.add_argument("--exclude", default="test,tests,mock,mocks,example,examples,preset,presets,fixture,fixtures,vendor,vendors")
     parser.add_argument("--detectors", default="")

--- a/scripts/quality/sierra_parallel_signal.py
+++ b/scripts/quality/sierra_parallel_signal.py
@@ -90,7 +90,7 @@ def _safe_repo_rel(path: Path, repo_dir: Path) -> str:
 
 @functools.cache
 def _sandbox_home() -> Path:
-    sandbox = Path(tempfile.mkdtemp(prefix=f"starknet-skills-sierra-home-{os.getpid()}-")).resolve()
+    sandbox = Path(tempfile.mkdtemp(prefix=f"starknet-agentic-sierra-home-{os.getpid()}-")).resolve()
     (sandbox / ".cache").mkdir(parents=True, exist_ok=True)
     (sandbox / ".config").mkdir(parents=True, exist_ok=True)
     (sandbox / ".local" / "share").mkdir(parents=True, exist_ok=True)
@@ -945,7 +945,7 @@ def main() -> int:
     parser.add_argument("--scan-id", required=True)
     parser.add_argument("--repos", nargs="*", default=[])
     parser.add_argument("--repos-file", default="")
-    parser.add_argument("--workdir", default="/tmp/starknet-skills-sierra-scan")
+    parser.add_argument("--workdir", default="/tmp/starknet-agentic-sierra-scan")
     parser.add_argument("--git-host", default="https://github.com")
     parser.add_argument("--detector-findings-jsonl", default="")
     parser.add_argument("--output-json", required=True)

--- a/scripts/quality/validate_skills.py
+++ b/scripts/quality/validate_skills.py
@@ -2,7 +2,7 @@
 """Repository-level SKILL.md quality checks.
 
 This validator enforces a minimal, deterministic subset of modern skill-authoring
-standards for the starknet-skills repository.
+standards for the starknet-agentic repository.
 """
 
 from __future__ import annotations

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,6 +2,8 @@
 
 Production-ready skills for AI agents operating on Starknet. Built for the Agent Skills specification, compatible with 35+ agent platforms including Claude Code, Cursor, GitHub Copilot, and more.
 
+Canonical note: this repository is now the canonical source for Cairo/Starknet skills. See [`docs/CAIRO_SKILLS_MIGRATION.md`](../docs/CAIRO_SKILLS_MIGRATION.md) for maintainer migration details.
+
 ## Available Skills
 
 | Skill | Description | Status |
@@ -53,7 +55,7 @@ npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-auditor
 /plugin marketplace add keep-starknet-strange/starknet-agentic
 
 # Install all skills
-/plugin install starknet-skills@keep-starknet-strange-starknet-agentic
+/plugin install starknet-agentic-skills@keep-starknet-strange-starknet-agentic
 
 # Or install individual skill plugins
 /plugin install starknet-wallet@keep-starknet-strange-starknet-agentic
@@ -86,7 +88,7 @@ Installed skills don't auto-update. To get the latest version:
 npx skills add keep-starknet-strange/starknet-agentic --force
 
 # Claude Code - update plugin
-/plugin update starknet-skills@keep-starknet-strange-starknet-agentic
+/plugin update starknet-agentic-skills@keep-starknet-strange-starknet-agentic
 
 # Git clone - pull latest
 git pull origin main

--- a/skills/account-abstraction/SKILL.md
+++ b/skills/account-abstraction/SKILL.md
@@ -2,7 +2,7 @@
 name: account-abstraction
 description: Starknet account abstraction correctness and security guidance for validate/execute paths, nonces, signatures, and session policies.
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"0.1.1","org":"keep-starknet-strange","source":"starknet-skills"}
+metadata: {"author":"starknet-agentic","version":"0.1.2","org":"keep-starknet-strange","source":"starknet-agentic","migrated_from":"starknet-skills"}
 keywords: [starknet, account-abstraction, signatures, nonces, session-keys, policy]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -30,17 +30,17 @@ Not a substitute for a formal audit — but the check you should never skip.
 **Claude Code CLI:**
 
 ```bash
-git clone https://github.com/keep-starknet-strange/starknet-skills.git \
+git clone https://github.com/keep-starknet-strange/starknet-agentic.git \
   && mkdir -p ~/.claude/commands/cairo-auditor \
-  && cp -R starknet-skills/cairo-auditor/. ~/.claude/commands/cairo-auditor/
+  && cp -R starknet-agentic/skills/cairo-auditor/. ~/.claude/commands/cairo-auditor/
 ```
 
 **Cursor (manual guidance only):**
 
 ```bash
-git clone https://github.com/keep-starknet-strange/starknet-skills.git \
+git clone https://github.com/keep-starknet-strange/starknet-agentic.git \
   && mkdir -p docs/cairo-auditor \
-  && cp -R starknet-skills/cairo-auditor/references/. docs/cairo-auditor/
+  && cp -R starknet-agentic/skills/cairo-auditor/references/. docs/cairo-auditor/
 ```
 
 Cursor does not execute this package as a runnable `/cairo-auditor` command. Use Claude Code CLI or Plugin Marketplace for the executable orchestrator flow. In Cursor, treat these files as reference guidance only.
@@ -49,18 +49,18 @@ There is no official global `~/.cursor/skills` install path for this package.
 **Claude Code Plugin Marketplace:**
 
 ```bash
-/plugin marketplace add keep-starknet-strange/starknet-skills
-/plugin install cairo-auditor@starknet-skills
+/plugin marketplace add keep-starknet-strange/starknet-agentic
+/plugin install cairo-auditor@keep-starknet-strange-starknet-agentic
 ```
 
 **Update to latest:**
 
 ```bash
-cd starknet-skills && git pull
+cd starknet-agentic && git pull
 # Claude Code CLI:
-cp -R cairo-auditor/. ~/.claude/commands/cairo-auditor/
+cp -R skills/cairo-auditor/. ~/.claude/commands/cairo-auditor/
 # Cursor docs refresh (manual guidance only):
-cp -R cairo-auditor/references/. docs/cairo-auditor/
+cp -R skills/cairo-auditor/references/. docs/cairo-auditor/
 ```
 
 ## Usage

--- a/skills/cairo-auditor/SKILL.md
+++ b/skills/cairo-auditor/SKILL.md
@@ -197,16 +197,16 @@ Before doing anything else, print this exactly:
 
 ## Version Check
 
-After printing the banner, run two parallel tool calls: (a) Read the local `VERSION` file from the same directory as this skill, (b) Bash `curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-skills/main/cairo-auditor/VERSION`. If the remote fetch succeeds and the versions differ, print:
+After printing the banner, run two parallel tool calls: (a) Read the local `VERSION` file from the same directory as this skill, (b) Bash `curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/VERSION`. If the remote fetch succeeds and the versions differ, print:
 
-> You are not using the latest version. Run `/plugin marketplace update keep-starknet-strange/starknet-skills` for best security coverage.
+> You are not using the latest version. Run `/plugin update starknet-agentic-skills@keep-starknet-strange-starknet-agentic` for best security coverage.
 
 Then continue normally. If the fetch fails (offline, timeout), skip silently.
 
 Use this command for the remote check:
 
 ```bash
-curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-skills/main/cairo-auditor/VERSION
+curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/VERSION
 ```
 
 ## Limitations

--- a/skills/cairo-contract-authoring/SKILL.md
+++ b/skills/cairo-contract-authoring/SKILL.md
@@ -2,7 +2,7 @@
 name: cairo-contract-authoring
 description: Cairo smart-contract authoring on Starknet. Trigger on "write a contract", "create a contract", "implement this in Cairo", "add storage/events/interface", "compose components". Guides structure, security patterns, and component wiring.
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"0.2.0","org":"keep-starknet-strange","source":"starknet-skills","contributors":["kronosapiens/dojoengine"]}
+metadata: {"author":"starknet-agentic","version":"0.2.1","org":"keep-starknet-strange","source":"starknet-agentic","migrated_from":"starknet-skills","contributors":["kronosapiens/dojoengine"]}
 keywords: [cairo, contract-authoring, starknet, openzeppelin, components, storage, events, interfaces]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true

--- a/skills/cairo-testing/SKILL.md
+++ b/skills/cairo-testing/SKILL.md
@@ -2,7 +2,7 @@
 name: cairo-testing
 description: Cairo smart-contract testing with snforge. Trigger on "write tests", "add unit tests", "fuzz test", "integration test", "test this contract", "regression test". Guides test strategy, cheatcode usage, and coverage.
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"0.2.0","org":"keep-starknet-strange","source":"starknet-skills"}
+metadata: {"author":"starknet-agentic","version":"0.2.1","org":"keep-starknet-strange","source":"starknet-agentic","migrated_from":"starknet-skills"}
 keywords: [cairo, testing, snforge, starknet-foundry, fuzzing, integration]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true

--- a/skills/starknet-network-facts/SKILL.md
+++ b/skills/starknet-network-facts/SKILL.md
@@ -2,7 +2,7 @@
 name: starknet-network-facts
 description: Starknet network-level constraints and protocol facts that impact contract safety and agent reasoning.
 license: Apache-2.0
-metadata: {"author":"starknet-agentic","version":"0.1.1","org":"keep-starknet-strange","source":"starknet-skills"}
+metadata: {"author":"starknet-agentic","version":"0.1.2","org":"keep-starknet-strange","source":"starknet-agentic","migrated_from":"starknet-skills"}
 keywords: [starknet, network, fees, tx-version, sequencer, inclusion]
 allowed-tools: [Bash, Read, Write, Glob, Grep, Task]
 user-invocable: true


### PR DESCRIPTION
## Summary
- aligns top-level maintainer docs with the Cairo skills cutover (`README.md`, `AGENT.md`, `CLAUDE.md`, `agents.md`)
- adds maintainer migration guide: `docs/CAIRO_SKILLS_MIGRATION.md`
- updates plugin metadata to a canonical bundle id (`starknet-agentic-skills`) with explicit `version` and `skills[]`
- updates skills install/update examples to canonical plugin id
- rewires `cairo-auditor` update/version-check references from `starknet-skills` to `starknet-agentic`
- updates migrated skill metadata `source`/`migrated_from` fields for provenance clarity
- normalizes quality/pipeline script labels and temp prefixes from `starknet-skills` to `starknet-agentic`

## Validation
- `python3 scripts/quality/validate_marketplace.py`
- `python3 scripts/skills_manifest.py --check`
- `python3 scripts/check_cairo_skill_cutover.py`
- `python3 scripts/quick_validate_skill.py skills/account-abstraction skills/cairo-auditor skills/cairo-contract-authoring skills/cairo-testing skills/starknet-network-facts`

## Notes
- this PR is stacked on #351 (`codex/pr3-ci-evals`)
