### PR TITLE
fix(release): add repository field for npm provenance

### DIFF
--- a/packages/create-starknet-agent/package.json
+++ b/packages/create-starknet-agent/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/keep-starknet-strange/starknet-agentic"
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/create-starknet-agent"
   },
   "homepage": "https://starknet-agentic.vercel.app",
   "type": "module",

--- a/packages/prediction-arb-scanner/package.json
+++ b/packages/prediction-arb-scanner/package.json
@@ -2,6 +2,11 @@
   "name": "@starknetfoundation/starknet-agentic-prediction-arb-scanner",
   "version": "0.1.0",
   "description": "Signals-only prediction market arb scanner (Polymarket x Limitless x Raize), Starknet-native output model.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/prediction-arb-scanner"
+  },
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -2,6 +2,11 @@
   "name": "@starknetfoundation/starknet-agentic-a2a",
   "version": "0.1.0",
   "description": "A2A protocol adapter for Starknet-native AI agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/starknet-a2a"
+  },
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/starknet-agent-passport/package.json
+++ b/packages/starknet-agent-passport/package.json
@@ -2,6 +2,11 @@
   "name": "@starknetfoundation/starknet-agentic-agent-passport",
   "version": "0.1.0",
   "description": "Passport layer on top of ERC-8004 IdentityRegistry: capability metadata conventions + client helpers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/starknet-agent-passport"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -2,6 +2,11 @@
   "name": "@starknetfoundation/starknet-agentic-mcp-server",
   "version": "0.1.0",
   "description": "MCP server exposing Starknet operations as tools for AI agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/starknet-mcp-server"
+  },
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/starknet-onboarding-utils/package.json
+++ b/packages/starknet-onboarding-utils/package.json
@@ -2,6 +2,11 @@
   "name": "@starknetfoundation/starknet-agentic-onboarding-utils",
   "version": "0.1.0",
   "description": "Shared onboarding utilities for Starknet Agentic examples (preflight, deploy via factory, first action checks).",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keep-starknet-strange/starknet-agentic",
+    "directory": "packages/starknet-onboarding-utils"
+  },
   "type": "module",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- npm publish was failing with `E422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is ""`.
- The provenance bundle (signed via OIDC) pins the GitHub source repo. npm requires it to match the `repository.url` field in each package.json. The 5 newly-renamed scoped packages had no `repository` field at all.
- Adds the field to all 5, with `directory` pointing to the package's path in the monorepo. Also adds `directory` to `create-starknet-agent` for parity (its `repository.url` was already set, so it wasn't broken — just incomplete).

## Test plan

- [ ] Release workflow (triggered by merge) successfully publishes all 5 scoped packages + bumps `create-starknet-agent` to 0.5.0.
- [ ] `npm view @starknetfoundation/starknet-agentic-mcp-server` shows the published version after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)