### PR TITLE
ci: drop pnpm/action-setup version to unblock PR #354

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -147,8 +145,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -172,8 +168,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -359,8 +353,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -480,8 +472,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@53751a9789c7351e4924f01fe68370252a4f1f18 # v2
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@53751a9789c7351e4924f01fe68370252a4f1f18
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.28.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/signer-auth-conformance.yml
+++ b/.github/workflows/signer-auth-conformance.yml
@@ -74,8 +74,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@53751a9789c7351e4924f01fe68370252a4f1f18 # v2.4.1
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
## Summary
- Remove the redundant `with: version:` input from every `pnpm/action-setup` step across 5 workflows
- `packageManager: pnpm@10.28.2` in root `package.json` remains the single source of truth

## Why
Dependabot's #354 bumps `pnpm/action-setup` SHAs. The newer action code refuses to run when both a workflow-level `version:` and a `packageManager` field are present:

\`\`\`
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.28.2 in the package.json with the key "packageManager"
Remove one of these versions...
\`\`\`

That's what fails the `signer-auth-conformance / runtime` check on #354. Once this lands, #354 can be rebased and will go green.

This change is safe on current main too — `pnpm/action-setup` has read `packageManager` from `package.json` for several versions, so dropping the redundant input is a no-op for the current SHAs while also fixing the upcoming bump.

## Test plan
- [ ] CI green on this PR
- [ ] Rebase #354 on top; `signer-auth-conformance / runtime` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)