### PR TITLE
chore(build): emit dts via tsc to unblock TypeScript 6

### DIFF
--- a/packages/create-starknet-agent/package.json
+++ b/packages/create-starknet-agent/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean",
+    "build": "tsup src/index.ts --format esm --clean && tsc -p tsconfig.build.json --noCheck",
     "dev": "tsup src/index.ts --format esm --watch",
     "prepublishOnly": "pnpm build",
     "test": "vitest run",

--- a/packages/create-starknet-agent/tsconfig.build.json
+++ b/packages/create-starknet-agent/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/prediction-arb-scanner/package.json
+++ b/packages/prediction-arb-scanner/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/prediction-arb-scanner/tsconfig.build.json
+++ b/packages/prediction-arb-scanner/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsup src/string.ts --format esm --dts --outDir dist"
+    "build": "tsup src/string.ts --format esm --outDir dist && tsc -p tsconfig.build.json --noCheck"
   },
   "exports": {
     "./string": {

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "dev": "tsup src/index.ts --format esm --watch",
     "test": "vitest run"
   },

--- a/packages/starknet-a2a/tsconfig.build.json
+++ b/packages/starknet-a2a/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/starknet-agent-passport/package.json
+++ b/packages/starknet-agent-passport/package.json
@@ -9,7 +9,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "dev": "tsup src/index.ts --format esm --watch",
     "test": "vitest run"
   },

--- a/packages/starknet-agent-passport/tsconfig.build.json
+++ b/packages/starknet-agent-passport/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "dev": "tsup src/index.ts --format esm --watch",
     "pretest": "pnpm --filter @starknet-agentic/x402-starknet build",
     "test": "vitest run",

--- a/packages/starknet-mcp-server/tsconfig.build.json
+++ b/packages/starknet-mcp-server/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/starknet-onboarding-utils/package.json
+++ b/packages/starknet-onboarding-utils/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/starknet-onboarding-utils/tsconfig.build.json
+++ b/packages/starknet-onboarding-utils/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/x402-starknet/package.json
+++ b/packages/x402-starknet/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "pnpm --filter @starknet-agentic/shared build && tsup src/index.ts --format esm --dts",
+    "build": "pnpm --filter @starknet-agentic/shared build && tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "test": "vitest run",
     "lint": "eslint ."
   },

--- a/packages/x402-starknet/tsconfig.build.json
+++ b/packages/x402-starknet/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary
- Replace `tsup ... --dts` with `tsup ... && tsc -p tsconfig.build.json --noCheck` across all 8 TS packages
- Add per-package `tsconfig.build.json` (src-only, tests excluded, `emitDeclarationOnly`)

## Why
tsup's internal `--dts` step (rollup-plugin-dts) injects `baseUrl` into its in-memory compilerOptions, which TypeScript 6.0 rejects with `TS5101`. This blocks the TS 6.0.3 bump dependabot proposes in #394 — see that PR's failing Type Check / Test / Onboarding Smoke jobs.

Switching the dts step to direct `tsc` sidesteps the injected option entirely.

## Notes
- `--noCheck` preserves prior build behavior: tsup's `--dts` was already silently suppressing type errors. For example, on main `starknet-mcp-server/dist/index.d.ts` was a 20-byte stub (`#!/usr/bin/env node`) — real type errors in `helpers/keyringProxySigner.ts` and `services/TokenService.ts` never surfaced. Fixing those is out of scope for this unblock.
- Lint/typecheck jobs remain separate sources of truth for type correctness.

## Test plan
- [x] `pnpm build` passes locally on TypeScript 5.9.3
- [x] `pnpm build` passes locally on TypeScript 6.0.3
- [ ] CI green on this PR
- [ ] Rebase #394 on top of this and confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)