### PR TITLE
chore: rename npm scope to @starknetfoundation/starknet-agentic-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
         run: pnpm --dir examples/onboard-agent install --frozen-lockfile
 
       - name: Build shared workspace package
-        run: pnpm --filter @starknet-agentic/shared build
+        run: pnpm --filter @starknetfoundation/starknet-agentic-shared build
 
       - name: Run onboarding smoke checks
         run: pnpm --dir examples/onboard-agent smoke

--- a/.github/workflows/session-signature-v2-conformance.yml
+++ b/.github/workflows/session-signature-v2-conformance.yml
@@ -142,7 +142,7 @@ jobs:
           EOF_JS
 
       - name: Run session vector conformance tests
-        run: pnpm --filter @starknet-agentic/mcp-server test -- __tests__/helpers/sessionSignatureVectors.test.ts
+        run: pnpm --filter @starknetfoundation/starknet-agentic-mcp-server test -- __tests__/helpers/sessionSignatureVectors.test.ts
 
   parity_with_external_repos:
     runs-on: ubuntu-latest

--- a/.github/workflows/signer-auth-conformance.yml
+++ b/.github/workflows/signer-auth-conformance.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run auth conformance vectors (shows failing vector IDs)
         run: |
-          pnpm --filter @starknet-agentic/mcp-server test -- __tests__/helpers/keyringAuthVectors.test.ts
+          pnpm --filter @starknetfoundation/starknet-agentic-mcp-server test -- __tests__/helpers/keyringAuthVectors.test.ts
 
   parity_with_counterparts:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ For production environments, use MCP proxy signer mode rather than raw in-proces
 | Package | Path | Purpose |
 |---|---|---|
 | `create-starknet-agent` | [`packages/create-starknet-agent`](./packages/create-starknet-agent/) | Scaffolds/installs Starknet agent integration |
-| `@starknet-agentic/mcp-server` | [`packages/starknet-mcp-server`](./packages/starknet-mcp-server/) | Starknet operations over MCP |
-| `@starknet-agentic/a2a` | [`packages/starknet-a2a`](./packages/starknet-a2a/) | A2A protocol adapter |
-| `@starknet-agentic/agent-passport` | [`packages/starknet-agent-passport`](./packages/starknet-agent-passport/) | ERC-8004 capability metadata helpers |
-| `@starknet-agentic/prediction-arb-scanner` | [`packages/prediction-arb-scanner`](./packages/prediction-arb-scanner/) | Signals-only prediction market arb scanner output model |
-| `@starknet-agentic/onboarding-utils` | [`packages/starknet-onboarding-utils`](./packages/starknet-onboarding-utils/) | Shared onboarding helpers |
+| `@starknetfoundation/starknet-agentic-mcp-server` | [`packages/starknet-mcp-server`](./packages/starknet-mcp-server/) | Starknet operations over MCP |
+| `@starknetfoundation/starknet-agentic-a2a` | [`packages/starknet-a2a`](./packages/starknet-a2a/) | A2A protocol adapter |
+| `@starknetfoundation/starknet-agentic-agent-passport` | [`packages/starknet-agent-passport`](./packages/starknet-agent-passport/) | ERC-8004 capability metadata helpers |
+| `@starknetfoundation/starknet-agentic-prediction-arb-scanner` | [`packages/prediction-arb-scanner`](./packages/prediction-arb-scanner/) | Signals-only prediction market arb scanner output model |
+| `@starknetfoundation/starknet-agentic-onboarding-utils` | [`packages/starknet-onboarding-utils`](./packages/starknet-onboarding-utils/) | Shared onboarding helpers |
 
 ### Skills
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,12 +23,12 @@ Core infrastructure features required for v1.0 release. MVP definition: MCP serv
 **Description**: Publish all complete skills to GitHub, ClawHub, and other channels for maximum distribution.
 
 **Requirements**:
-- [x] Register/Setup Publication for `@starknet-agentic/skill-wallet`
-- [x] Register/Setup Publication for `@starknet-agentic/skill-defi`
-- [x] Register/Setup Publication for `@starknet-agentic/skill-identity`
-- [x] Register/Setup Publication for `@starknet-agentic/skill-mini-pay`
-- [x] Register/Setup Publication for `@starknet-agentic/skill-anonymous-wallet`
-- [x] Register/Setup Publication for `@starknet-agentic/huginn-onboard`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-skill-wallet`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-skill-defi`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-skill-identity`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-skill-mini-pay`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-skill-anonymous-wallet`
+- [x] Register/Setup Publication for `@starknetfoundation/starknet-agentic-huginn-onboard`
 - [ ] Publish skills to ClawHub for OpenClaw/MoltBook users (blocked: CLI not on npm, publishing workflow undocumented)
 - [x] Update skills README with installation instructions for all channels
 - [x] Set up automated publishing in CI workflow

--- a/docs/demos/secure-agent-defi.md
+++ b/docs/demos/secure-agent-defi.md
@@ -61,7 +61,7 @@ Schema source:
 Before execute mode:
 
 1. Build MCP server dist:
-   - `pnpm --filter @starknet-agentic/mcp-server build`
+   - `pnpm --filter @starknetfoundation/starknet-agentic-mcp-server build`
 2. Ensure funded test account:
    - `STARKNET_ACCOUNT_ADDRESS`
 3. Configure signer authentication mode:

--- a/docs/guides/openclaw-quickstart.md
+++ b/docs/guides/openclaw-quickstart.md
@@ -20,7 +20,7 @@ Add the MCP server to your agent runtime config and set env vars:
   "mcpServers": {
     "starknet": {
       "command": "npx",
-      "args": ["@starknet-agentic/mcp-server"],
+      "args": ["@starknetfoundation/starknet-agentic-mcp-server"],
       "env": {
         "STARKNET_RPC_URL": "https://starknet-sepolia-rpc.publicnode.com",
         "STARKNET_ACCOUNT_ADDRESS": "0x...",

--- a/examples/carry-agent/README.md
+++ b/examples/carry-agent/README.md
@@ -43,13 +43,13 @@ pip install x10-python-trading-starknet==0.0.17
 From the repository root:
 
 ```bash
-pnpm --filter @starknet-agentic/carry-agent-demo run run
+pnpm --filter @starknetfoundation/starknet-agentic-carry-agent-demo run run
 ```
 
 Execute mode with safety rails:
 
 ```bash
-pnpm --filter @starknet-agentic/carry-agent-demo run run:execute
+pnpm --filter @starknetfoundation/starknet-agentic-carry-agent-demo run run:execute
 ```
 
 Spot execution through MCP (Starknet tool surface):
@@ -58,7 +58,7 @@ From the repository root:
 
 ```bash
 # build MCP server once
-pnpm --filter @starknet-agentic/mcp-server build
+pnpm --filter @starknetfoundation/starknet-agentic-mcp-server build
 
 # run carry agent with spot execution delegated to MCP starknet_swap
 CARRY_RUN_MODE=execute \
@@ -67,7 +67,7 @@ CARRY_EXTENDED_PYTHON_BIN=examples/carry-agent/.venv/bin/python \
 STARKNET_RPC_URL=https://starknet-sepolia-rpc.publicnode.com \
 STARKNET_ACCOUNT_ADDRESS=0x... \
 STARKNET_PRIVATE_KEY=0x... \
-pnpm --filter @starknet-agentic/carry-agent-demo run run
+pnpm --filter @starknetfoundation/starknet-agentic-carry-agent-demo run run
 ```
 
 Output:
@@ -80,8 +80,8 @@ Output:
 From the repository root:
 
 ```bash
-pnpm --filter @starknet-agentic/carry-agent-demo test
-pnpm --filter @starknet-agentic/carry-agent-demo typecheck
+pnpm --filter @starknetfoundation/starknet-agentic-carry-agent-demo test
+pnpm --filter @starknetfoundation/starknet-agentic-carry-agent-demo typecheck
 ```
 
 ## Safety notes

--- a/examples/carry-agent/package.json
+++ b/examples/carry-agent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/carry-agent-demo",
+  "name": "@starknetfoundation/starknet-agentic-carry-agent-demo",
   "version": "0.1.0",
   "private": true,
   "description": "Deterministic carry monitor example for Starknet-agentic using Extended market data.",

--- a/examples/crosschain-demo/package.json
+++ b/examples/crosschain-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/crosschain-demo",
+  "name": "@starknetfoundation/starknet-agentic-crosschain-demo",
   "version": "0.1.0",
   "private": true,
   "description": "Cross-chain ERC-8004 demo: Base Sepolia registration + Starknet onboarding",
@@ -10,10 +10,10 @@
     "demo:verify": "npx tsx run.ts --gasfree --verify-tx",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "pretest": "pnpm --filter @starknet-agentic/onboarding-utils build"
+    "pretest": "pnpm --filter @starknetfoundation/starknet-agentic-onboarding-utils build"
   },
   "dependencies": {
-    "@starknet-agentic/onboarding-utils": "workspace:*",
+    "@starknetfoundation/starknet-agentic-onboarding-utils": "workspace:*",
     "dotenv": "^17.4.2",
     "ethers": "^6.16.0",
     "starknet": "^9.4.2"

--- a/examples/crosschain-demo/run.ts
+++ b/examples/crosschain-demo/run.ts
@@ -13,7 +13,7 @@ import {
   cairo,
 } from "starknet";
 import { Contract, Interface, JsonRpcProvider, Wallet, ZeroAddress } from "ethers";
-import { waitForTransactionWithTimeout } from "@starknet-agentic/onboarding-utils";
+import { waitForTransactionWithTimeout } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import { preflight } from "./steps/preflight.js";
 import { deployAccount } from "./steps/deploy-account.js";
 import { fundDeployer } from "./steps/fund-deployer.js";

--- a/examples/crosschain-demo/steps/deploy-account.ts
+++ b/examples/crosschain-demo/steps/deploy-account.ts
@@ -2,7 +2,7 @@ import {
   deployAccountViaFactory,
   type DeployerAccountLike,
   type ProviderLike,
-} from "@starknet-agentic/onboarding-utils";
+} from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import type { StarknetNetworkConfig } from "../config.js";
 
 export interface DeployAccountResult {

--- a/examples/crosschain-demo/steps/first-action.ts
+++ b/examples/crosschain-demo/steps/first-action.ts
@@ -1,4 +1,4 @@
-import { firstActionBalances } from "@starknet-agentic/onboarding-utils";
+import { firstActionBalances } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import type { RpcProvider } from "starknet";
 import { TOKENS } from "../config.js";
 

--- a/examples/crosschain-demo/steps/preflight.ts
+++ b/examples/crosschain-demo/steps/preflight.ts
@@ -1,4 +1,4 @@
-import { preflightStarknet } from "@starknet-agentic/onboarding-utils";
+import { preflightStarknet } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import type { Account, RpcProvider } from "starknet";
 import { STARKNET_NETWORKS, TOKENS, type StarknetNetworkConfig } from "../config.js";
 

--- a/examples/crosschain-demo/tsconfig.json
+++ b/examples/crosschain-demo/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "paths": {
-      "@starknet-agentic/onboarding-utils": [
+      "@starknetfoundation/starknet-agentic-onboarding-utils": [
         "../../packages/starknet-onboarding-utils/src/index.ts"
       ]
     },

--- a/examples/defi-agent/README.md
+++ b/examples/defi-agent/README.md
@@ -258,7 +258,7 @@ await this.findArbitrage(TOKENS.STRK, TOKENS.USDC, amount);
 ### Add On-Chain Identity
 
 ```typescript
-import { createStarknetA2AAdapter } from "@starknet-agentic/a2a";
+import { createStarknetA2AAdapter } from "@starknetfoundation/starknet-agentic-a2a";
 
 const adapter = createStarknetA2AAdapter({ ... });
 await adapter.registerAgent(account, {

--- a/examples/erc8004-validation-demo/package.json
+++ b/examples/erc8004-validation-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/erc8004-validation-demo",
+  "name": "@starknetfoundation/starknet-agentic-erc8004-validation-demo",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/examples/full-stack-swarm/README.md
+++ b/examples/full-stack-swarm/README.md
@@ -4,7 +4,7 @@ This is an end-to-end demo that shows the “whole stack” working together:
 
 - **On-chain session keys + spending caps**: `contracts/session-account`
 - **Hardened signer boundary**: [SISNA](https://github.com/omarespejel/SISNA) (session keys never touch the agent runtime)
-- **Agent tool surface**: `@starknet-agentic/mcp-server` (MCP tools)
+- **Agent tool surface**: `@starknetfoundation/starknet-agentic-mcp-server` (MCP tools)
 - **Gasless execution**: AVNU Paymaster (sponsored)
 - **On-chain identity**: ERC-8004 (IdentityRegistry)
 
@@ -59,7 +59,7 @@ Signer provider options:
 ## Run
 
 ```bash
-pnpm --filter @starknet-agentic/full-stack-swarm-example run
+pnpm --filter @starknetfoundation/starknet-agentic-full-stack-swarm-example run
 ```
 
 The script writes a local `state.json` (contains keys; do not share) and prints a JSON report you can screenshot.

--- a/examples/full-stack-swarm/package.json
+++ b/examples/full-stack-swarm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/full-stack-swarm-example",
+  "name": "@starknetfoundation/starknet-agentic-full-stack-swarm-example",
   "version": "0.1.0",
   "private": true,
   "description": "Full stack swarm demo: SessionAccount + SISNA signer boundary + MCP tools + AVNU gasless + ERC-8004",

--- a/examples/full-stack-swarm/run.ts
+++ b/examples/full-stack-swarm/run.ts
@@ -6,7 +6,7 @@
  * - Mint ERC-8004 identities (gasless via AVNU paymaster).
  * - Register a session key + spending policy on-chain.
  * - Start SISNA as a signer boundary (holds session private keys).
- * - Run AVNU swaps via @starknet-agentic/mcp-server in signer proxy mode.
+ * - Run AVNU swaps via @starknetfoundation/starknet-agentic-mcp-server in signer proxy mode.
  * - Prove on-chain denial by attempting an oversized swap.
  *
  * Output:

--- a/examples/onboard-agent/README.md
+++ b/examples/onboard-agent/README.md
@@ -80,7 +80,7 @@ The script saves:
 
 1. **Fund the new account** with ETH or STRK for gas
 2. **Set up session keys** for delegated operations (see `contracts/agent-account/`)
-3. **Publish capabilities** via `@starknet-agentic/agent-passport`
+3. **Publish capabilities** via `@starknetfoundation/starknet-agentic-agent-passport`
 4. **Connect to MCP server** for AI-agent operations (see `packages/starknet-mcp-server/`)
 
 ## Architecture

--- a/examples/onboard-agent/package.json
+++ b/examples/onboard-agent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/onboard-agent-example",
+  "name": "@starknetfoundation/starknet-agentic-onboard-agent-example",
   "version": "0.1.0",
   "private": true,
   "description": "E2E agent onboarding flow: deploy account + register identity + verify",
@@ -12,7 +12,7 @@
     "smoke": "npx tsx smoke.ts"
   },
   "dependencies": {
-    "@starknet-agentic/onboarding-utils": "workspace:*",
+    "@starknetfoundation/starknet-agentic-onboarding-utils": "workspace:*",
     "dotenv": "^17.4.2",
     "starknet": "^9.4.2"
   },

--- a/examples/onboard-agent/steps/deploy-account.ts
+++ b/examples/onboard-agent/steps/deploy-account.ts
@@ -17,7 +17,7 @@ import {
   deployAccountViaFactory,
   type DeployerAccountLike,
   type ProviderLike,
-} from "@starknet-agentic/onboarding-utils";
+} from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import type { NetworkConfig } from "../config.js";
 
 export interface DeployAccountResult {

--- a/examples/onboard-agent/steps/first-action.ts
+++ b/examples/onboard-agent/steps/first-action.ts
@@ -5,7 +5,7 @@
  * Optional (--verify-tx): send a 0-value self-transfer to prove tx plumbing.
  */
 
-import { firstActionBalances, type ProviderLike } from "@starknet-agentic/onboarding-utils";
+import { firstActionBalances, type ProviderLike } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import { TOKENS } from "../config.js";
 
 export interface FirstActionResult {

--- a/examples/onboard-agent/steps/preflight.ts
+++ b/examples/onboard-agent/steps/preflight.ts
@@ -4,7 +4,7 @@
  */
 
 import { type Account, type RpcProvider } from "starknet";
-import { preflightStarknet } from "@starknet-agentic/onboarding-utils";
+import { preflightStarknet } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import { NETWORKS, TOKENS, type NetworkConfig } from "../config.js";
 
 export interface PreflightResult {

--- a/examples/onboard-agent/tsconfig.json
+++ b/examples/onboard-agent/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "paths": {
-      "@starknet-agentic/onboarding-utils": [
+      "@starknetfoundation/starknet-agentic-onboarding-utils": [
         "../../packages/starknet-onboarding-utils/src/index.ts"
       ]
     },

--- a/examples/secure-defi-demo/README.md
+++ b/examples/secure-defi-demo/README.md
@@ -30,7 +30,7 @@ From repo root:
 
 ```bash
 pnpm install
-pnpm --filter @starknet-agentic/mcp-server build
+pnpm --filter @starknetfoundation/starknet-agentic-mcp-server build
 ```
 
 Setup env:
@@ -49,19 +49,19 @@ Note: the MCP sidecar initializes signing at startup, so even `dry-run` needs si
 Dry-run (no write tx required):
 
 ```bash
-pnpm --filter @starknet-agentic/secure-defi-demo run
+pnpm --filter @starknetfoundation/starknet-agentic-secure-defi-demo run
 ```
 
 Execute mode (real tx writes):
 
 ```bash
-pnpm --filter @starknet-agentic/secure-defi-demo run:execute
+pnpm --filter @starknetfoundation/starknet-agentic-secure-defi-demo run:execute
 ```
 
 Execute + withdraw path:
 
 ```bash
-pnpm --filter @starknet-agentic/secure-defi-demo run:withdraw
+pnpm --filter @starknetfoundation/starknet-agentic-secure-defi-demo run:withdraw
 ```
 
 v1.1 full-proof profile (execute + identity + Base anchor):
@@ -70,7 +70,7 @@ v1.1 full-proof profile (execute + identity + Base anchor):
 DEMO_AUTO_REGISTER_AGENT=1 \
 DEMO_ANCHOR_BASE_TO_ERC8004=1 \
 DEMO_BASE_ATTESTATION_PATH=./artifacts/base-attestation-demo.json \
-pnpm --filter @starknet-agentic/secure-defi-demo run:execute
+pnpm --filter @starknetfoundation/starknet-agentic-secure-defi-demo run:execute
 ```
 
 Strict security proof profile (issue #315):
@@ -83,7 +83,7 @@ DEMO_ANCHOR_BASE_TO_ERC8004=1 \
 STARKNET_SIGNER_MODE=proxy \
 DEMO_SESSION_ACCOUNT_ADDRESS=0x... \
 DEMO_SESSION_KEY_PUBLIC_KEY=0x... \
-pnpm --filter @starknet-agentic/secure-defi-demo run:execute
+pnpm --filter @starknetfoundation/starknet-agentic-secure-defi-demo run:execute
 ```
 
 Optional Starkzap claim input:

--- a/examples/secure-defi-demo/package.json
+++ b/examples/secure-defi-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/secure-defi-demo",
+  "name": "@starknetfoundation/starknet-agentic-secure-defi-demo",
   "version": "0.1.0",
   "private": true,
   "description": "Deterministic Base->Starknet secure DeFi demo (session key evidence + Vesu + policy rejection)",

--- a/examples/secure-defi-demo/src/config.ts
+++ b/examples/secure-defi-demo/src/config.ts
@@ -71,7 +71,7 @@ function resolveMcpEntry(): string {
       [
         `MCP entry not found at: ${inferred}`,
         "Build it first from repo root:",
-        "pnpm --filter @starknet-agentic/mcp-server build",
+        "pnpm --filter @starknetfoundation/starknet-agentic-mcp-server build",
       ].join("\n"),
     );
   }

--- a/examples/starkzap-onboard-transfer/package.json
+++ b/examples/starkzap-onboard-transfer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/starkzap-onboard-transfer",
+  "name": "@starknetfoundation/starknet-agentic-starkzap-onboard-transfer",
   "version": "0.1.0",
   "private": true,
   "description": "Demo: gasless onboarding + STRK transfer on Sepolia via Starkzap SDK",

--- a/packages/create-starknet-agent/README.md
+++ b/packages/create-starknet-agent/README.md
@@ -32,7 +32,7 @@ npx create-starknet-agent@latest
 ```
 
 **What gets configured:**
-- MCP server pointing to `@starknet-agentic/mcp-server`
+- MCP server pointing to `@starknetfoundation/starknet-agentic-mcp-server`
 - Skills: `starknet-wallet`, `starknet-defi`
 - Environment template for credentials
 

--- a/packages/create-starknet-agent/docs/ROADMAP.md
+++ b/packages/create-starknet-agent/docs/ROADMAP.md
@@ -157,7 +157,7 @@ my-agent/
 **Description**: Integrate starknet-mcp-server as a stdio subprocess (sidecar pattern) that the agent uses for Starknet operations.
 
 **Requirements**:
-- [ ] Create MCP client that spawns `@starknet-agentic/mcp-server` as child process
+- [ ] Create MCP client that spawns `@starknetfoundation/starknet-agentic-mcp-server` as child process
 - [ ] Implement stdio transport for MCP protocol communication
 - [ ] Add tool discovery (list available tools from MCP server)
 - [ ] Implement tool execution with timeout and error handling
@@ -475,7 +475,7 @@ Your agent will be available at http://localhost:3000
 **Configuration Schema**:
 ```typescript
 // agent.config.ts
-import { defineConfig } from '@starknet-agentic/agent';
+import { defineConfig } from '@starknetfoundation/starknet-agentic-agent';
 
 export default defineConfig({
   // Agent identity
@@ -1043,11 +1043,11 @@ Long-term features and community-driven enhancements.
 | Feature | Depends On |
 |---------|------------|
 | Platform Detection (0.1) | Knowledge of OpenClaw/Claude Code config file locations |
-| Agent Self-Install (0.3) | `@starknet-agentic/mcp-server` published to npm |
-| MCP Sidecar | `@starknet-agentic/mcp-server` published to npm |
+| Agent Self-Install (0.3) | `@starknetfoundation/starknet-agentic-mcp-server` published to npm |
+| MCP Sidecar | `@starknetfoundation/starknet-agentic-mcp-server` published to npm |
 | Skills Installation | `skills/manifest.json` or individual SKILL.md files in repo |
 | On-chain Identity | ERC-8004 contracts deployed (Sepolia done, Mainnet pending) |
-| A2A Discovery | `@starknet-agentic/a2a` package |
+| A2A Discovery | `@starknetfoundation/starknet-agentic-a2a` package |
 | Session Keys | Agent Account contract deployed |
 | Skill Marketplace | GitHub API access, skills manifest.json |
 

--- a/packages/create-starknet-agent/docs/SPEC.md
+++ b/packages/create-starknet-agent/docs/SPEC.md
@@ -121,14 +121,14 @@ const DETECTION_RULES: DetectionRule[] = [
 
 ### MCP Server Configuration
 
-All platforms receive an MCP server configuration pointing to `@starknet-agentic/mcp-server`:
+All platforms receive an MCP server configuration pointing to `@starknetfoundation/starknet-agentic-mcp-server`:
 
 ```json
 {
   "mcpServers": {
     "starknet": {
       "command": "npx",
-      "args": ["@starknet-agentic/mcp-server@latest"],
+      "args": ["@starknetfoundation/starknet-agentic-mcp-server@latest"],
       "env": {
         "STARKNET_RPC_URL": "${STARKNET_RPC_URL:-https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_7/YOUR_API_KEY}",
         "STARKNET_ACCOUNT_ADDRESS": "${STARKNET_ACCOUNT_ADDRESS}",
@@ -179,7 +179,7 @@ npx create-starknet-agent verify
 
 Checks:
 1. MCP config exists and is valid JSON
-2. MCP server binary is available (`npx @starknet-agentic/mcp-server --version`)
+2. MCP server binary is available (`npx @starknetfoundation/starknet-agentic-mcp-server --version`)
 3. Required environment variables are set (not their values, just existence)
 4. Skills are installed
 5. (Optional) Can reach Starknet RPC and query a balance
@@ -854,7 +854,7 @@ export class MCPSidecar {
 
   async connect(): Promise<void> {
     // Spawn MCP server process
-    this.process = spawn('npx', ['@starknet-agentic/mcp-server'], {
+    this.process = spawn('npx', ['@starknetfoundation/starknet-agentic-mcp-server'], {
       env: {
         ...process.env,
         STARKNET_RPC_URL: this.config.rpcUrl,
@@ -867,7 +867,7 @@ export class MCPSidecar {
     // Create MCP client with stdio transport
     const transport = new StdioClientTransport({
       command: 'npx',
-      args: ['@starknet-agentic/mcp-server'],
+      args: ['@starknetfoundation/starknet-agentic-mcp-server'],
       env: { /* ... */ },
     });
 
@@ -922,7 +922,7 @@ export class MCPSidecar {
 
 ### Available Tools
 
-The MCP server exposes these tools (from `@starknet-agentic/mcp-server`):
+The MCP server exposes these tools (from `@starknetfoundation/starknet-agentic-mcp-server`):
 
 | Tool | Description | Arguments |
 |------|-------------|-----------|

--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -113,7 +113,7 @@ describe("MCP config generation", () => {
       mcpServers: {
         starknet: {
           command: "npx",
-          args: ["-y", "@starknet-agentic/mcp-server@latest"],
+          args: ["-y", "@starknetfoundation/starknet-agentic-mcp-server@latest"],
           env: expect.objectContaining({
             STARKNET_RPC_URL: expectedRpcUrl,
           }),

--- a/packages/create-starknet-agent/src/verify.ts
+++ b/packages/create-starknet-agent/src/verify.ts
@@ -223,7 +223,7 @@ async function checkMcpServer(
 
         // Try to extract version from args
         const args = serverConfig.args || [];
-        const versionArg = args.find((a: string) => a.includes("@starknet-agentic/mcp-server"));
+        const versionArg = args.find((a: string) => a.includes("@starknetfoundation/starknet-agentic-mcp-server"));
         if (versionArg) {
           const versionMatch = versionArg.match(/@([\d.]+|latest)$/);
           if (versionMatch) {
@@ -262,7 +262,7 @@ async function pingMcpServer(
     const timeout = 10000; // 10 second timeout
 
     // Try to spawn the MCP server with a simple ping
-    const child = spawn("npx", ["-y", "@starknet-agentic/mcp-server@latest", "--help"], {
+    const child = spawn("npx", ["-y", "@starknetfoundation/starknet-agentic-mcp-server@latest", "--help"], {
       stdio: verbose ? "inherit" : "pipe",
       env: {
         ...process.env,
@@ -697,7 +697,7 @@ export async function runVerification(args: VerifyArgs): Promise<void> {
     }
 
     if (mcpResult.serverConfigured) {
-      console.log(`  ${pc.green("✓")} Server binary: @starknet-agentic/mcp-server${mcpResult.serverVersion ? `@${mcpResult.serverVersion}` : ""}`);
+      console.log(`  ${pc.green("✓")} Server binary: @starknetfoundation/starknet-agentic-mcp-server${mcpResult.serverVersion ? `@${mcpResult.serverVersion}` : ""}`);
     } else if (mcpResult.configExists) {
       console.log(`  ${pc.red("✗")} Starknet server not configured in MCP config`);
     }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -208,7 +208,7 @@ function generateMcpConfig(network: Network, secretsEnvPath?: string): string {
     mcpServers: {
       starknet: {
         command: "npx",
-        args: ["-y", "@starknet-agentic/mcp-server@latest"],
+        args: ["-y", "@starknetfoundation/starknet-agentic-mcp-server@latest"],
         env: {
           STARKNET_RPC_URL: rpcUrl,
           STARKNET_PRIVATE_KEY: "${STARKNET_PRIVATE_KEY}",

--- a/packages/prediction-arb-scanner/README.md
+++ b/packages/prediction-arb-scanner/README.md
@@ -1,4 +1,4 @@
-# @starknet-agentic/prediction-arb-scanner
+# @starknetfoundation/starknet-agentic-prediction-arb-scanner
 
 Signals-only prediction market arbitrage scanner.
 

--- a/packages/prediction-arb-scanner/package.json
+++ b/packages/prediction-arb-scanner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/prediction-arb-scanner",
+  "name": "@starknetfoundation/starknet-agentic-prediction-arb-scanner",
   "version": "0.1.0",
   "description": "Signals-only prediction market arb scanner (Polymarket x Limitless x Raize), Starknet-native output model.",
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/shared",
+  "name": "@starknetfoundation/starknet-agentic-shared",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/starknet-a2a/README.md
+++ b/packages/starknet-a2a/README.md
@@ -24,7 +24,7 @@ npm run build
 ### Initialize the Adapter
 
 ```typescript
-import { createStarknetA2AAdapter } from "@starknet-agentic/a2a";
+import { createStarknetA2AAdapter } from "@starknetfoundation/starknet-agentic-a2a";
 
 const adapter = createStarknetA2AAdapter({
   rpcUrl: "https://starknet-mainnet.g.alchemy.com/v2/YOUR_KEY",
@@ -170,7 +170,7 @@ Generate /.well-known/agent.json content for agent discovery.
 
 ```typescript
 import express from "express";
-import { createStarknetA2AAdapter } from "@starknet-agentic/a2a";
+import { createStarknetA2AAdapter } from "@starknetfoundation/starknet-agentic-a2a";
 
 const app = express();
 const adapter = createStarknetA2AAdapter({ ... });

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/a2a",
+  "name": "@starknetfoundation/starknet-agentic-a2a",
   "version": "0.1.0",
   "description": "A2A protocol adapter for Starknet-native AI agents",
   "type": "module",

--- a/packages/starknet-agent-passport/README.md
+++ b/packages/starknet-agent-passport/README.md
@@ -1,4 +1,4 @@
-# @starknet-agentic/agent-passport
+# @starknetfoundation/starknet-agentic-agent-passport
 
 Passport conventions on top of ERC-8004 `IdentityRegistry`.
 
@@ -17,7 +17,7 @@ Example capability object:
 {
   "name": "swap",
   "description": "Swap tokens via AVNU",
-  "endpoint": "mcp://@starknet-agentic/mcp-server/swap",
+  "endpoint": "mcp://@starknetfoundation/starknet-agentic-mcp-server/swap",
   "version": "1"
 }
 ```

--- a/packages/starknet-agent-passport/package.json
+++ b/packages/starknet-agent-passport/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/agent-passport",
+  "name": "@starknetfoundation/starknet-agentic-agent-passport",
   "version": "0.1.0",
   "description": "Passport layer on top of ERC-8004 IdentityRegistry: capability metadata conventions + client helpers",
   "type": "module",

--- a/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
+++ b/packages/starknet-mcp-server/__tests__/handlers/tools.test.ts
@@ -115,7 +115,7 @@ vi.mock("@avnu/avnu-sdk", () => ({
 // Mock x402-starknet
 const mockCreateStarknetPaymentSignatureHeader = vi.fn();
 
-vi.mock("@starknet-agentic/x402-starknet", () => ({
+vi.mock("@starknetfoundation/starknet-agentic-x402-starknet", () => ({
   createStarknetPaymentSignatureHeader: mockCreateStarknetPaymentSignatureHeader,
 }));
 

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/mcp-server",
+  "name": "@starknetfoundation/starknet-agentic-mcp-server",
   "version": "0.1.0",
   "description": "MCP server exposing Starknet operations as tools for AI agents",
   "type": "module",
@@ -7,14 +7,14 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "dev": "tsup src/index.ts --format esm --watch",
-    "pretest": "pnpm --filter @starknet-agentic/x402-starknet build",
+    "pretest": "pnpm --filter @starknetfoundation/starknet-agentic-x402-starknet build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@avnu/avnu-sdk": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@starknet-agentic/x402-starknet": "workspace:*",
+    "@starknetfoundation/starknet-agentic-x402-starknet": "workspace:*",
     "starknet": "^9.4.2",
     "zod": "^4.4.1"
   },

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -73,7 +73,7 @@ import {
   type QuoteRequest,
 } from "@avnu/avnu-sdk";
 import { z } from "zod";
-import { createStarknetPaymentSignatureHeader } from "@starknet-agentic/x402-starknet";
+import { createStarknetPaymentSignatureHeader } from "@starknetfoundation/starknet-agentic-x402-starknet";
 import { formatAmount, formatQuoteFields, formatErrorMessage } from "./utils/formatter.js";
 import { PolicyGuard, loadPolicyConfig } from "./middleware/policyGuard.js";
 import { KeyringProxySigner } from "./helpers/keyringProxySigner.js";

--- a/packages/starknet-onboarding-utils/__tests__/index.test.ts
+++ b/packages/starknet-onboarding-utils/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import {
   waitForTransactionWithTimeout,
 } from "../src/index.js";
 
-describe("@starknet-agentic/onboarding-utils", () => {
+describe("@starknetfoundation/starknet-agentic-onboarding-utils", () => {
   describe("waitForTransactionWithTimeout", () => {
     it("resolves when the receipt arrives before timeout", async () => {
       vi.useFakeTimers();

--- a/packages/starknet-onboarding-utils/package.json
+++ b/packages/starknet-onboarding-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/onboarding-utils",
+  "name": "@starknetfoundation/starknet-agentic-onboarding-utils",
   "version": "0.1.0",
   "description": "Shared onboarding utilities for Starknet Agentic examples (preflight, deploy via factory, first action checks).",
   "type": "module",
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@starknet-agentic/shared": "workspace:*",
+    "@starknetfoundation/starknet-agentic-shared": "workspace:*",
     "starknet": "^9.4.2"
   },
   "devDependencies": {

--- a/packages/starknet-onboarding-utils/src/index.ts
+++ b/packages/starknet-onboarding-utils/src/index.ts
@@ -12,7 +12,7 @@ import {
   type Call,
   type PaymasterDetails,
 } from "starknet";
-import { trimTrailingChar as trimTrailingCharShared } from "@starknet-agentic/shared/string";
+import { trimTrailingChar as trimTrailingCharShared } from "@starknetfoundation/starknet-agentic-shared/string";
 
 export type ProviderLike = Pick<RpcProvider, "getChainId" | "callContract" | "waitForTransaction">;
 

--- a/packages/x402-starknet/README.md
+++ b/packages/x402-starknet/README.md
@@ -1,4 +1,4 @@
-# @starknet-agentic/x402-starknet
+# @starknetfoundation/starknet-agentic-x402-starknet
 
 Small helpers for x402-on-Starknet header handling.
 

--- a/packages/x402-starknet/package.json
+++ b/packages/x402-starknet/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@starknet-agentic/x402-starknet",
+  "name": "@starknetfoundation/starknet-agentic-x402-starknet",
   "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "pnpm --filter @starknet-agentic/shared build && tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
+    "build": "pnpm --filter @starknetfoundation/starknet-agentic-shared build && tsup src/index.ts --format esm && tsc -p tsconfig.build.json --noCheck",
     "test": "vitest run",
     "lint": "eslint ."
   },
   "dependencies": {
-    "@starknet-agentic/shared": "workspace:*",
+    "@starknetfoundation/starknet-agentic-shared": "workspace:*",
     "starknet": "^9.4.2"
   },
   "devDependencies": {

--- a/packages/x402-starknet/src/index.ts
+++ b/packages/x402-starknet/src/index.ts
@@ -1,5 +1,5 @@
 import { Account, RpcProvider, type TypedData } from "starknet"
-import { trimTrailingChar } from "@starknet-agentic/shared/string"
+import { trimTrailingChar } from "@starknetfoundation/starknet-agentic-shared/string"
 
 export type X402PaymentRequired = {
   /** opaque scheme id, ex: exact-starknet */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
 
   examples/crosschain-demo:
     dependencies:
-      '@starknet-agentic/onboarding-utils':
+      '@starknetfoundation/starknet-agentic-onboarding-utils':
         specifier: workspace:*
         version: link:../../packages/starknet-onboarding-utils
       dotenv:
@@ -162,7 +162,7 @@ importers:
 
   examples/onboard-agent:
     dependencies:
-      '@starknet-agentic/onboarding-utils':
+      '@starknetfoundation/starknet-agentic-onboarding-utils':
         specifier: workspace:*
         version: link:../../packages/starknet-onboarding-utils
       dotenv:
@@ -316,7 +316,7 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.1)
-      '@starknet-agentic/x402-starknet':
+      '@starknetfoundation/starknet-agentic-x402-starknet':
         specifier: workspace:*
         version: link:../x402-starknet
       starknet:
@@ -344,7 +344,7 @@ importers:
 
   packages/starknet-onboarding-utils:
     dependencies:
-      '@starknet-agentic/shared':
+      '@starknetfoundation/starknet-agentic-shared':
         specifier: workspace:*
         version: link:../shared
       starknet:
@@ -366,7 +366,7 @@ importers:
 
   packages/x402-starknet:
     dependencies:
-      '@starknet-agentic/shared':
+      '@starknetfoundation/starknet-agentic-shared':
         specifier: workspace:*
         version: link:../shared
       starknet:

--- a/skills/README.md
+++ b/skills/README.md
@@ -182,7 +182,7 @@ These skills complement the Starknet MCP Server which provides direct tool acces
   "mcpServers": {
     "starknet": {
       "command": "npx",
-      "args": ["@starknet-agentic/mcp-server"],
+      "args": ["@starknetfoundation/starknet-agentic-mcp-server"],
       "env": {
         "STARKNET_RPC_URL": "https://...",
         "STARKNET_ACCOUNT_ADDRESS": "0x...",

--- a/skills/starknet-js/package.json
+++ b/skills/starknet-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@starknet-agentic/skill-starknet-js",
+  "name": "@starknetfoundation/starknet-agentic-skill-starknet-js",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Renames all 8 scoped workspace packages from `@starknet-agentic/*` to `@starknetfoundation/starknet-agentic-*` so they can be published under the Starknet Foundation npm org.
- Unscoped `create-starknet-agent` CLI keeps its name (preserves `npm create starknet-agent` UX).
- No logic changes — pure rename across `package.json` names, internal `workspace:*` deps, imports, docs, READMEs, CI workflow filters, the `create-starknet-agent` runtime `npx` invocations, and `pnpm-lock.yaml`.

## Mapping

| Old | New |
|---|---|
| `@starknet-agentic/a2a` | `@starknetfoundation/starknet-agentic-a2a` |
| `@starknet-agentic/agent-passport` | `@starknetfoundation/starknet-agentic-agent-passport` |
| `@starknet-agentic/mcp-server` | `@starknetfoundation/starknet-agentic-mcp-server` |
| `@starknet-agentic/onboarding-utils` | `@starknetfoundation/starknet-agentic-onboarding-utils` |
| `@starknet-agentic/prediction-arb-scanner` | `@starknetfoundation/starknet-agentic-prediction-arb-scanner` |
| `@starknet-agentic/shared` *(private)* | `@starknetfoundation/starknet-agentic-shared` |
| `@starknet-agentic/x402-starknet` *(private)* | `@starknetfoundation/starknet-agentic-x402-starknet` |
| `@starknet-agentic/skill-starknet-js` | `@starknetfoundation/starknet-agentic-skill-starknet-js` |

## Why now

CI's Release workflow has been failing on every push because `NPM_TOKEN` is unset and there's no `@starknet-agentic` npm org. Switching to the foundation scope unblocks publishing once a token is added.

## Required follow-up (not in this PR)

1. Confirm the `starknetfoundation` npm org exists and owns the `@starknetfoundation` scope.
2. Generate an Automation token from a member account.
3. `gh secret set NPM_TOKEN --repo keep-starknet-strange/starknet-agentic`.
4. Merge this PR; the next push to `main` will publish all 5 publishable packages at their current local versions.

## Test plan

- [ ] CI typecheck/lint/build passes (the only pre-existing failure is `examples/starkzap-onboard-transfer` — unrelated `StarkSDK` typo on `main`).
- [ ] `pnpm install` resolves cleanly with new names (verified locally).
- [ ] `pnpm -r build` succeeds.
- [ ] After merge + token, Release workflow successfully publishes 5 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm package scope from `@starknet-agentic/` to `@starknetfoundation/starknet-agentic-` across all published packages, including MCP server, onboarding utilities, A2A adapter, and agent passport. Update your imports and dependencies accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->