### PR TITLE
refactor(cairo-auditor): tighten trigger, restructure orchestration i…

### DIFF
--- a/skills/cairo-auditor/SKILL.md
+++ b/skills/cairo-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cairo-auditor
-description: Security audit of Cairo/Starknet code. Trigger on "audit", "check this contract", "review for security". Modes - default (full repo), deep (+ adversarial reasoning), or specific filenames.
+description: Security audit of Cairo/Starknet smart contracts. Trigger on phrases like "audit this Cairo contract", "Starknet security review", "check this .cairo file for vulnerabilities", "release-gate audit", or invoking the `cairo-auditor` command. Supports default (full-repo `.cairo` scan), deep (adds adversarial reasoning agent), and targeted-file modes. Do NOT trigger for Solidity/EVM audits, dependency-vulnerability scans, or general code review.
 license: MIT
 metadata: {"author":"starknet-agentic","version":"0.2.2","org":"keep-starknet-strange","source":"starknet-agentic"}
 keywords: [cairo, starknet, security, audit, vulnerabilities, semgrep]
@@ -12,47 +12,41 @@ user-invocable: true
 
 You are the orchestrator of a parallelized Cairo/Starknet security audit. Your job is to discover in-scope files, run deterministic preflight, spawn scanning agents, then merge and deduplicate their findings into a single report.
 
+The turn-by-turn bash and agent-spawn details live in the workflows. This file is the contract: when to trigger, mode/flag semantics, error codes, and the reporting contract.
+
 ## Quick Start
 
-- Default flow: [workflows/default.md](workflows/default.md)
-- Deep flow: [workflows/deep.md](workflows/deep.md)
+- Default flow (4 vector specialists): [workflows/default.md](workflows/default.md)
+- Deep flow (4 vector + 1 adversarial, with fail-closed gates): [workflows/deep.md](workflows/deep.md)
 - Report schema: [references/report-formatting.md](references/report-formatting.md)
+- Judging / FP gate: [references/judging.md](references/judging.md)
 
-## Starknet.js Examples
+## Banner
 
-```ts
-import { Account, Contract, RpcProvider } from "starknet";
+Before doing anything else, print this exactly:
 
-const provider = new RpcProvider({ nodeUrl: process.env.STARKNET_RPC! });
-const account = new Account({ provider, address: process.env.ACCOUNT_ADDRESS!, signer: process.env.PRIVATE_KEY! });
-const contract = new Contract({ abi, address: process.env.CONTRACT_ADDRESS!, providerOrAccount: account });
-
-try {
-  // View call for quick sanity checks while triaging findings.
-  const owner = await contract.call("owner", []);
-
-  // State-changing probe used during exploit-path validation.
-  const tx = await contract.invoke("set_owner", [owner]);
-  const receipt = await provider.waitForTransaction(tx.transaction_hash);
-  console.log({ finality: receipt.finality_status });
-} catch (err) {
-  console.error("audit probe failed", err);
-}
+```text
+ ██████╗ █████╗ ██╗██████╗  ██████╗      █████╗ ██╗   ██╗██████╗ ██╗████████╗ ██████╗ ██████╗
+██╔════╝██╔══██╗██║██╔══██╗██╔═══██╗    ██╔══██╗██║   ██║██╔══██╗██║╚══██╔══╝██╔═══██╗██╔══██╗
+██║     ███████║██║██████╔╝██║   ██║    ███████║██║   ██║██║  ██║██║   ██║   ██║   ██║██████╔╝
+██║     ██╔══██║██║██╔══██╗██║   ██║    ██╔══██║██║   ██║██║  ██║██║   ██║   ██║   ██║██╔══██╗
+╚██████╗██║  ██║██║██║  ██║╚██████╔╝    ██║  ██║╚██████╔╝██████╔╝██║   ██║   ╚██████╔╝██║  ██║
+ ╚═════╝╚═╝  ╚═╝╚═╝╚═╝  ╚═╝ ╚═════╝     ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
 ```
 
-## Error Codes and Recovery
+## Version Check
 
-| Code | Condition | Recovery |
-| --- | --- | --- |
-| `CAUD-001` | In-scope file discovery produced zero files | Re-run with explicit filenames and verify exclude rules did not hide target contracts. |
-| `CAUD-002` | Preflight scan failed or unavailable | Run `python3 "{skill_root}/scripts/quality/audit_local_repo.py"` manually and attach output to the audit context. |
-| `CAUD-003` | Agent bundle generation failed | Rebuild `{workdir}/cairo-audit-agent-*-bundle.md` and confirm each bundle has non-zero line count. |
-| `CAUD-004` | Conflicting findings across agents | Keep the highest-confidence root cause, then request a focused re-run on the disputed file. |
-| `CAUD-005` | Report includes only low-confidence items | Re-run deep mode with the host-specific cairo-auditor entrypoint (for example, `/starknet-agentic-skills:cairo-auditor deep` in Claude Code) and add deterministic checks from Semgrep/audit findings. |
-| `CAUD-006` | Deep mode requested but specialist agents unavailable | Re-run in an environment with Agent tool support. Where fail-closed enforcement is enabled, `--allow-degraded` explicitly permits fallback. |
-| `CAUD-007` | Deep mode host capability preflight failed | For hosts with preflight enforcement enabled, surface remediation and stop before findings unless `--allow-degraded` is explicitly present. |
-| `CAUD-008` | Agent transport instability or stalled specialist completion | Retry failed/stalled specialists once. In hosts with deep-mode enforcement enabled, unresolved specialist outages are treated as fail-closed unless explicitly degraded. |
-| `CAUD-009` | Strict-model requirement could not be satisfied | Re-run on a host that supports required models, or omit `--strict-models` to allow documented fallback. |
+After printing the banner, run two parallel tool calls: (a) Read the local `VERSION` file from the same directory as this skill, (b) Bash:
+
+```bash
+curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/VERSION
+```
+
+If the remote fetch succeeds and the versions differ, print:
+
+> You are not using the latest version. Update via your install method (e.g. `git pull` or reinstall the plugin) for best security coverage.
+
+Then continue normally. If the fetch fails (offline, timeout), skip silently.
 
 ## When to Use
 
@@ -80,314 +74,56 @@ try {
 - Skip exact directory names via `find ... -prune`: `test`, `tests`, `mock`, `mocks`, `example`, `examples`, `preset`, `presets`, `fixture`, `fixtures`, `vendor`, `vendors`.
 - Skip files matching: `*_test.cairo`, `*Test*.cairo`.
 
-- **Default** (no arguments): scan all `.cairo` files in the repo using the exclude pattern.
-- **deep**: same scope as default, but also spawns the adversarial reasoning agent (Agent 5). Use for thorough reviews. Slower and more costly.
-- **`$filename ...`**: scan the specified file(s) only.
+| Mode | Trigger | Scope | Workflow |
+| --- | --- | --- | --- |
+| default | no arguments | All `.cairo` files in repo (with exclude pattern) | [workflows/default.md](workflows/default.md) |
+| deep | `deep` argument | Same scope as default + adversarial reasoning agent | [workflows/deep.md](workflows/deep.md) |
+| filename | `$filename ...` | Only the listed file(s); preflight skipped | [workflows/default.md](workflows/default.md) (filename branch) |
 
-**Flags:**
+Deep mode is slower and more costly. Use it for thorough reviews of high-value contracts.
 
-- `--file-output` (off by default): also write the report to a markdown file. Without this flag, output goes to the terminal only.
-- `--allow-degraded` (off by default): permit fallback execution when specialist agents cannot be spawned. On hosts with deep-mode enforcement enabled, this flag opts into degraded execution.
+## Flags
+
+The audit accepts the following Flags:
+
+- `--file-output` (off by default): also write the report to a markdown file at `{repo-root}/security-review-{timestamp}.md`. Without this flag, output goes to the terminal only.
+- `--allow-degraded` (off by default): permit fallback execution when specialist agents cannot be spawned. On hosts with deep-mode enforcement enabled, this flag opts into degraded execution; the report is marked `degraded-deep` with explicit warnings.
 - `--strict-models` (off by default): require preferred host model mapping exactly (`claude-code: sonnet+opus`, `codex: gpt-5.4`). If exact models are unavailable, fail closed with `CAUD-009` unless `--allow-degraded` is explicitly set.
 - `--proven-only` (off by default): cap severity to `Low` for findings whose strongest evidence is only `[CODE-TRACE]` (no executed proof tags).
 
-## Host Capability Preflight (Deep Mode, Experimental)
-
-The host-capability preflight below is an experimental hardening path. Use it when your host exposes specialist-agent capability checks.
-
-Before Turn 1 when mode is `deep`, run a lightweight capability preflight and emit a one-line status:
-
-- Detect host family: `codex`, `claude-code`, or `unknown`.
-- Verify Agent tool availability and ability to spawn specialist agents.
-- Deep mode requires 5 specialist agents total (Agents 1-4 + Agent 5 adversarial).
-- Verify threat-intel fetch capability via Bash:
-  - `command -v curl` must succeed, and
-  - `curl -sfI --connect-timeout 5 --max-time 10 https://starknet.io` must succeed.
-- For `codex` hosts, probe preferred model availability before spawn:
-  - run one lightweight specialist probe using `model: gpt-5.4`,
-  - persist success/failure and fallback decision.
-- Persist preflight evidence to `{workdir}/cairo-audit-host-capabilities.json` when the probe is available.
-
-If preflight fails (in hosts where preflight is enabled):
-
-- Without `--allow-degraded`: emit `CAUD-007`, print remediation, and stop before findings.
-- With `--allow-degraded`: continue in `degraded-deep` mode and keep explicit warning lines in scope and execution trace.
-
-Remediation hints to print when preflight fails:
-
-- `codex`: `codex features enable multi_agent`, then verify with `codex features list`, then restart the session.
-- `claude-code`: run `/reload-plugins`, update the installed plugin if needed, and retry deep mode.
-
-## Host-Aware Model Routing
-
-Select specialist model labels from detected host before spawning:
-
-- `claude-code`
-  - `VECTOR_MODEL=sonnet` (host alias for `claude-sonnet-4-6`)
-  - `ADVERSARIAL_MODEL=opus` (host alias for `claude-opus-4-6`)
-- `codex`
-  - `VECTOR_MODEL=gpt-5.4` (Codex-specific label; may change across host versions)
-  - `ADVERSARIAL_MODEL=gpt-5.4`
-  - If `gpt-5.4` probe fails and `--strict-models` is not set, fallback to `gpt-5.2` for both.
-- `unknown`
-  - `VECTOR_MODEL=sonnet` (host alias for `claude-sonnet-4-6`)
-  - `ADVERSARIAL_MODEL=opus` (host alias for `claude-opus-4-6`)
-
-Persist the selected plan to `{workdir}/cairo-audit-model-plan.txt` and keep model labels in the execution trace as observed runtime values (not assumptions).
-
-Strict-model gate:
-
-- When `--strict-models` is set, do not silently fallback.
-- If preferred host mapping cannot be satisfied, emit `CAUD-009` and stop before findings unless `--allow-degraded` is explicitly present.
-- If degraded execution is explicitly permitted, continue with resolved fallback labels and mark `Execution Integrity: DEGRADED`.
-
-## Orchestration
-
-**Turn 1 — Discover.** Print the banner, then in the same message make parallel tool calls.
-
-First, resolve a per-run private work directory:
-
-- If `CAIRO_AUDITOR_WORKDIR` is set, use it as `{workdir}`.
-- Otherwise create one with `mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX"` and `chmod 700`.
-- Print `WORKDIR=<absolute-path>` in Turn 1 output and reuse that exact path as `{workdir}` for all later turns.
-
-(a) Resolve and persist in-scope `.cairo` files to `{workdir}/cairo-audit-files.txt` per mode selection:
-
-```bash
-WORKDIR="${CAIRO_AUDITOR_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX")}"
-chmod 700 "$WORKDIR"
-echo "WORKDIR=$WORKDIR"
-find <repo-root> \
-  \( -type d \( -name test -o -name tests -o -name mock -o -name mocks -o -name example -o -name examples -o -name fixture -o -name fixtures -o -name vendor -o -name vendors -o -name preset -o -name presets \) -prune \) \
-  -o \( -type f -name "*.cairo" ! -name "*_test.cairo" ! -name "*Test*.cairo" -print \) \
-  | sort > "$WORKDIR/cairo-audit-files.txt"
-cat "$WORKDIR/cairo-audit-files.txt"
-```
-
-For **`$filename ...`** mode, do not run `find`. Instead, run:
-
-```bash
-WORKDIR="${CAIRO_AUDITOR_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX")}"
-chmod 700 "$WORKDIR"
-echo "WORKDIR=$WORKDIR"
-REPO_ROOT=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "<repo-root>")
-> "$WORKDIR/cairo-audit-files.txt"
-for f in "$@"; do
-  [ -z "$f" ] && continue
-  ABS_PATH=$(python3 - "$REPO_ROOT" "$f" <<'PY'
-import os
-import sys
-
-repo_root, arg = sys.argv[1], sys.argv[2]
-candidate = arg if os.path.isabs(arg) else os.path.join(repo_root, arg)
-print(os.path.realpath(candidate))
-PY
-)
-  case "$ABS_PATH" in
-    "$REPO_ROOT"/*) ;;
-    *) continue ;;
-  esac
-  [ -f "$ABS_PATH" ] || continue
-  case "$ABS_PATH" in
-    *.cairo) echo "$ABS_PATH" >> "$WORKDIR/cairo-audit-files.txt" ;;
-  esac
-done
-sort -u -o "$WORKDIR/cairo-audit-files.txt" "$WORKDIR/cairo-audit-files.txt"
-cat "$WORKDIR/cairo-audit-files.txt"
-```
-
-(b) Glob for `**/references/attack-vectors/attack-vectors-1.md` and resolve:
-
-- `{refs_root}` = two levels up from the match (`.../references`)
-- `{skill_root}` = three levels up from the match (skill directory that contains `SKILL.md`, `agents/`, `references/`, `VERSION`)
-
-(c) If `{skill_root}/scripts/quality/audit_local_repo.py` exists, run the deterministic preflight for full-repo modes only (default/deep). In `$filename ...` mode, skip preflight so the context stays scoped to the targeted files:
-
-```bash
-python3 "{skill_root}/scripts/quality/audit_local_repo.py" --repo-root <repo-root> --scan-id preflight --output-dir "{workdir}"
-```
-
-Print the preflight results (class counts, severity counts) as context for specialists.
-
-**Turn 2 — Prepare.** In a single message, make three parallel tool calls:
-
-(a) Read `{skill_root}/agents/vector-scan.md` — you will paste this full text into every agent prompt.
-
-(b) Read `{refs_root}/report-formatting.md` — you will use this for the final report.
-
-(c) Bash: create four per-agent bundle files (`{workdir}/cairo-audit-agent-{1,2,3,4}-bundle.md`) in a **single command**. Each bundle concatenates:
-  - **all** in-scope `.cairo` files (with `### path` headers and fenced code blocks),
-  - `{refs_root}/judging.md`,
-  - `{refs_root}/report-formatting.md`,
-  - `{refs_root}/attack-vectors/attack-vectors-N.md` (one per agent — only the attack-vectors file differs).
-
-Print line counts per bundle. Example command:
-
-Before running this command, substitute placeholders (`{refs_root}`, `{repo-root}`) with the concrete paths resolved in Turn 1.
-
-```bash
-REFS="{refs_root}"
-SRC="{repo-root}"
-WORKDIR="{workdir}"
-IN_SCOPE="$WORKDIR/cairo-audit-files.txt"
-set -euo pipefail
-
-build_code_block() {
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    REL=$(echo "$f" | sed "s|$SRC/||")
-    echo "### $REL"
-    echo '```cairo'
-    cat "$f"
-    echo '```'
-    echo ""
-  done < "$IN_SCOPE"
-}
-
-CODE=$(build_code_block)
-
-for i in 1 2 3 4; do
-  {
-    echo "$CODE"
-    echo "---"
-    cat "$REFS/judging.md"
-    echo "---"
-    cat "$REFS/report-formatting.md"
-    echo "---"
-    cat "$REFS/attack-vectors/attack-vectors-$i.md"
-  } > "$WORKDIR/cairo-audit-agent-$i-bundle.md"
-  echo "Bundle $i: $(wc -l < "$WORKDIR/cairo-audit-agent-$i-bundle.md") lines"
-done
-```
-
-Do NOT inline source-code files into prompts. Bundles replace raw source in prompts. Non-code context blocks (deterministic preflight summary and optional threat-intel summary) may be appended.
-
-**Turn 2.5 — Threat Intel Enrichment (Deep Mode, Optional).**
-
-When network access is available, run a small enrichment pass and write `{workdir}/cairo-audit-threat-intel.md`:
-
-- Read `{refs_root}/threat-intel-sources.md` first and follow its source policy.
-- Use `curl` through Bash as the query mechanism for primary-source security material (official audit reports, incident postmortems, protocol docs, vendor writeups).
-- Execute pre-checks before querying:
-  - if `curl` is missing, mark this stage `SKIPPED: no curl`,
-  - if connectivity check fails, mark this stage `SKIPPED: offline`.
-- Keep it bounded: max 6 sources and max 12 extracted signals.
-- Normalize each signal into: `date`, `source`, `class hint`, `one-line exploit shape`.
-- Prefer Cairo/Starknet first; if sparse, include high-signal EVM analogs that map to listed vectors.
-- If a fetch command fails after pre-check, mark `FAILED: curl error <code>` in execution trace and continue.
-- If unavailable/offline, continue and mark this stage as `SKIPPED` in execution trace.
-- Keep query commands/examples aligned with `threat-intel-sources.md`.
-
-Threat-intel usage rules:
-
-- Intel is a prioritization aid only.
-- Never report a finding from intel alone.
-- Every reported finding must still pass the local FP gate with a concrete in-scope path.
-
-**Turn 3 — Spawn.** Use foreground Agent tool calls only (do NOT use `run_in_background`).
-
-- Always spawn Agents 1–4 in parallel.
-- In **deep** mode, use adaptive fanout:
-  - If the largest in-scope file is `<= 1000` lines and all bundles are `<= 1400` lines, spawn Agent 5 in parallel with Agents 1–4.
-  - Otherwise, run two waves for transport stability:
-    1. Wave A: Agents 1–4 in parallel.
-    2. Wave B: Agent 5 after Wave A completes.
-
-- Resolve host-aware model labels first:
-  - write `{workdir}/cairo-audit-model-plan.txt` with `host`, `vector_model`, and `adversarial_model`.
-  - include preflight probe fields when available: `gpt_5_4_probe` and `fallback_reason`.
-  - use that resolved `vector_model` for Agents 1–4 and `adversarial_model` for Agent 5.
-
-- **Agents 1–4** (vector scanning) — spawn with `model: "{vector_model}"`. Each agent prompt must contain the full text of `vector-scan.md` (read in Turn 2, paste into every prompt). After the instructions, add: `Your bundle file is {workdir}/cairo-audit-agent-N-bundle.md (XXXX lines).` (substitute the real line count). Include deterministic preflight results if available. If `{workdir}/cairo-audit-threat-intel.md` exists and has normalized signals, append a compact "Threat Intel (hints only)" block (max 12 lines) to each prompt.
-
-- **Agent 5** (adversarial reasoning, **deep** mode only) — spawn with `model: "{adversarial_model}"`. The prompt must instruct it to:
-  1. Read `{skill_root}/agents/adversarial.md` for its full instructions.
-  2. Read `{refs_root}/judging.md` and `{refs_root}/report-formatting.md`.
-  3. If present, read `{workdir}/cairo-audit-threat-intel.md` as a prioritization hint only.
-  4. Read `{workdir}/cairo-audit-files.txt` to obtain in-scope paths, then read only those `.cairo` files directly (not via bundle).
-  5. Reason freely — no attack vector reference. Look for logic errors, unsafe interactions, access control gaps, economic exploits, multi-step cross-function chains.
-  6. Apply FP gate to each finding immediately.
-  7. Format findings per report-formatting.md.
-
-After spawning, persist execution evidence that will be reused in the final report:
-- confirm `{workdir}/cairo-audit-files.txt` exists and count in-scope files,
-- record line counts for `{workdir}/cairo-audit-agent-{1,2,3,4}-bundle.md`,
-- record whether Agent 5 was spawned (deep) or skipped (non-deep),
-- record each agent's observed runtime model label to `{workdir}/cairo-audit-agent-models.txt` (use actual spawn metadata; if not exposed, use `default` or `unknown`).
-
-Transport resilience:
-- If the agent transport reports disconnect/fallback warnings or a specialist stalls with no completion, retry that specialist exactly once.
-- Use adaptive stall timeout by largest bundle size:
-  - `<=1200` lines: 180 seconds (parallel-spawn baseline)
-  - `1201-1400` lines: 360 seconds (still parallel-spawn eligible; extra time for larger bundles)
-  - `1401-1800` lines: 360 seconds (Wave B regime)
-  - `>1800` lines: 600 seconds (Wave B regime, very large bundles)
-- Retry failed/stalled specialists serially (one at a time) to reduce transport saturation.
-- If retry still fails, treat the specialist as unavailable.
-
-Integrity gate (for hosts where deep-mode enforcement is enabled):
-- In **deep** mode, if any required specialist agent (1-4 or 5) cannot be spawned or returns unavailable, treat the run as failed unless `--allow-degraded` is explicitly present.
-- On failure, stop before findings and print `CAUD-006` with a one-line reason plus host remediation hints.
-- If a specialist output is malformed (not `No findings.` and not valid finding blocks), rerun that specialist once; if still malformed, treat it as unavailable.
-- When `--strict-models` is set, treat model fallback as unavailable capability and enforce the same fail-closed behavior (`CAUD-009`) unless `--allow-degraded` is explicitly present.
-**Turn 4 — Report.** Merge all agent results and emit the report in canonical order:
-
-1. Deduplicate by root cause (keep the higher-confidence version, merge broader attack path details; on confidence tie keep higher priority, then more complete path evidence).
-2. Apply evidence tags per `references/judging.md` Evidence Tags section:
-   - Validate every finding has `[CODE-TRACE]`; if a source agent omitted it, add `[CODE-TRACE]` during merge normalization.
-   - Add `[PREFLIGHT-HIT]` if the deterministic preflight flagged the same class or entry point.
-   - Add `[CROSS-AGENT]` if 2+ agents independently reported the same root cause before deduplication.
-   - Add `[ADVERSARIAL]` if Agent 5 discovered or confirmed the finding.
-3. Findings with only `[CODE-TRACE]` (no additional tags) are valid but lower-signal; reviewers use the Evidence column in Findings Index to prioritize review order.
-4. Sort findings by priority (`P0` first); within each priority tier sort by confidence (highest first).
-5. Re-number findings sequentially starting at `1`.
-6. Insert one **Below Confidence Threshold** separator row in the findings index immediately before the first finding with confidence < 75.
-7. Print findings directly — do not re-draft or re-describe them.
-8. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`.
-9. Add scope table and findings index table per report-formatting.md.
-10. Add the disclaimer.
-
-Dropped-candidate handling:
-
-- If a candidate is discarded during FP gate or dedupe, add one row in `Dropped Candidates` with `candidate`, `class`, and `drop_reason`.
-- Accepted `drop_reason` values: `false_positive`, `duplicate_root_cause`, `below_confidence_threshold`, `insufficient_evidence`.
-- If none were dropped, still include the section with a single `none` row.
-
-If `--file-output` is set, write the report to `{repo-root}/security-review-{timestamp}.md` and print the path.
-
-## Banner
-
-Before doing anything else, print this exactly:
-
-```text
- ██████╗ █████╗ ██╗██████╗  ██████╗      █████╗ ██╗   ██╗██████╗ ██╗████████╗ ██████╗ ██████╗
-██╔════╝██╔══██╗██║██╔══██╗██╔═══██╗    ██╔══██╗██║   ██║██╔══██╗██║╚══██╔══╝██╔═══██╗██╔══██╗
-██║     ███████║██║██████╔╝██║   ██║    ███████║██║   ██║██║  ██║██║   ██║   ██║   ██║██████╔╝
-██║     ██╔══██║██║██╔══██╗██║   ██║    ██╔══██║██║   ██║██║  ██║██║   ██║   ██║   ██║██╔══██╗
-╚██████╗██║  ██║██║██║  ██║╚██████╔╝    ██║  ██║╚██████╔╝██████╔╝██║   ██║   ╚██████╔╝██║  ██║
- ╚═════╝╚═╝  ╚═╝╚═╝╚═╝  ╚═╝ ╚═════╝     ╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝
-```
-
-## Version Check
-
-After printing the banner, run two parallel tool calls: (a) Read the local `VERSION` file from the same directory as this skill, (b) Bash `curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/VERSION`. If the remote fetch succeeds and the versions differ, print:
-
-> You are not using the latest version. Update via your install method (e.g. `git pull` or reinstall the plugin) for best security coverage.
-
-Then continue normally. If the fetch fails (offline, timeout), skip silently.
-
-Use this command for the remote check:
-
-```bash
-curl -sf --connect-timeout 5 --max-time 10 https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/VERSION
-```
-
-## Limitations
-
-- Works best on codebases under **5,000 lines** of Cairo. Past that, triage accuracy and mid-bundle recall degrade.
-- For large codebases, run per-module by passing explicit file arguments (`$filename ...`) rather than full-repo.
-- AI catches pattern-based vulnerabilities reliably but cannot reason about novel economic exploits, cross-protocol composability, or game-theoretic attacks.
-- Not a substitute for a formal audit — but the check you should never skip.
+## Orchestration Overview
+
+Both workflows follow the same four-turn structure:
+
+1. **Discover** — resolve `{workdir}`, enumerate in-scope `.cairo` files, run deterministic preflight (full-repo modes only).
+2. **Prepare** — read agent prompt templates and build per-agent bundle files (code + judging + formatting + one attack-vectors partition).
+3. **Spawn** — call the Agent tool in parallel (default: 4 agents; deep: 4 vector + 1 adversarial, with adaptive fanout). Spawn in foreground only.
+4. **Report** — merge, deduplicate by root cause, apply evidence tags, sort by priority+confidence, emit per `references/report-formatting.md`.
+
+The full bash and per-turn agent-spawn details are in the workflow files. Always read the relevant workflow before executing.
+
+## Error Codes and Recovery
+
+| Code | Condition | Recovery |
+| --- | --- | --- |
+| `CAUD-001` | In-scope file discovery produced zero files | Re-run with explicit filenames and verify exclude rules did not hide target contracts. |
+| `CAUD-002` | Preflight scan failed or unavailable | Run `python3 "{skill_root}/scripts/quality/audit_local_repo.py"` manually and attach output to the audit context. |
+| `CAUD-003` | Agent bundle generation failed | Rebuild `{workdir}/cairo-audit-agent-*-bundle.md` and confirm each bundle has non-zero line count. |
+| `CAUD-004` | Conflicting findings across agents | Keep the highest-confidence root cause, then request a focused re-run on the disputed file. |
+| `CAUD-005` | Report includes only low-confidence items | Re-run deep mode with the host-specific cairo-auditor entrypoint (for example, `/starknet-agentic-skills:cairo-auditor deep` in Claude Code) and add deterministic checks from Semgrep/audit findings. |
+| `CAUD-006` | Deep mode requested but specialist agents unavailable | Re-run in an environment with Agent tool support. Where fail-closed enforcement is enabled, `--allow-degraded` explicitly permits fallback. |
+| `CAUD-007` | Deep mode host capability preflight failed | For hosts with preflight enforcement enabled, surface remediation and stop before findings unless `--allow-degraded` is explicitly present. |
+| `CAUD-008` | Agent transport instability or stalled specialist completion | Retry failed/stalled specialists once. In hosts with deep-mode enforcement enabled, unresolved specialist outages are treated as fail-closed unless explicitly degraded. |
+| `CAUD-009` | Strict-model requirement could not be satisfied | Re-run on a host that supports required models, or omit `--strict-models` to allow documented fallback. |
+
+Fail-closed semantics for deep mode (single source of truth):
+
+- On hosts where deep-mode enforcement is enabled, deep mode is fail-closed by default. If specialist agents (1-4 or 5) cannot be spawned or return unavailable, emit `CAUD-006` and do not publish findings unless `--allow-degraded` is explicitly present.
+- Preflight failure surfaces `CAUD-007` with the same `--allow-degraded` carve-out.
+- `--strict-models` failure surfaces `CAUD-009` with the same carve-out.
+- When `--allow-degraded` is honored, mark scope mode as `degraded-deep`, set `Execution Integrity: DEGRADED`, and include the warning lines required by `references/report-formatting.md`.
+
+The deep workflow contains the full preflight, model-routing, transport-retry, and fail-closed implementation. Do not duplicate that logic here.
 
 ## Reporting Contract
 
@@ -403,6 +139,8 @@ Each finding must include:
 - `required_tests` (regression + guard tests)
 - `evidence_tags` (`[CODE-TRACE]` minimum; upgrade when stronger proof exists)
 
+Report sections must appear in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`. See `references/report-formatting.md` for the full schema and dropped-candidate handling.
+
 ## Evidence Priority
 
 1. `references/vulnerability-db/`
@@ -417,7 +155,11 @@ Each finding must include:
 - Findings with confidence `<75` may be listed as low-confidence notes without a fix block.
 - If `--proven-only` is present, findings that only carry `[CODE-TRACE]` evidence must be emitted at `Low` severity.
 - Do not report: style/naming issues, gas optimizations, missing events without security impact, generic centralization notes without exploit path, theoretical attacks requiring compromised sequencer.
-- On hosts where deep-mode enforcement is enabled, deep mode is fail-closed by default: if specialist agents are unavailable and `--allow-degraded` is not present, emit `CAUD-006` and do not publish a findings report.
-- If `--allow-degraded` is present and fallback is used, mark scope mode as `degraded-deep` and include an explicit warning line at top: `WARNING: degraded execution (specialist agents unavailable)`.
-- For degraded execution, repeat a second warning immediately before `Findings Index`: `WARNING: degraded execution may omit exploitable paths`.
 - Use dependency lockfiles and local workspace sources first when validating library behavior; avoid recursive global-cache grep sweeps unless the dependency path is unresolved.
+
+## Limitations
+
+- Works best on codebases under **5,000 lines** of Cairo. Past that, triage accuracy and mid-bundle recall degrade.
+- For large codebases, run per-module by passing explicit file arguments (`$filename ...`) rather than full-repo.
+- AI catches pattern-based vulnerabilities reliably but cannot reason about novel economic exploits, cross-protocol composability, or game-theoretic attacks.
+- Not a substitute for a formal audit — but the check you should never skip.

--- a/skills/cairo-auditor/scripts/doctor.sh
+++ b/skills/cairo-auditor/scripts/doctor.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-WORKDIR="${CAIRO_AUDITOR_WORKDIR:-/tmp}"
+WORKDIR="${CAIRO_AUDITOR_WORKDIR:-}"
 WORKDIR_EXPLICIT=0
+if [[ -n "$WORKDIR" ]]; then
+  WORKDIR_EXPLICIT=1
+fi
 REPORT_DIR="."
 REPORT_PATH=""
 REPORT_EXPLICIT=0
@@ -10,6 +13,9 @@ REPORT_EXPLICIT=0
 usage() {
   cat <<'EOF'
 Usage: bash skills/cairo-auditor/scripts/doctor.sh [--workdir PATH] [--report-dir PATH] [--report PATH]
+
+If --workdir is omitted and CAIRO_AUDITOR_WORKDIR is not set, the most recent
+cairo-auditor.* directory under $TMPDIR (or /tmp) is auto-discovered.
 
 Checks:
   - host-capabilities artifact exists
@@ -84,6 +90,41 @@ resolve_artifact_root() {
     echo "$preferred"
     return
   fi
+
+  # SKILL.md uses `mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX"` per run.
+  # When no explicit --workdir is given, discover the most-recent matching
+  # directory under both $TMPDIR (if set) and /tmp.
+  local candidate=""
+  local newest=""
+  local newest_mtime=0
+  local search_root mtime
+  for search_root in "${TMPDIR:-}" "/tmp"; do
+    [[ -z "$search_root" ]] && continue
+    [[ ! -d "$search_root" ]] && continue
+    while IFS= read -r candidate; do
+      [[ -z "$candidate" ]] && continue
+      [[ ! -d "$candidate" ]] && continue
+      mtime=$(stat -f '%m' "$candidate" 2>/dev/null || stat -c '%Y' "$candidate" 2>/dev/null || echo 0)
+      if [[ "${mtime:-0}" -gt "$newest_mtime" ]]; then
+        newest_mtime="$mtime"
+        newest="$candidate"
+      fi
+    done < <(find "$search_root" -maxdepth 1 -type d -name 'cairo-auditor.*' 2>/dev/null)
+  done
+
+  if [[ -n "$newest" && -f "$newest/cairo-audit-host-capabilities.json" ]]; then
+    echo "$newest"
+    return
+  fi
+  if [[ -n "$newest" ]]; then
+    # Found a workdir but no host-capabilities artifact — return it so the
+    # caller can report the missing artifact rather than silently scanning /tmp.
+    echo "$newest"
+    return
+  fi
+
+  # Legacy fallback: artifacts may have been written directly to /tmp by an
+  # older orchestration path that did not use mktemp.
   if [[ -f "/tmp/cairo-audit-host-capabilities.json" ]]; then
     echo "/tmp"
     return
@@ -93,25 +134,30 @@ resolve_artifact_root() {
 
 ART_ROOT="$(resolve_artifact_root "$WORKDIR" "$WORKDIR_EXPLICIT")"
 
-if [[ -f "$ART_ROOT/cairo-audit-host-capabilities.json" ]]; then
-  say_ok "Host capabilities file: $ART_ROOT/cairo-audit-host-capabilities.json"
+if [[ -z "$ART_ROOT" ]]; then
+  say_fail "No cairo-auditor workdir found. Pass --workdir, set CAIRO_AUDITOR_WORKDIR, or run an audit first to create one."
 else
-  say_fail "Missing host capabilities file: $ART_ROOT/cairo-audit-host-capabilities.json"
-fi
-
-for i in 1 2 3 4; do
-  bundle="$ART_ROOT/cairo-audit-agent-$i-bundle.md"
-  if [[ ! -f "$bundle" ]]; then
-    say_fail "Missing bundle: $bundle"
-    continue
-  fi
-  lines="$(wc -l < "$bundle" | tr -d ' ')"
-  if [[ "${lines:-0}" -gt 0 ]]; then
-    say_ok "Bundle $i lines: $lines"
+  echo "Inspecting workdir: $ART_ROOT"
+  if [[ -f "$ART_ROOT/cairo-audit-host-capabilities.json" ]]; then
+    say_ok "Host capabilities file: $ART_ROOT/cairo-audit-host-capabilities.json"
   else
-    say_fail "Bundle $i is empty: $bundle"
+    say_fail "Missing host capabilities file: $ART_ROOT/cairo-audit-host-capabilities.json"
   fi
-done
+
+  for i in 1 2 3 4; do
+    bundle="$ART_ROOT/cairo-audit-agent-$i-bundle.md"
+    if [[ ! -f "$bundle" ]]; then
+      say_fail "Missing bundle: $bundle"
+      continue
+    fi
+    lines="$(wc -l < "$bundle" | tr -d ' ')"
+    if [[ "${lines:-0}" -gt 0 ]]; then
+      say_ok "Bundle $i lines: $lines"
+    else
+      say_fail "Bundle $i is empty: $bundle"
+    fi
+  done
+fi
 
 if [[ -z "$REPORT_PATH" ]]; then
   REPORT_PATH="$(ls -t "$REPORT_DIR"/security-review-*.md 2>/dev/null | head -n 1 || true)"

--- a/skills/cairo-auditor/tests/README.md
+++ b/skills/cairo-auditor/tests/README.md
@@ -1,12 +1,14 @@
-# Preflight Fixtures
+# Cairo Auditor Test Suite
 
-This directory holds deterministic fixtures for `skills/cairo-auditor/scripts/quality/audit_local_repo.py`.
+This directory holds deterministic fixtures and validators for the cairo-auditor skill: the preflight scanner (`scripts/quality/audit_local_repo.py`), the bundle-generation step from `workflows/default.md`, and the documented fail-closed contract for deep mode.
 
 ## Run
 
 ```bash
 python3 skills/cairo-auditor/tests/validate_preflight.py
 python3 skills/cairo-auditor/tests/validate_deep_smoke.py
+python3 skills/cairo-auditor/tests/validate_bundle_generation.py
+python3 skills/cairo-auditor/tests/validate_failclosed_contract.py
 ```
 
 The check runs deterministic fixture repos:
@@ -23,3 +25,7 @@ The check runs deterministic fixture repos:
 - vulnerable fixture scan still produces at least one deterministic finding,
 - report contract still exposes execution integrity + trace sections,
 - canonical ordering includes `Dropped Candidates`.
+
+`validate_bundle_generation.py` exercises the bash bundle-generation pipeline from `workflows/default.md` against the `insecure_upgrade_controller` fixture and asserts that all four per-agent bundle files exist, are non-trivially sized, and contain the expected sections (cairo source, judging rubric, report formatting, the per-agent attack-vectors partition). This catches regressions in the documented orchestration before specialist agents are spawned.
+
+`validate_failclosed_contract.py` pins the documented fail-closed contract for deep mode without spawning real agents: SKILL.md owns the `CAUD-006`/`CAUD-007`/`CAUD-009` error codes and the `--allow-degraded` carve-out; `workflows/deep.md` owns the Integrity Gate and the explicit `WARNING: degraded execution …` lines required when degraded execution is honored; `workflows/default.md` does not duplicate that logic; `references/report-formatting.md` enumerates the `Execution Integrity: <FULL|DEGRADED|FAILED>` tri-state.

--- a/skills/cairo-auditor/tests/validate_bundle_generation.py
+++ b/skills/cairo-auditor/tests/validate_bundle_generation.py
@@ -9,6 +9,7 @@ that each specialist later consumes.
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 import sys
@@ -27,17 +28,21 @@ REQUIRED_BUNDLE_MARKERS = (
 )
 
 
-def build_bundles(fixture: Path, workdir: Path) -> tuple[bool, str]:
+def build_bundles(fixture: Path, workdir: Path, bash_path: str) -> tuple[bool, str]:
     in_scope = workdir / "cairo-audit-files.txt"
     cairo_files = sorted(fixture.rglob("*.cairo"))
     if not cairo_files:
         return False, f"fixture {fixture} contained no .cairo files"
     in_scope.write_text("\n".join(str(p) for p in cairo_files) + "\n", encoding="utf-8")
 
+    refs_q = shlex.quote(str(REFS))
+    src_q = shlex.quote(str(fixture))
+    workdir_q = shlex.quote(str(workdir))
+
     script = f"""set -euo pipefail
-REFS={REFS!s}
-SRC={fixture!s}
-WORKDIR={workdir!s}
+REFS={refs_q}
+SRC={src_q}
+WORKDIR={workdir_q}
 IN_SCOPE="$WORKDIR/cairo-audit-files.txt"
 
 build_code_block() {{
@@ -68,7 +73,7 @@ for i in 1 2 3 4; do
 done
 """
     proc = subprocess.run(
-        ["bash", "-c", script],
+        [bash_path, "-c", script],
         text=True,
         capture_output=True,
         check=False,
@@ -92,10 +97,8 @@ def validate_bundles(workdir: Path) -> tuple[bool, str]:
         missing = [m for m in REQUIRED_BUNDLE_MARKERS if m not in content]
         if missing:
             return False, f"bundle {bundle} missing markers: {missing}"
-        attack_marker = f"attack-vectors-{i}"
-        # The file is concatenated as raw text; the content of the partition
-        # itself rather than a literal filename should appear. Check the partition
-        # source is included by ensuring its first heading is present.
+        # The file is concatenated as raw text; verify the per-agent attack-vectors
+        # partition is included by checking its first heading appears.
         partition_path = REFS / "attack-vectors" / f"attack-vectors-{i}.md"
         partition_first_line = partition_path.read_text(encoding="utf-8").splitlines()[0]
         if partition_first_line not in content:
@@ -107,17 +110,17 @@ def validate_bundles(workdir: Path) -> tuple[bool, str]:
     return True, "all 4 bundles exist, are non-empty, and contain required sections"
 
 
-def main() -> int:
+def main(bash_path: str) -> int:
     if not FIXTURE.exists():
         print(f"missing fixture: {FIXTURE}", file=sys.stderr)
         return 1
     if not (REFS / "judging.md").is_file():
-        print(f"missing references/judging.md", file=sys.stderr)
+        print("missing references/judging.md", file=sys.stderr)
         return 1
 
     with tempfile.TemporaryDirectory(prefix="cairo-auditor-bundles-") as tmp:
         workdir = Path(tmp)
-        ok, msg = build_bundles(FIXTURE, workdir)
+        ok, msg = build_bundles(FIXTURE, workdir, bash_path)
         print(msg)
         if not ok:
             print("\nbundle generation failed", file=sys.stderr)
@@ -134,7 +137,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    if shutil.which("bash") is None:
+    resolved_bash = shutil.which("bash")
+    if resolved_bash is None:
         print("bash not available; skipping", file=sys.stderr)
         raise SystemExit(0)
-    raise SystemExit(main())
+    raise SystemExit(main(resolved_bash))

--- a/skills/cairo-auditor/tests/validate_bundle_generation.py
+++ b/skills/cairo-auditor/tests/validate_bundle_generation.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Asserts the bundle-generation step from workflows/default.md produces 4
+non-empty per-agent bundle files when run on a fixture repo.
+
+The orchestrator skill cannot spawn real Agent calls in CI, so this test
+exercises the deterministic bash pipeline that builds the four bundle files
+that each specialist later consumes.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REFS = ROOT / "references"
+FIXTURE = ROOT / "tests" / "fixtures" / "insecure_upgrade_controller"
+
+REQUIRED_BUNDLE_MARKERS = (
+    "### ",                                # at least one source-file header
+    "```cairo",                            # fenced cairo code block
+    "# Finding Validation (Cairo)",        # first heading of references/judging.md
+    "# Report Formatting",                 # first heading of references/report-formatting.md
+)
+
+
+def build_bundles(fixture: Path, workdir: Path) -> tuple[bool, str]:
+    in_scope = workdir / "cairo-audit-files.txt"
+    cairo_files = sorted(fixture.rglob("*.cairo"))
+    if not cairo_files:
+        return False, f"fixture {fixture} contained no .cairo files"
+    in_scope.write_text("\n".join(str(p) for p in cairo_files) + "\n", encoding="utf-8")
+
+    script = f"""set -euo pipefail
+REFS={REFS!s}
+SRC={fixture!s}
+WORKDIR={workdir!s}
+IN_SCOPE="$WORKDIR/cairo-audit-files.txt"
+
+build_code_block() {{
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    REL=$(echo "$f" | sed "s|$SRC/||")
+    echo "### $REL"
+    echo '```cairo'
+    cat "$f"
+    echo '```'
+    echo ""
+  done < "$IN_SCOPE"
+}}
+
+CODE=$(build_code_block)
+
+for i in 1 2 3 4; do
+  {{
+    echo "$CODE"
+    echo "---"
+    cat "$REFS/judging.md"
+    echo "---"
+    cat "$REFS/report-formatting.md"
+    echo "---"
+    cat "$REFS/attack-vectors/attack-vectors-$i.md"
+  }} > "$WORKDIR/cairo-audit-agent-$i-bundle.md"
+  echo "Bundle $i: $(wc -l < "$WORKDIR/cairo-audit-agent-$i-bundle.md") lines"
+done
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        return False, f"bundle script exited {proc.returncode}: {proc.stderr.strip()}"
+    return True, proc.stdout.strip()
+
+
+def validate_bundles(workdir: Path) -> tuple[bool, str]:
+    for i in (1, 2, 3, 4):
+        bundle = workdir / f"cairo-audit-agent-{i}-bundle.md"
+        if not bundle.is_file():
+            return False, f"missing bundle {bundle}"
+        content = bundle.read_text(encoding="utf-8")
+        if not content.strip():
+            return False, f"bundle {bundle} is empty"
+        if bundle.stat().st_size < 1024:
+            return False, f"bundle {bundle} suspiciously small ({bundle.stat().st_size} bytes)"
+        missing = [m for m in REQUIRED_BUNDLE_MARKERS if m not in content]
+        if missing:
+            return False, f"bundle {bundle} missing markers: {missing}"
+        attack_marker = f"attack-vectors-{i}"
+        # The file is concatenated as raw text; the content of the partition
+        # itself rather than a literal filename should appear. Check the partition
+        # source is included by ensuring its first heading is present.
+        partition_path = REFS / "attack-vectors" / f"attack-vectors-{i}.md"
+        partition_first_line = partition_path.read_text(encoding="utf-8").splitlines()[0]
+        if partition_first_line not in content:
+            return (
+                False,
+                f"bundle {bundle} does not contain attack-vectors-{i} partition "
+                f"(missing first line: {partition_first_line!r})",
+            )
+    return True, "all 4 bundles exist, are non-empty, and contain required sections"
+
+
+def main() -> int:
+    if not FIXTURE.exists():
+        print(f"missing fixture: {FIXTURE}", file=sys.stderr)
+        return 1
+    if not (REFS / "judging.md").is_file():
+        print(f"missing references/judging.md", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cairo-auditor-bundles-") as tmp:
+        workdir = Path(tmp)
+        ok, msg = build_bundles(FIXTURE, workdir)
+        print(msg)
+        if not ok:
+            print("\nbundle generation failed", file=sys.stderr)
+            return 1
+
+        ok, msg = validate_bundles(workdir)
+        print(msg)
+        if not ok:
+            print("\nbundle validation failed", file=sys.stderr)
+            return 1
+
+    print("\nbundle generation validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    if shutil.which("bash") is None:
+        print("bash not available; skipping", file=sys.stderr)
+        raise SystemExit(0)
+    raise SystemExit(main())

--- a/skills/cairo-auditor/tests/validate_failclosed_contract.py
+++ b/skills/cairo-auditor/tests/validate_failclosed_contract.py
@@ -73,15 +73,30 @@ def main() -> int:
     )
 
     # workflows/default.md must NOT silently re-implement deep-mode fail-closed
-    # logic — that is the deep workflow's responsibility. Verify default does
-    # not claim to handle CAUD-006.
+    # logic — that is the deep workflow's responsibility. Verify none of the
+    # deep-only markers leaked into default.
     default_content = DEFAULT_WORKFLOW.read_text(encoding="utf-8")
-    if "CAUD-006" in default_content:
+    forbidden_in_default = (
+        "CAUD-006",
+        "CAUD-007",
+        "CAUD-009",
+        "--allow-degraded",
+        "degraded-deep",
+        "WARNING: degraded execution (specialist agents unavailable)",
+        "WARNING: degraded execution may omit exploitable paths",
+    )
+    leaked = [m for m in forbidden_in_default if m in default_content]
+    if leaked:
         checks.append(
-            (False, "workflows/default.md should not duplicate CAUD-006 fail-closed logic")
+            (
+                False,
+                f"workflows/default.md leaked deep-only fail-closed markers: {leaked}",
+            )
         )
     else:
-        checks.append((True, "workflows/default.md does not duplicate CAUD-006 logic"))
+        checks.append(
+            (True, "workflows/default.md does not duplicate deep-only fail-closed markers")
+        )
 
     # references/report-formatting.md must enumerate the Execution Integrity
     # tri-state value the report carries when degraded.

--- a/skills/cairo-auditor/tests/validate_failclosed_contract.py
+++ b/skills/cairo-auditor/tests/validate_failclosed_contract.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Asserts the documented fail-closed contract for deep mode.
+
+The skill cannot actually spawn agents in CI, so this test pins the *contract*
+that the orchestrator must honor: when specialist agents are unavailable and
+`--allow-degraded` is not present, deep mode emits CAUD-006 and stops before
+findings. Same fail-closed semantics for CAUD-007 (preflight) and CAUD-009
+(strict-models). When `--allow-degraded` is present, the report must carry the
+documented `degraded-deep` warning lines.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_DOC = ROOT / "SKILL.md"
+DEEP_WORKFLOW = ROOT / "workflows" / "deep.md"
+DEFAULT_WORKFLOW = ROOT / "workflows" / "default.md"
+REPORT_FORMAT = ROOT / "references" / "report-formatting.md"
+
+
+def must_contain(path: Path, needles: tuple[str, ...]) -> tuple[bool, str]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, f"unable to read {path}: {exc}"
+    missing = [n for n in needles if n not in content]
+    if missing:
+        return False, f"{path.relative_to(ROOT)} missing: {missing}"
+    return True, f"{path.relative_to(ROOT)} contains required fail-closed markers"
+
+
+def main() -> int:
+    checks: list[tuple[bool, str]] = []
+
+    # SKILL.md owns the error-code contract and the single-source-of-truth
+    # fail-closed semantics block that both workflows reference.
+    checks.append(
+        must_contain(
+            SKILL_DOC,
+            (
+                "CAUD-006",
+                "CAUD-007",
+                "CAUD-009",
+                "--allow-degraded",
+                "--strict-models",
+                "--proven-only",
+                "Fail-closed semantics for deep mode",
+                "do not publish findings",
+            ),
+        )
+    )
+
+    # workflows/deep.md owns the Integrity Gate and the explicit warning lines
+    # required when --allow-degraded is honored.
+    checks.append(
+        must_contain(
+            DEEP_WORKFLOW,
+            (
+                "Integrity gate",
+                "CAUD-006",
+                "CAUD-007",
+                "CAUD-009",
+                "--allow-degraded",
+                "WARNING: degraded execution (specialist agents unavailable)",
+                "WARNING: degraded execution may omit exploitable paths",
+                "Execution Integrity: DEGRADED",
+                "degraded-deep",
+            ),
+        )
+    )
+
+    # workflows/default.md must NOT silently re-implement deep-mode fail-closed
+    # logic — that is the deep workflow's responsibility. Verify default does
+    # not claim to handle CAUD-006.
+    default_content = DEFAULT_WORKFLOW.read_text(encoding="utf-8")
+    if "CAUD-006" in default_content:
+        checks.append(
+            (False, "workflows/default.md should not duplicate CAUD-006 fail-closed logic")
+        )
+    else:
+        checks.append((True, "workflows/default.md does not duplicate CAUD-006 logic"))
+
+    # references/report-formatting.md must enumerate the Execution Integrity
+    # tri-state value the report carries when degraded.
+    checks.append(
+        must_contain(
+            REPORT_FORMAT,
+            (
+                "Execution Integrity: <FULL|DEGRADED|FAILED>",
+                "## Execution Trace",
+            ),
+        )
+    )
+
+    failures: list[str] = []
+    for ok, msg in checks:
+        print(msg)
+        if not ok:
+            failures.append(msg)
+
+    if failures:
+        print("\nfail-closed contract validation failed", file=sys.stderr)
+        return 1
+
+    print("\nfail-closed contract validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cairo-auditor/workflows/deep.md
+++ b/skills/cairo-auditor/workflows/deep.md
@@ -1,16 +1,18 @@
 # Deep Workflow
 
-Extends default with adversarial reasoning. Orchestrated by [SKILL.md](../SKILL.md).
+Extends [default.md](default.md) with adversarial reasoning, host-capability preflight, host-aware model routing, threat-intel enrichment, and fail-closed integrity gates. Orchestrated by [SKILL.md](../SKILL.md).
+
+This file owns deep-mode-specific logic. For the shared Turn 1–4 base orchestration (file enumeration, bundle generation, vector-spec spawn, report assembly), follow [default.md](default.md) and add the deltas described here.
 
 ## Pipeline
 
-1. **Discover** — same as default.
+1. **Discover** — same as default, plus host-capability preflight (see below).
 2. **Prepare** — same as default, plus resolve adversarial agent instructions.
-3. **Threat Intel (optional)** — run bounded `curl`-based enrichment and persist `{workdir}/cairo-audit-threat-intel.md`; include SKIPPED/FAILED reason in execution trace when unavailable.
-4. **Spawn** — Adaptive deep fanout:
-   - small scopes (largest file <= 1000 lines **and** all bundles <= 1400 lines): 4 parallel vector specialists + 1 adversarial specialist in parallel (host-aware model routing).
-   - large scopes: two waves for reliability (Wave A: Agents 1-4, Wave B: Agent 5).
-5. **Report** — Merge all 5 agent outputs, deduplicate, apply optional `--proven-only` severity cap for `[CODE-TRACE]`-only findings, sort, emit.
+3. **Threat Intel (optional)** — bounded `curl`-based enrichment persisted to `{workdir}/cairo-audit-threat-intel.md`. Includes `SKIPPED`/`FAILED` reason in execution trace when unavailable.
+4. **Spawn** — adaptive deep fanout with host-aware model routing:
+   - small scopes (largest file ≤ 1000 lines **and** all bundles ≤ 1400 lines): 4 parallel vector specialists + 1 adversarial specialist in parallel.
+   - large scopes: two waves for reliability (Wave A: Agents 1–4, Wave B: Agent 5).
+5. **Report** — merge all 5 agent outputs, deduplicate, apply optional `--proven-only` severity cap for `[CODE-TRACE]`-only findings, sort, emit.
 
 ## Agent Configuration
 
@@ -23,13 +25,162 @@ Codex fallback is `gpt-5.2` when `gpt-5.4` probe fails and `--strict-models` is 
 `--strict-models` disables fallback and fails closed if preferred host models are unavailable.
 `--proven-only` caps `[CODE-TRACE]`-only findings at Low severity for conservative release gates.
 
-## Agent 5 — Adversarial Specialist
+## Confidence Threshold
 
-- No attack vector reference — reasons freely about logic errors, unsafe interactions, multi-step chains.
-- Reads all in-scope files directly (not via bundle).
-- Focuses on: cross-function boundary reasoning, trust-chain composition, session/account interplay, upgrade failure modes.
-- Applies FP gate and confidence scoring per `judging.md`.
-- Higher cost but catches findings that pattern-based scanning misses.
+Same as default ([default.md](default.md#confidence-threshold)). The adversarial agent's findings still pass through the FP gate and confidence scoring.
+
+---
+
+## Turn 1 — Discover (deep delta)
+
+Run the [default Turn 1](default.md#turn-1--discover) base steps (workdir, file enumeration, deterministic preflight). Then add the host-capability preflight below.
+
+### Host Capability Preflight (Experimental)
+
+The host-capability preflight is an experimental hardening path. Use it when your host exposes specialist-agent capability checks. Run a lightweight check and emit a one-line status:
+
+- Detect host family: `codex`, `claude-code`, or `unknown`.
+- Verify Agent tool availability and ability to spawn specialist agents.
+- Deep mode requires 5 specialist agents total (Agents 1-4 + Agent 5 adversarial).
+- Verify threat-intel fetch capability via Bash:
+  - `command -v curl` must succeed, and
+  - `curl -sfI --connect-timeout 5 --max-time 10 https://starknet.io` must succeed.
+- For `codex` hosts, probe preferred model availability before spawn:
+  - run one lightweight specialist probe using `model: gpt-5.4`,
+  - persist success/failure and fallback decision.
+- Persist preflight evidence to `{workdir}/cairo-audit-host-capabilities.json` when the probe is available.
+
+If preflight fails (in hosts where preflight is enabled):
+
+- Without `--allow-degraded`: emit `CAUD-007`, print remediation, and stop before findings.
+- With `--allow-degraded`: continue in `degraded-deep` mode and keep explicit warning lines in scope and execution trace.
+
+Remediation hints to print when preflight fails:
+
+- `codex`: `codex features enable multi_agent`, then verify with `codex features list`, then restart the session.
+- `claude-code`: run `/reload-plugins`, update the installed plugin if needed, and retry deep mode.
+
+### Host-Aware Model Routing
+
+Select specialist model labels from detected host before spawning:
+
+- `claude-code`
+  - `VECTOR_MODEL=sonnet` (host alias for `claude-sonnet-4-6`)
+  - `ADVERSARIAL_MODEL=opus` (host alias for `claude-opus-4-6`)
+- `codex`
+  - `VECTOR_MODEL=gpt-5.4` (Codex-specific label; may change across host versions)
+  - `ADVERSARIAL_MODEL=gpt-5.4`
+  - If `gpt-5.4` probe fails and `--strict-models` is not set, fallback to `gpt-5.2` for both.
+- `unknown`
+  - `VECTOR_MODEL=sonnet` (host alias for `claude-sonnet-4-6`)
+  - `ADVERSARIAL_MODEL=opus` (host alias for `claude-opus-4-6`)
+
+Persist the selected plan to `{workdir}/cairo-audit-model-plan.txt` with `host`, `vector_model`, `adversarial_model`, and (when available) `gpt_5_4_probe` and `fallback_reason`. Keep model labels in the execution trace as observed runtime values (not assumptions).
+
+Strict-model gate:
+
+- When `--strict-models` is set, do not silently fallback.
+- If preferred host mapping cannot be satisfied, emit `CAUD-009` and stop before findings unless `--allow-degraded` is explicitly present.
+- If degraded execution is explicitly permitted, continue with resolved fallback labels and mark `Execution Integrity: DEGRADED`.
+
+## Turn 2 — Prepare (deep delta)
+
+Run [default Turn 2](default.md#turn-2--prepare) bundle generation as-is. The four vector bundles are identical to default mode; the adversarial agent reads files directly rather than via bundle.
+
+## Turn 2.5 — Threat Intel Enrichment (Optional)
+
+When network access is available, run a small enrichment pass and write `{workdir}/cairo-audit-threat-intel.md`:
+
+- Read `{refs_root}/threat-intel-sources.md` first and follow its source policy.
+- Use `curl` through Bash as the query mechanism for primary-source security material (official audit reports, incident postmortems, protocol docs, vendor writeups).
+- Execute pre-checks before querying:
+  - if `curl` is missing, mark this stage `SKIPPED: no curl`,
+  - if connectivity check fails, mark this stage `SKIPPED: offline`.
+- Keep it bounded: max 6 sources and max 12 extracted signals.
+- Normalize each signal into: `date`, `source`, `class hint`, `one-line exploit shape`.
+- Prefer Cairo/Starknet first; if sparse, include high-signal EVM analogs that map to listed vectors.
+- If a fetch command fails after pre-check, mark `FAILED: curl error <code>` in execution trace and continue.
+- If unavailable/offline, continue and mark this stage as `SKIPPED` in execution trace.
+- Keep query commands/examples aligned with `threat-intel-sources.md`.
+
+Threat-intel usage rules:
+
+- Intel is a prioritization aid only.
+- Never report a finding from intel alone.
+- Every reported finding must still pass the local FP gate with a concrete in-scope path.
+
+## Turn 3 — Spawn (deep delta)
+
+Use foreground Agent tool calls only (do NOT use `run_in_background`).
+
+Resolve host-aware model labels first:
+
+- write `{workdir}/cairo-audit-model-plan.txt` with `host`, `vector_model`, and `adversarial_model`.
+- include preflight probe fields when available: `gpt_5_4_probe` and `fallback_reason`.
+- use that resolved `vector_model` for Agents 1–4 and `adversarial_model` for Agent 5.
+
+### Adaptive fanout
+
+- If the largest in-scope file is `<= 1000` lines and all bundles are `<= 1400` lines, spawn Agent 5 in parallel with Agents 1–4.
+- Otherwise, run two waves for transport stability:
+  1. **Wave A**: Agents 1–4 in parallel.
+  2. **Wave B**: Agent 5 after Wave A completes.
+
+### Agents 1–4 (vector scanning)
+
+Spawn with `model: "{vector_model}"`. Each agent prompt must contain the full text of `vector-scan.md` (read in Turn 2). After the instructions, append: `Your bundle file is {workdir}/cairo-audit-agent-N-bundle.md (XXXX lines).` (substitute the real line count). Include deterministic preflight results if available. If `{workdir}/cairo-audit-threat-intel.md` exists and has normalized signals, append a compact "Threat Intel (hints only)" block (max 12 lines) to each prompt.
+
+### Agent 5 (adversarial reasoning)
+
+Spawn with `model: "{adversarial_model}"`. The prompt must instruct it to:
+
+1. Read `{skill_root}/agents/adversarial.md` for its full instructions.
+2. Read `{refs_root}/judging.md` and `{refs_root}/report-formatting.md`.
+3. If present, read `{workdir}/cairo-audit-threat-intel.md` as a prioritization hint only.
+4. Read `{workdir}/cairo-audit-files.txt` to obtain in-scope paths, then read only those `.cairo` files directly (not via bundle).
+5. Reason freely — no attack vector reference. Look for logic errors, unsafe interactions, access control gaps, economic exploits, multi-step cross-function chains.
+6. Apply FP gate to each finding immediately.
+7. Format findings per `report-formatting.md`.
+
+After spawning, persist execution evidence:
+
+- confirm `{workdir}/cairo-audit-files.txt` exists and count in-scope files,
+- record line counts for `{workdir}/cairo-audit-agent-{1,2,3,4}-bundle.md`,
+- record whether Agent 5 was spawned in parallel (small scope) or as Wave B (large scope),
+- record each agent's observed runtime model label to `{workdir}/cairo-audit-agent-models.txt` (use actual spawn metadata; if not exposed, use `default` or `unknown`).
+
+### Transport resilience
+
+- If the agent transport reports disconnect/fallback warnings or a specialist stalls with no completion, retry that specialist exactly once.
+- Adaptive stall timeout by largest bundle size:
+  - `<= 1200` lines: 180 seconds (parallel-spawn baseline)
+  - `1201-1400` lines: 360 seconds (still parallel-spawn eligible; extra time for larger bundles)
+  - `1401-1800` lines: 360 seconds (Wave B regime)
+  - `> 1800` lines: 600 seconds (Wave B regime, very large bundles)
+- Retry failed/stalled specialists serially (one at a time) to reduce transport saturation.
+- If retry still fails, treat the specialist as unavailable and apply the integrity gate below.
+
+### Integrity gate
+
+For hosts where deep-mode enforcement is enabled, fail-closed semantics apply (full table is in [SKILL.md error codes](../SKILL.md#error-codes-and-recovery)):
+
+- If any required specialist agent (1-4 or 5) cannot be spawned or returns unavailable: emit `CAUD-006`, stop before findings, print host remediation hints. `--allow-degraded` opts into degraded execution.
+- If a specialist output is malformed (not `No findings.` and not valid finding blocks): rerun once. If still malformed, treat as unavailable.
+- `--strict-models` failure: emit `CAUD-009`. Same `--allow-degraded` carve-out.
+- Preflight failure: emit `CAUD-007`. Same `--allow-degraded` carve-out.
+
+## Turn 4 — Report (deep delta)
+
+Run [default Turn 4](default.md#turn-4--report) merge/dedupe/sort/emit, then add the deep-only evidence tag:
+
+- Add `[ADVERSARIAL]` if Agent 5 discovered or confirmed the finding.
+
+For degraded execution:
+
+- Mark scope mode as `degraded-deep`.
+- Set `Execution Integrity: DEGRADED`.
+- Include an explicit warning line at top: `WARNING: degraded execution (specialist agents unavailable)`.
+- Repeat a second warning immediately before `Findings Index`: `WARNING: degraded execution may omit exploitable paths`.
 
 ## When to Use Deep Mode
 

--- a/skills/cairo-auditor/workflows/deep.md
+++ b/skills/cairo-auditor/workflows/deep.md
@@ -37,25 +37,29 @@ Run the [default Turn 1](default.md#turn-1--discover) base steps (workdir, file 
 
 ### Host Capability Preflight (Experimental)
 
-The host-capability preflight is an experimental hardening path. Use it when your host exposes specialist-agent capability checks. Run a lightweight check and emit a one-line status:
+The host-capability preflight is an experimental hardening path. Use it when your host exposes specialist-agent capability checks. Run the probes below and persist their results to `{workdir}/cairo-audit-host-capabilities.json`. Each probe records one of `OK`, `SKIPPED: <reason>`, or `FAILED: <reason>`. Probes are split into two classes with different blocking semantics:
+
+**Blocking probes (capability):** failure means deep mode cannot run as designed.
 
 - Detect host family: `codex`, `claude-code`, or `unknown`.
-- Verify Agent tool availability and ability to spawn specialist agents.
-- Deep mode requires 5 specialist agents total (Agents 1-4 + Agent 5 adversarial).
-- Verify threat-intel fetch capability via Bash:
-  - `command -v curl` must succeed, and
-  - `curl -sfI --connect-timeout 5 --max-time 10 https://starknet.io` must succeed.
+- Verify Agent tool availability and ability to spawn specialist agents (deep mode requires 5: Agents 1–4 + Agent 5 adversarial).
+
+**Non-blocking probes (connectivity / model availability):** record evidence; do not abort.
+
+- Threat-intel fetch capability via Bash. Each step records its own status:
+  - `command -v curl` → `OK` or `SKIPPED: no curl`.
+  - `curl -sfI --connect-timeout 5 --max-time 10 https://starknet.io` → `OK` or `FAILED: curl error <code>` or `SKIPPED: offline`.
 - For `codex` hosts, probe preferred model availability before spawn:
   - run one lightweight specialist probe using `model: gpt-5.4`,
-  - persist success/failure and fallback decision.
-- Persist preflight evidence to `{workdir}/cairo-audit-host-capabilities.json` when the probe is available.
+  - record `OK`, `FAILED`, and the chosen fallback in `cairo-audit-host-capabilities.json` (the model-routing fallback path in [Host-Aware Model Routing](#host-aware-model-routing) consumes this).
 
-If preflight fails (in hosts where preflight is enabled):
+**Failure handling:**
 
-- Without `--allow-degraded`: emit `CAUD-007`, print remediation, and stop before findings.
-- With `--allow-degraded`: continue in `degraded-deep` mode and keep explicit warning lines in scope and execution trace.
+- Capability failure (Agent tool unavailable) without `--allow-degraded`: emit `CAUD-007`, print remediation, stop before findings.
+- Capability failure with `--allow-degraded`: continue in `degraded-deep` mode and keep explicit warning lines in scope and execution trace.
+- Connectivity failure (threat-intel probes) is non-blocking by default: continue without threat-intel enrichment and mark Turn 2.5 as `SKIPPED`/`FAILED` in the execution trace. The `--strict-models` gate independently handles model-availability failures (see [strict-model gate](#host-aware-model-routing)).
 
-Remediation hints to print when preflight fails:
+Remediation hints to print when capability preflight fails:
 
 - `codex`: `codex features enable multi_agent`, then verify with `codex features list`, then restart the session.
 - `claude-code`: run `/reload-plugins`, update the installed plugin if needed, and retry deep mode.

--- a/skills/cairo-auditor/workflows/default.md
+++ b/skills/cairo-auditor/workflows/default.md
@@ -184,6 +184,8 @@ Transport resilience: if a specialist stalls or returns malformed output, retry 
 
 ## Turn 4 — Report
 
+This Turn is canonical for both default and deep modes; deep inherits the steps below (including the `--proven-only` cap), then adds the `[ADVERSARIAL]` evidence tag and any degraded-execution warnings ([deep.md Turn 4](deep.md#turn-4--report-deep-delta)).
+
 Merge all agent results and emit the report in canonical order:
 
 1. Deduplicate by root cause (keep the higher-confidence version, merge broader attack path details; on confidence tie keep higher priority, then more complete path evidence).
@@ -191,14 +193,15 @@ Merge all agent results and emit the report in canonical order:
    - Validate every finding has `[CODE-TRACE]`; if a source agent omitted it, add `[CODE-TRACE]` during merge normalization.
    - Add `[PREFLIGHT-HIT]` if the deterministic preflight flagged the same class or entry point.
    - Add `[CROSS-AGENT]` if 2+ agents independently reported the same root cause before deduplication.
-3. Findings with only `[CODE-TRACE]` (no additional tags) are valid but lower-signal; reviewers use the Evidence column in Findings Index to prioritize review order.
-4. Sort findings by priority (`P0` first); within each priority tier sort by confidence (highest first).
-5. Re-number findings sequentially starting at `1`.
-6. Insert one **Below Confidence Threshold** separator row in the findings index immediately before the first finding with confidence < 75.
-7. Print findings directly — do not re-draft or re-describe them.
-8. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`.
-9. Add scope table and findings index table per `references/report-formatting.md`.
-10. Add the disclaimer.
+3. **Apply the `--proven-only` severity cap (if the flag was passed):** for any finding whose only evidence tag is `[CODE-TRACE]`, cap `severity` at `Low` before sorting. This must run before step 4 so the sort sees post-cap severity. Findings with stronger evidence (`[PREFLIGHT-HIT]`, `[CROSS-AGENT]`, `[ADVERSARIAL]` from deep mode) keep their original severity.
+4. Findings with only `[CODE-TRACE]` (no additional tags) are valid but lower-signal; reviewers use the Evidence column in Findings Index to prioritize review order.
+5. Sort findings by priority (`P0` first); within each priority tier sort by confidence (highest first).
+6. Re-number findings sequentially starting at `1`.
+7. Insert one **Below Confidence Threshold** separator row in the findings index immediately before the first finding with confidence < 75.
+8. Print findings directly — do not re-draft or re-describe them.
+9. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`.
+10. Add scope table and findings index table per `references/report-formatting.md`.
+11. Add the disclaimer.
 
 ### Dropped-candidate handling
 

--- a/skills/cairo-auditor/workflows/default.md
+++ b/skills/cairo-auditor/workflows/default.md
@@ -2,9 +2,11 @@
 
 Standard 4-agent parallel scan. Orchestrated by [SKILL.md](../SKILL.md).
 
+This workflow is also the canonical orchestration base. Deep mode ([deep.md](deep.md)) extends it with preflight, model routing, threat intel, and an adversarial agent.
+
 ## Pipeline
 
-1. **Discover** — `find` in-scope `.cairo` files, run deterministic preflight.
+1. **Discover** — resolve `{workdir}`, `find` in-scope `.cairo` files, run deterministic preflight (skipped in `$filename ...` mode).
 2. **Prepare** — Read `vector-scan.md`, build 4 bundle files (code + judging + formatting + one attack-vector partition each).
 3. **Spawn** — 4 parallel vector specialists with host-aware vector model (`claude-code: sonnet`, `codex: gpt-5.4` with fallback `gpt-5.2`), each triages vectors, deep-checks survivors, applies FP gate.
 4. **Report** — Merge, deduplicate by root cause, apply optional `--proven-only` severity cap for `[CODE-TRACE]`-only findings, sort by confidence, emit with scope table and disclaimer.
@@ -24,3 +26,184 @@ Standard 4-agent parallel scan. Orchestrated by [SKILL.md](../SKILL.md).
 - If confidence is < 75: keep as low-confidence notes, no fix block.
 - If `--proven-only` is set and a finding is `[CODE-TRACE]` only: cap severity to Low.
 - If the FP gate fails: drop the item entirely.
+
+---
+
+## Turn 1 — Discover
+
+In a single message, make parallel tool calls.
+
+### (a) Resolve `{workdir}`
+
+- If `CAIRO_AUDITOR_WORKDIR` is set, use it as `{workdir}`.
+- Otherwise create one with `mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX"` and `chmod 700`.
+- Print `WORKDIR=<absolute-path>` in Turn 1 output and reuse that exact path as `{workdir}` for all later turns.
+
+### (b) Enumerate in-scope files
+
+For default and deep modes:
+
+```bash
+WORKDIR="${CAIRO_AUDITOR_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX")}"
+chmod 700 "$WORKDIR"
+echo "WORKDIR=$WORKDIR"
+find <repo-root> \
+  \( -type d \( -name test -o -name tests -o -name mock -o -name mocks -o -name example -o -name examples -o -name fixture -o -name fixtures -o -name vendor -o -name vendors -o -name preset -o -name presets \) -prune \) \
+  -o \( -type f -name "*.cairo" ! -name "*_test.cairo" ! -name "*Test*.cairo" -print \) \
+  | sort > "$WORKDIR/cairo-audit-files.txt"
+cat "$WORKDIR/cairo-audit-files.txt"
+```
+
+For **`$filename ...`** mode, do not run `find`. Instead:
+
+```bash
+WORKDIR="${CAIRO_AUDITOR_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/cairo-auditor.XXXXXX")}"
+chmod 700 "$WORKDIR"
+echo "WORKDIR=$WORKDIR"
+REPO_ROOT=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "<repo-root>")
+> "$WORKDIR/cairo-audit-files.txt"
+for f in "$@"; do
+  [ -z "$f" ] && continue
+  ABS_PATH=$(python3 - "$REPO_ROOT" "$f" <<'PY'
+import os
+import sys
+
+repo_root, arg = sys.argv[1], sys.argv[2]
+candidate = arg if os.path.isabs(arg) else os.path.join(repo_root, arg)
+print(os.path.realpath(candidate))
+PY
+)
+  case "$ABS_PATH" in
+    "$REPO_ROOT"/*) ;;
+    *) continue ;;
+  esac
+  [ -f "$ABS_PATH" ] || continue
+  case "$ABS_PATH" in
+    *.cairo) echo "$ABS_PATH" >> "$WORKDIR/cairo-audit-files.txt" ;;
+  esac
+done
+sort -u -o "$WORKDIR/cairo-audit-files.txt" "$WORKDIR/cairo-audit-files.txt"
+cat "$WORKDIR/cairo-audit-files.txt"
+```
+
+If the file list is empty, emit `CAUD-001` and stop.
+
+### (c) Resolve skill paths
+
+Glob for `**/references/attack-vectors/attack-vectors-1.md` and resolve:
+
+- `{refs_root}` = two levels up from the match (`.../references`)
+- `{skill_root}` = three levels up from the match (skill directory that contains `SKILL.md`, `agents/`, `references/`, `VERSION`)
+
+### (d) Deterministic preflight
+
+If `{skill_root}/scripts/quality/audit_local_repo.py` exists, run preflight for full-repo modes only (default/deep). In `$filename ...` mode, skip preflight so the context stays scoped to the targeted files:
+
+```bash
+python3 "{skill_root}/scripts/quality/audit_local_repo.py" --repo-root <repo-root> --scan-id preflight --output-dir "{workdir}"
+```
+
+Print the preflight results (class counts, severity counts) as context for specialists.
+
+## Turn 2 — Prepare
+
+In a single message, make three parallel tool calls:
+
+### (a) Read `{skill_root}/agents/vector-scan.md`
+
+You will paste this full text into every agent prompt.
+
+### (b) Read `{refs_root}/report-formatting.md`
+
+You will use this for the final report.
+
+### (c) Build per-agent bundle files
+
+In a **single command**, create four per-agent bundle files (`{workdir}/cairo-audit-agent-{1,2,3,4}-bundle.md`). Each bundle concatenates:
+
+- **all** in-scope `.cairo` files (with `### path` headers and fenced code blocks),
+- `{refs_root}/judging.md`,
+- `{refs_root}/report-formatting.md`,
+- `{refs_root}/attack-vectors/attack-vectors-N.md` (one per agent — only the attack-vectors file differs).
+
+Print line counts per bundle. Before running this command, substitute placeholders (`{refs_root}`, `{repo-root}`, `{workdir}`) with the concrete paths resolved in Turn 1.
+
+```bash
+REFS="{refs_root}"
+SRC="{repo-root}"
+WORKDIR="{workdir}"
+IN_SCOPE="$WORKDIR/cairo-audit-files.txt"
+set -euo pipefail
+
+build_code_block() {
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    REL=$(echo "$f" | sed "s|$SRC/||")
+    echo "### $REL"
+    echo '```cairo'
+    cat "$f"
+    echo '```'
+    echo ""
+  done < "$IN_SCOPE"
+}
+
+CODE=$(build_code_block)
+
+for i in 1 2 3 4; do
+  {
+    echo "$CODE"
+    echo "---"
+    cat "$REFS/judging.md"
+    echo "---"
+    cat "$REFS/report-formatting.md"
+    echo "---"
+    cat "$REFS/attack-vectors/attack-vectors-$i.md"
+  } > "$WORKDIR/cairo-audit-agent-$i-bundle.md"
+  echo "Bundle $i: $(wc -l < "$WORKDIR/cairo-audit-agent-$i-bundle.md") lines"
+done
+```
+
+Do NOT inline source-code files into prompts. Bundles replace raw source in prompts. Non-code context blocks (deterministic preflight summary and optional threat-intel summary) may be appended.
+
+If any bundle ends up with zero lines, emit `CAUD-003` and rebuild before spawning.
+
+## Turn 3 — Spawn
+
+Use foreground Agent tool calls only (do NOT use `run_in_background`). Spawn Agents 1–4 in parallel.
+
+For each agent, pass `model: "sonnet"` (Claude Code) or the host-resolved vector model. The prompt must contain the full text of `vector-scan.md` (read in Turn 2). After the instructions, append: `Your bundle file is {workdir}/cairo-audit-agent-N-bundle.md (XXXX lines).` (substitute the real line count). Include deterministic preflight results if available.
+
+After spawning, persist execution evidence that will be reused in the final report:
+
+- confirm `{workdir}/cairo-audit-files.txt` exists and count in-scope files,
+- record line counts for `{workdir}/cairo-audit-agent-{1,2,3,4}-bundle.md`,
+- record `Agent 5: skipped (default mode)` for the execution trace,
+- record each agent's observed runtime model label to `{workdir}/cairo-audit-agent-models.txt` (use actual spawn metadata; if not exposed, use `default` or `unknown`).
+
+Transport resilience: if a specialist stalls or returns malformed output, retry that specialist exactly once. Use a 180-second stall timeout for default-mode bundles (typically `<= 1200` lines).
+
+## Turn 4 — Report
+
+Merge all agent results and emit the report in canonical order:
+
+1. Deduplicate by root cause (keep the higher-confidence version, merge broader attack path details; on confidence tie keep higher priority, then more complete path evidence).
+2. Apply evidence tags per `references/judging.md` Evidence Tags section:
+   - Validate every finding has `[CODE-TRACE]`; if a source agent omitted it, add `[CODE-TRACE]` during merge normalization.
+   - Add `[PREFLIGHT-HIT]` if the deterministic preflight flagged the same class or entry point.
+   - Add `[CROSS-AGENT]` if 2+ agents independently reported the same root cause before deduplication.
+3. Findings with only `[CODE-TRACE]` (no additional tags) are valid but lower-signal; reviewers use the Evidence column in Findings Index to prioritize review order.
+4. Sort findings by priority (`P0` first); within each priority tier sort by confidence (highest first).
+5. Re-number findings sequentially starting at `1`.
+6. Insert one **Below Confidence Threshold** separator row in the findings index immediately before the first finding with confidence < 75.
+7. Print findings directly — do not re-draft or re-describe them.
+8. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`.
+9. Add scope table and findings index table per `references/report-formatting.md`.
+10. Add the disclaimer.
+
+### Dropped-candidate handling
+
+- If a candidate is discarded during FP gate or dedupe, add one row in `Dropped Candidates` with `candidate`, `class`, and `drop_reason`.
+- Accepted `drop_reason` values: `false_positive`, `duplicate_root_cause`, `below_confidence_threshold`, `insufficient_evidence`.
+- If none were dropped, still include the section with a single `none` row.
+
+If `--file-output` is set, write the report to `{repo-root}/security-review-{timestamp}.md` and print the path.

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -11,7 +11,7 @@
       "skill_md_path": "skills/account-abstraction/SKILL.md"
     },
     {
-      "description": "Security audit of Cairo/Starknet code. Trigger on \"audit\", \"check this contract\", \"review for security\". Modes - default (full repo), deep (+ adversarial reasoning), or specific filenames.",
+      "description": "Security audit of Cairo/Starknet smart contracts. Trigger on phrases like \"audit this Cairo contract\", \"Starknet security review\", \"check this .cairo file for vulnerabilities\", \"release-gate audit\", or invoking the `cairo-auditor` command. Supports default (full-repo `.cairo` scan), deep (adds adversarial reasoning agent), and targeted-file modes. Do NOT trigger for Solidity/EVM audits, dependency-vulnerability scans, or general code review.",
       "install": "npx skills add keep-starknet-strange/starknet-agentic/skills/cairo-auditor",
       "name": "cairo-auditor",
       "raw_skill_md_url": "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/cairo-auditor/SKILL.md",


### PR DESCRIPTION
…nto workflows, add tests

Tightens the SKILL.md trigger description with Cairo/Starknet-specific phrases and explicit anti-triggers (Solidity, dependency scans).

Inverts progressive disclosure: SKILL.md (423 -> 165 lines) now holds only the trigger contract, mode/flag tables, error-code table, and the single source of truth for fail-closed semantics. The full Turn 1-4 bash orchestration moves into workflows/default.md (canonical base) and workflows/deep.md (deep-only deltas: host preflight, model routing, threat intel, adversarial agent, integrity gate). Removes the out-of-place starknet.js example.

Fixes scripts/doctor.sh to auto-discover the most recent cairo-auditor.* directory under \$TMPDIR / /tmp, matching the per-run mktemp -d workdir the orchestration creates. Friendlier message when no workdir is found.

Adds two orchestrator-level tests:
- validate_bundle_generation.py: runs the documented bundle bash on the insecure_upgrade_controller fixture and asserts 4 non-empty bundles each contain source + judging + report-formatting + correct attack-vectors-N.
- validate_failclosed_contract.py: pins SKILL.md as owner of CAUD-006/007/009
  + --allow-degraded carve-out, deep.md as owner of the Integrity Gate and WARNING lines, and confirms default.md does not duplicate that logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote version check with local validation and silent-fail behavior.
  * Deep-mode fail-closed enforcement with degraded-execution tracking and integrity markers; explicit error codes and allow-degraded option.
  * Deterministic per-agent bundle generation for audits.

* **Documentation**
  * Clarified Cairo/Starknet audit scope, orchestration (Turn 1–4) and reporting/ordering requirements.
  * Condensed flags/mode docs and added version/banner guidance.

* **Tests**
  * CI validations for bundle generation and fail-closed contract contract enforcement.

* **Bug Fixes**
  * More robust workdir resolution and clearer "no workdir" messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->