### PR TITLE
chore: add MIT license and author to scoped packages

### DIFF
--- a/.changeset/add-license-author-metadata.md
+++ b/.changeset/add-license-author-metadata.md
@@ -1,0 +1,9 @@
+---
+"@starknetfoundation/starknet-agentic-mcp-server": patch
+"@starknetfoundation/starknet-agentic-a2a": patch
+"@starknetfoundation/starknet-agentic-agent-passport": patch
+"@starknetfoundation/starknet-agentic-onboarding-utils": patch
+"@starknetfoundation/starknet-agentic-prediction-arb-scanner": patch
+---
+
+Add `license: MIT` and `author` metadata so npm shows the correct license on the package pages and downstream consumers can redistribute under MIT (matching the repo's LICENSE file). The first-published 0.1.0 versions inadvertently shipped without a license field.

--- a/packages/prediction-arb-scanner/package.json
+++ b/packages/prediction-arb-scanner/package.json
@@ -2,6 +2,8 @@
   "name": "@starknetfoundation/starknet-agentic-prediction-arb-scanner",
   "version": "0.1.0",
   "description": "Signals-only prediction market arb scanner (Polymarket x Limitless x Raize), Starknet-native output model.",
+  "author": "Starknet Agentic Contributors",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/keep-starknet-strange/starknet-agentic",

--- a/packages/starknet-a2a/package.json
+++ b/packages/starknet-a2a/package.json
@@ -2,6 +2,8 @@
   "name": "@starknetfoundation/starknet-agentic-a2a",
   "version": "0.1.0",
   "description": "A2A protocol adapter for Starknet-native AI agents",
+  "author": "Starknet Agentic Contributors",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/keep-starknet-strange/starknet-agentic",

--- a/packages/starknet-agent-passport/package.json
+++ b/packages/starknet-agent-passport/package.json
@@ -2,6 +2,8 @@
   "name": "@starknetfoundation/starknet-agentic-agent-passport",
   "version": "0.1.0",
   "description": "Passport layer on top of ERC-8004 IdentityRegistry: capability metadata conventions + client helpers",
+  "author": "Starknet Agentic Contributors",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/keep-starknet-strange/starknet-agentic",

--- a/packages/starknet-mcp-server/package.json
+++ b/packages/starknet-mcp-server/package.json
@@ -2,6 +2,8 @@
   "name": "@starknetfoundation/starknet-agentic-mcp-server",
   "version": "0.1.0",
   "description": "MCP server exposing Starknet operations as tools for AI agents",
+  "author": "Starknet Agentic Contributors",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/keep-starknet-strange/starknet-agentic",

--- a/packages/starknet-onboarding-utils/package.json
+++ b/packages/starknet-onboarding-utils/package.json
@@ -2,6 +2,8 @@
   "name": "@starknetfoundation/starknet-agentic-onboarding-utils",
   "version": "0.1.0",
   "description": "Shared onboarding utilities for Starknet Agentic examples (preflight, deploy via factory, first action checks).",
+  "author": "Starknet Agentic Contributors",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/keep-starknet-strange/starknet-agentic",


### PR DESCRIPTION
## Summary

The 5 newly-published `@starknetfoundation/starknet-agentic-*` packages shipped at `0.1.0` without `license` or `author` fields, so npm displays "license: none" on each package page. The repo itself is MIT-licensed, so this is a metadata gap, not an actual licensing change.

## Changes

- Adds `"author": "Starknet Agentic Contributors"` and `"license": "MIT"` to all 5 scoped package.json files (matching the existing `create-starknet-agent` package).
- Adds a changeset entry that will bump each package to `0.1.1` on the next release.

## What happens after merge

1. changesets/action opens a "Version Packages" PR bumping the 5 packages from `0.1.0` to `0.1.1`.
2. Merging that PR triggers Release → publishes `0.1.1` versions with proper license metadata.

## Test plan

- [ ] After 0.1.1 publish, `npm view @starknetfoundation/starknet-agentic-mcp-server license` returns `MIT`.
- [ ] npm package page displays MIT badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)