### PR TITLE
docs: make cairo-auditor first run zero-friction

### DIFF
--- a/skills/QUICKSTART_2MIN.md
+++ b/skills/QUICKSTART_2MIN.md
@@ -3,6 +3,8 @@
 Goal: get a concrete `security-review-*.md` artifact from `cairo-auditor` in under
 2 minutes.
 
+Use your own Cairo project first. If you do not have one handy, create a temporary `.cairo` file and run the same prompts against that path.
+
 ## 1) Codex
 
 Install:
@@ -20,7 +22,7 @@ For an immutable install, replace `main` with a commit SHA you trust.
 Prompt:
 
 ```text
-Use cairo-auditor default mode on this repo with --file-output.
+Run cairo-auditor on path/to/your_contract.cairo with --file-output.
 Output only the final report.
 Report only concrete exploitable issues with severity and file:line references.
 ```
@@ -44,7 +46,7 @@ Note: marketplace/plugin installs resolve published bundle metadata rather than 
 Prompt:
 
 ```text
-Use /starknet-agentic-skills:cairo-auditor --file-output to audit this repo in default mode.
+/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output
 Output only the final report with severity, exploit path, and patch guidance.
 ```
 
@@ -65,7 +67,7 @@ Note: this command is not Git-ref pinned as written.
 Prompt (in your host runtime after install):
 
 ```text
-Use cairo-auditor default mode on contracts/**/*.cairo with --file-output.
+Use cairo-auditor on path/to/your_contract.cairo with --file-output.
 Output only the final report.
 Only include defensible findings with file:line references.
 ```

--- a/skills/QUICKSTART_2MIN.md
+++ b/skills/QUICKSTART_2MIN.md
@@ -3,7 +3,7 @@
 Goal: get a concrete `security-review-*.md` artifact from `cairo-auditor` in under
 2 minutes.
 
-Use your own Cairo project first. If you do not have one handy, create a temporary `.cairo` file and run the same prompts against that path.
+Use your own Cairo project first. If you do not have one handy, create a temporary `.cairo` file using the [demo file instructions](./cairo-auditor/README.md#no-cairo-project-handy) and run the same prompts against that path.
 
 ## 1) Codex
 

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -41,7 +41,7 @@ Only the badged surfaces above are currently verified in this repository.
 
 ## Try it now
 
-Install one skill, run the deterministic demo contract, and confirm that a `security-review-*.md` artifact was written.
+Install one skill, open any Cairo project, and run `cairo-auditor` on your own contract file. If you do not have a project handy yet, use the self-contained demo file below.
 
 ```bash
 # 1) Install (Codex)
@@ -53,12 +53,12 @@ python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-g
 # Restart Codex so the skill is picked up
 ```
 
+Claude Code users: use the marketplace install under [Install](#install), then run the command below against your local Cairo file.
+
 ```text
 # 2) Prompt
-# The demo fixture path below assumes you are inside a local clone of this repository.
-# If not, replace it with your own local .cairo file path.
-Codex: Run cairo-auditor deep on skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo with --file-output. Output only the final report.
-Claude Code: /starknet-agentic-skills:cairo-auditor deep skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo --file-output
+Codex: Run cairo-auditor on path/to/your_contract.cairo with --file-output. Output only the final report.
+Claude Code: /starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output
 ```
 
 ```bash
@@ -68,11 +68,41 @@ ls -lt security-review-*.md | head -n 1
 
 Expected artifact: `security-review-*.md`
 
-For full host-integrity checks (`Execution Integrity: FULL`, specialist bundles, capability file), use the advanced verification flow later in this README or run the helper below from a local clone:
+Want adversarial multi-agent review after the first successful run?
+
+```text
+Codex: Run cairo-auditor deep on path/to/your_contract.cairo with --file-output. Output only the final report.
+Claude Code: /starknet-agentic-skills:cairo-auditor deep path/to/your_contract.cairo --file-output
+```
+
+### No Cairo project handy?
+
+Create a minimal vulnerable contract locally and audit that file instead.
 
 ```bash
-bash skills/cairo-auditor/scripts/doctor.sh --report-dir .
+cat > /tmp/test_vuln.cairo <<'EOF'
+#[starknet::contract]
+mod VulnerableUpgrade {
+    use starknet::ClassHash;
+    use starknet::syscalls::replace_class_syscall;
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    fn upgrade(ref self: ContractState, new_class: ClassHash) {
+        replace_class_syscall(new_class).unwrap();
+    }
+}
+EOF
 ```
+
+```text
+Codex: Run cairo-auditor on /tmp/test_vuln.cairo with --file-output. Output only the final report.
+Claude Code: /starknet-agentic-skills:cairo-auditor /tmp/test_vuln.cairo --file-output
+```
+
+You should see an upgrade-related finding against the ungated `replace_class_syscall` path.
 
 ## Audit pipeline
 
@@ -320,6 +350,16 @@ This is useful for conservative release gates and benchmark runs.
 **What AI catches well.** Missing access controls, CEI violations, unsafe upgrades, zero-address initialization, unbounded loops, stale reads, type confusion.
 
 AI catches what humans forget to check. Humans catch what AI cannot reason about. You need both.
+
+## Deterministic repo fixture (maintainers / CI)
+
+If you want the stable regression target used by this repository, clone `keep-starknet-strange/starknet-agentic` and audit:
+
+```text
+skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo
+```
+
+That fixture is intentionally vulnerable and should reliably produce three findings: missing access control on upgrade, missing timelock, and missing non-zero class-hash guard.
 
 ## How it works
 

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -97,6 +97,8 @@ mod VulnerableUpgrade {
 EOF
 ```
 
+Windows users: create the same contents in a local file such as `test_vuln.cairo` with your editor or PowerShell, then run the same prompt against that file path.
+
 ```text
 Codex: Run cairo-auditor on /tmp/test_vuln.cairo with --file-output. Output only the final report.
 Claude Code: /starknet-agentic-skills:cairo-auditor /tmp/test_vuln.cairo --file-output
@@ -351,7 +353,7 @@ This is useful for conservative release gates and benchmark runs.
 
 AI catches what humans forget to check. Humans catch what AI cannot reason about. You need both.
 
-## Deterministic repo fixture (maintainers / CI)
+## Deterministic repo fixture (maintainers / manual regression)
 
 If you want the stable regression target used by this repository, clone `keep-starknet-strange/starknet-agentic` and audit:
 
@@ -360,6 +362,8 @@ skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo
 ```
 
 That fixture is intentionally vulnerable and should reliably produce three findings: missing access control on upgrade, missing timelock, and missing non-zero class-hash guard.
+
+This path is primarily for manual maintainer regression. Repository CI runs separate validation checks for the skill and report contract rather than asking users to invoke this fixture path directly.
 
 ## How it works
 

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -80,7 +80,8 @@ Claude Code: /starknet-agentic-skills:cairo-auditor deep path/to/your_contract.c
 Create a minimal vulnerable contract locally and audit that file instead.
 
 ```bash
-cat > /tmp/test_vuln.cairo <<'EOF'
+TMP_CAIRO_FILE="$(mktemp "${TMPDIR:-/tmp}/cairo-auditor-demo.XXXXXX.cairo")"
+cat > "$TMP_CAIRO_FILE" <<'EOF'
 #[starknet::contract]
 mod VulnerableUpgrade {
     use starknet::ClassHash;
@@ -95,13 +96,14 @@ mod VulnerableUpgrade {
     }
 }
 EOF
+printf 'Demo contract written to %s\n' "$TMP_CAIRO_FILE"
 ```
 
 Windows users: create the same contents in a local file such as `test_vuln.cairo` with your editor or PowerShell, then run the same prompt against that file path.
 
 ```text
-Codex: Run cairo-auditor on /tmp/test_vuln.cairo with --file-output. Output only the final report.
-Claude Code: /starknet-agentic-skills:cairo-auditor /tmp/test_vuln.cairo --file-output
+Codex: Run cairo-auditor on the temp file path printed above with --file-output. Output only the final report.
+Claude Code: /starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
 ```
 
 You should see an upgrade-related finding against the ungated `replace_class_syscall` path.

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -102,8 +102,10 @@ printf 'Demo contract written to %s\n' "$TMP_CAIRO_FILE"
 Windows users: create the same contents in a local file such as `test_vuln.cairo` with your editor or PowerShell, then run the same prompt against that file path.
 
 ```text
-Codex: Run cairo-auditor on the temp file path printed above with --file-output. Output only the final report.
-Claude Code: /starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
+macOS/Linux (Codex): Run cairo-auditor on the temp file path printed above with --file-output. Output only the final report.
+macOS/Linux (Claude Code): /starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
+Windows (Codex): Run cairo-auditor on .\test_vuln.cairo with --file-output. Output only the final report.
+Windows (Claude Code): /starknet-agentic-skills:cairo-auditor .\test_vuln.cairo --file-output
 ```
 
 You should see an upgrade-related finding against the ungated `replace_class_syscall` path.

--- a/website/app/components/sections/GetStarted.tsx
+++ b/website/app/components/sections/GetStarted.tsx
@@ -4,18 +4,12 @@ import { InstallCommand } from "@/components/Hero/InstallCommand";
 import { StepCard } from "@/components/ui/StepCard";
 
 const CODEX_CAIRO_AUDITOR_COMMAND = [
-  'CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"',
-  'python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py" \\',
-  "  --repo keep-starknet-strange/starknet-agentic \\",
-  "  --path skills/cairo-auditor \\",
-  "  --ref main",
+  "Run cairo-auditor on path/to/your_contract.cairo with --file-output.",
+  "Output only the final report.",
 ].join("\n");
 
 const CLAUDE_CAIRO_AUDITOR_COMMAND = [
-  "/plugin marketplace add keep-starknet-strange/starknet-agentic",
-  "/plugin install starknet-agentic-skills@starknet-agentic-skills --scope user",
-  "/reload-plugins",
-  "/starknet-agentic-skills:cairo-auditor deep skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo --file-output",
+  "/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output",
 ].join("\n");
 
 export function GetStarted() {
@@ -44,7 +38,7 @@ export function GetStarted() {
                 Try Cairo Auditor First
               </h3>
               <p className="text-neo-dark/70 max-w-2xl">
-                Fastest path to a concrete artifact: run the deterministic vulnerable fixture and generate a real{" "}
+                Install the skill once, then run it on any local Cairo contract in your own workspace to generate a real{" "}
                 <code className="px-1.5 py-0.5 bg-neo-dark/5 rounded text-sm">security-review-*.md</code> report before
                 you wire the rest of the stack.
               </p>
@@ -73,7 +67,7 @@ export function GetStarted() {
           </div>
 
           <p className="mt-4 text-sm text-neo-dark/70">
-            The demo fixture path in the command above assumes you are inside a local clone of this repository. If not, clone the repo first or replace the path with your own local Cairo contract.
+            Use your own local Cairo path first. If you do not have a project handy yet, the 30-second guide includes a self-contained vulnerable demo file and the maintainer regression fixture.
           </p>
         </div>
 

--- a/website/app/components/sections/GetStarted.tsx
+++ b/website/app/components/sections/GetStarted.tsx
@@ -3,12 +3,12 @@ import { STEPS, EXTERNAL_LINKS } from "@/data/get-started";
 import { InstallCommand } from "@/components/Hero/InstallCommand";
 import { StepCard } from "@/components/ui/StepCard";
 
-const CODEX_CAIRO_AUDITOR_COMMAND = [
+const CODEX_CAIRO_AUDITOR_PROMPT = [
   "Run cairo-auditor on path/to/your_contract.cairo with --file-output.",
   "Output only the final report.",
 ].join("\n");
 
-const CLAUDE_CAIRO_AUDITOR_COMMAND = [
+const CLAUDE_CAIRO_AUDITOR_PROMPT = [
   "/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output",
 ].join("\n");
 
@@ -51,17 +51,21 @@ export function GetStarted() {
             </Link>
           </div>
 
+          <p className="mb-4 text-sm text-neo-dark/70">
+            First time here? Install the skill first from the guide, then come back and run one of the prompts below.
+          </p>
+
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="border-2 border-neo-dark/10 rounded p-4">
               <p className="text-sm font-heading font-bold text-neo-dark mb-2">Codex</p>
               <code className="block whitespace-pre-wrap break-all text-xs md:text-sm bg-neo-dark text-white rounded px-3 py-3">
-                {CODEX_CAIRO_AUDITOR_COMMAND}
+                {CODEX_CAIRO_AUDITOR_PROMPT}
               </code>
             </div>
             <div className="border-2 border-neo-dark/10 rounded p-4">
               <p className="text-sm font-heading font-bold text-neo-dark mb-2">Claude Code</p>
               <code className="block whitespace-pre-wrap break-all text-xs md:text-sm bg-neo-dark text-white rounded px-3 py-3">
-                {CLAUDE_CAIRO_AUDITOR_COMMAND}
+                {CLAUDE_CAIRO_AUDITOR_PROMPT}
               </code>
             </div>
           </div>

--- a/website/app/components/sections/GetStarted.tsx
+++ b/website/app/components/sections/GetStarted.tsx
@@ -38,7 +38,7 @@ export function GetStarted() {
                 Try Cairo Auditor First
               </h3>
               <p className="text-neo-dark/70 max-w-2xl">
-                Install the skill once, then run it on any local Cairo contract in your own workspace to generate a real{" "}
+                After installing the skill from the 30-second guide, run it on any local Cairo contract in your own workspace to generate a real{" "}
                 <code className="px-1.5 py-0.5 bg-neo-dark/5 rounded text-sm">security-review-*.md</code> report before
                 you wire the rest of the stack.
               </p>
@@ -47,12 +47,12 @@ export function GetStarted() {
               href="/docs/skills/cairo-auditor"
               className="neo-btn-secondary text-sm py-2 px-4 whitespace-nowrap"
             >
-              Open 30-second guide
+              Install + 30-second guide
             </Link>
           </div>
 
           <p className="mb-4 text-sm text-neo-dark/70">
-            First time here? Install the skill first from the guide, then come back and run one of the prompts below.
+            First time here? Step 1 is the install flow in the guide. Step 2 is one of the runtime prompts below.
           </p>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/website/content/docs/skills/cairo-auditor.mdx
+++ b/website/content/docs/skills/cairo-auditor.mdx
@@ -18,11 +18,11 @@ The `cairo-auditor` skill is the repo's security-review orchestrator for Cairo a
 Only the badged surfaces above are currently verified in this repository.
 
 <Callout type="success" title="Try it now">
-Audit the deterministic demo fixture first so you can verify the pipeline and get a real <code>security-review-*.md</code> artifact quickly.
+Install the skill, open any Cairo project, and audit one local <code>.cairo</code> file first. That is the real developer path and the fastest way to get a concrete <code>security-review-*.md</code> artifact.
 </Callout>
 
-<Callout type="info" title="Demo fixture path">
-The fixture path below assumes you are inside a local clone of <code>keep-starknet-strange/starknet-agentic</code>. If not, replace it with your own local <code>.cairo</code> file path.
+<Callout type="info" title="No Cairo project handy?">
+Use the self-contained demo file further below. The repo fixture is still available, but it now lives under maintainer verification instead of the first-run path.
 </Callout>
 
 ```bash
@@ -34,18 +34,64 @@ python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-g
   --ref main
 ```
 
+Claude Code users: use the marketplace install from the Installation section below, then run the same command against your local Cairo file.
+
 ```text
 # Codex prompt
-Run cairo-auditor deep on skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo with --file-output.
+Run cairo-auditor on path/to/your_contract.cairo with --file-output.
 Output only the final report.
 ```
 
 ```text
 # Claude Code command
-/starknet-agentic-skills:cairo-auditor deep skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo --file-output
+/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output
 ```
 
 Expected artifact: `security-review-*.md`
+
+### Want deeper adversarial review?
+
+After the first successful run, rerun the same target in `deep` mode:
+
+```text
+# Codex prompt
+Run cairo-auditor deep on path/to/your_contract.cairo with --file-output.
+Output only the final report.
+```
+
+```text
+# Claude Code command
+/starknet-agentic-skills:cairo-auditor deep path/to/your_contract.cairo --file-output
+```
+
+### No Cairo project handy?
+
+Create a minimal vulnerable contract locally and audit that file instead:
+
+```bash
+cat > /tmp/test_vuln.cairo <<'EOF'
+#[starknet::contract]
+mod VulnerableUpgrade {
+    use starknet::ClassHash;
+    use starknet::syscalls::replace_class_syscall;
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    fn upgrade(ref self: ContractState, new_class: ClassHash) {
+        replace_class_syscall(new_class).unwrap();
+    }
+}
+EOF
+```
+
+```text
+Run cairo-auditor on /tmp/test_vuln.cairo with --file-output.
+Output only the final report.
+```
+
+This should yield an upgrade-related finding against the ungated `replace_class_syscall` path.
 
 ## Rendered report preview
 
@@ -114,17 +160,17 @@ Use <code>--scope user</code> as the default. Use <code>--scope local</code> onl
 
 ## 30-Second Happy Path
 
-Run one deep audit and confirm that a report artifact was written.
+Run one default audit on your own contract and confirm that a report artifact was written.
 
 ```text
 # Codex prompt
-Run cairo-auditor deep on skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo with --file-output.
+Run cairo-auditor on path/to/your_contract.cairo with --file-output.
 Output only the final report.
 ```
 
 ```text
 # Claude Code command
-/starknet-agentic-skills:cairo-auditor deep skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo --file-output
+/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output
 ```
 
 ```bash
@@ -134,9 +180,9 @@ ls -lt security-review-*.md | head -n 1
 
 If you need full host-integrity markers (`Execution Integrity: FULL`, specialist bundles, capability file), use the advanced verification flow from the source README after the first report lands.
 
-## Deterministic Demo Target
+## Deterministic Repo Fixture (Maintainers / CI)
 
-If you want a stable live-demo contract, clone this repository and audit:
+If you want the stable regression fixture used by this repository, clone `keep-starknet-strange/starknet-agentic` and audit:
 
 ```text
 skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo

--- a/website/content/docs/skills/cairo-auditor.mdx
+++ b/website/content/docs/skills/cairo-auditor.mdx
@@ -92,13 +92,16 @@ Windows users: create the same contents in a local file such as `test_vuln.cairo
 
 ```text
 # Codex prompt
-Run cairo-auditor on the temp file path printed above with --file-output.
+macOS/Linux: Run cairo-auditor on the temp file path printed above with --file-output.
+Output only the final report.
+Windows: Run cairo-auditor on .\test_vuln.cairo with --file-output.
 Output only the final report.
 ```
 
 ```text
 # Claude Code command
-/starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
+macOS/Linux: /starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
+Windows: /starknet-agentic-skills:cairo-auditor .\test_vuln.cairo --file-output
 ```
 
 This should yield an upgrade-related finding against the ungated `replace_class_syscall` path.

--- a/website/content/docs/skills/cairo-auditor.mdx
+++ b/website/content/docs/skills/cairo-auditor.mdx
@@ -86,6 +86,8 @@ mod VulnerableUpgrade {
 EOF
 ```
 
+Windows users: create the same contents in a local file such as `test_vuln.cairo` with your editor or PowerShell, then run the same prompt against that file path.
+
 ```text
 Run cairo-auditor on /tmp/test_vuln.cairo with --file-output.
 Output only the final report.
@@ -180,7 +182,7 @@ ls -lt security-review-*.md | head -n 1
 
 If you need full host-integrity markers (`Execution Integrity: FULL`, specialist bundles, capability file), use the advanced verification flow from the source README after the first report lands.
 
-## Deterministic Repo Fixture (Maintainers / CI)
+## Deterministic Repo Fixture (Maintainers / Manual Regression)
 
 If you want the stable regression fixture used by this repository, clone `keep-starknet-strange/starknet-agentic` and audit:
 
@@ -189,6 +191,8 @@ skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo
 ```
 
 This fixture is intentionally vulnerable and should reliably produce three findings: missing access control on upgrade, missing timelock, and missing non-zero class-hash guard.
+
+This path is primarily for manual maintainer regression. Repository CI runs separate validation checks for the skill and report contract rather than asking users to invoke this fixture path directly.
 
 ## Modes
 

--- a/website/content/docs/skills/cairo-auditor.mdx
+++ b/website/content/docs/skills/cairo-auditor.mdx
@@ -69,7 +69,8 @@ Output only the final report.
 Create a minimal vulnerable contract locally and audit that file instead:
 
 ```bash
-cat > /tmp/test_vuln.cairo <<'EOF'
+TMP_CAIRO_FILE="$(mktemp "${TMPDIR:-/tmp}/cairo-auditor-demo.XXXXXX.cairo")"
+cat > "$TMP_CAIRO_FILE" <<'EOF'
 #[starknet::contract]
 mod VulnerableUpgrade {
     use starknet::ClassHash;
@@ -84,13 +85,20 @@ mod VulnerableUpgrade {
     }
 }
 EOF
+printf 'Demo contract written to %s\n' "$TMP_CAIRO_FILE"
 ```
 
 Windows users: create the same contents in a local file such as `test_vuln.cairo` with your editor or PowerShell, then run the same prompt against that file path.
 
 ```text
-Run cairo-auditor on /tmp/test_vuln.cairo with --file-output.
+# Codex prompt
+Run cairo-auditor on the temp file path printed above with --file-output.
 Output only the final report.
+```
+
+```text
+# Claude Code command
+/starknet-agentic-skills:cairo-auditor <temp-file-path> --file-output
 ```
 
 This should yield an upgrade-related finding against the ungated `replace_class_syscall` path.

--- a/website/content/docs/skills/overview.mdx
+++ b/website/content/docs/skills/overview.mdx
@@ -13,7 +13,7 @@ Skills are reusable capability packages that extend what AI agents can do on Sta
 
 If you only try one skill first, use [`cairo-auditor`](/docs/skills/cairo-auditor). It is the fastest proof that the install path, host integration, and report artifact flow are all working.
 
-The deterministic fixture path below assumes you are inside a local clone of this repository. If not, replace it with your own local `.cairo` file path.
+Install it once, then run it on any local `.cairo` file in your own project. The repo fixture is still available, but it is no longer the first-run path.
 
 ```bash
 # Codex
@@ -25,11 +25,21 @@ python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-g
 ```
 
 ```text
-# Claude Code
+# Codex prompt
+Run cairo-auditor on path/to/your_contract.cairo with --file-output.
+Output only the final report.
+```
+
+```text
+# Claude Code install
 /plugin marketplace add keep-starknet-strange/starknet-agentic
 /plugin install starknet-agentic-skills@starknet-agentic-skills --scope user
 /reload-plugins
-/starknet-agentic-skills:cairo-auditor deep skills/cairo-auditor/tests/fixtures/insecure_upgrade_controller/src/lib.cairo --file-output
+```
+
+```text
+# Claude Code command
+/starknet-agentic-skills:cairo-auditor path/to/your_contract.cairo --file-output
 ```
 
 Expected artifact: `security-review-*.md`


### PR DESCRIPTION
## Summary
- move the public cairo-auditor happy path from repo-clone fixture auditing to auditing the user's own local Cairo file
- add a self-contained `/tmp/test_vuln.cairo` fallback for users who want to try the skill before they trust it
- move the repository fixture to a maintainer / CI verification role and align website + quickstart copy with the new flow

## Validation
- `python3 scripts/quality/check_codex_distribution.py`
- `python3 -m unittest scripts/quality/test_codex_distribution.py`
- `pnpm --dir website build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quickstart now instructs running the Cairo Auditor against a user-specified local contract file instead of a repo fixture.
  * Site and docs updated to separate install (first-run) from runtime prompts and expectations.
  * Added an optional deep-mode adversarial re-run after initial review.
  * Added a self-contained demo workflow (with Windows guidance) for users without a project.
  * Clarified a deterministic fixture section for maintainer/CI regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->