### PR TITLE
chore: scope create-starknet-agent under @starknetfoundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ NOTE: The Agent Account contract at `contracts/agent-account/` (~570 lines main 
 | Build single TS package | `pnpm build` | `packages/<pkg>/` |
 | Dev mode (website) | `pnpm dev` | `website/` |
 | Deploy contracts (Sepolia) | `bash scripts/deploy_sepolia.sh` | `contracts/erc8004-cairo/` |
-| Scaffold new agent | `npx create-starknet-agent@latest` | any |
+| Scaffold new agent | `npx @starknetfoundation/create-starknet-agent@latest` | any |
 
 </commands>
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ This repo gives you:
 If you just want Starknet agent capabilities now:
 
 ```bash
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 ```
 
 Sanity check (npm availability):
 
 ```bash
-npm view create-starknet-agent version
+npm view @starknetfoundation/create-starknet-agent version
 ```
 
 The scaffolder detects your environment (OpenClaw/MoltBook, Claude Code, Cursor, or standalone) and wires Starknet integration automatically.
@@ -46,7 +46,7 @@ Use the path that matches your runtime:
 
 ```bash
 # Full project scaffold
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 ```
 
 ```bash
@@ -102,7 +102,7 @@ For the full skill catalog and Cairo migration notes, see [skills/README.md](./s
 
 ## System Requirements
 
-- CLI users (`npx create-starknet-agent@latest`): Node.js `>=18.0.0`
+- CLI users (`npx @starknetfoundation/create-starknet-agent@latest`): Node.js `>=18.0.0`
 - Contributors from source (this monorepo):
   - Node.js `>=20.9.0`
   - `pnpm` `>=10.28.2` (workspace package manager)

--- a/packages/create-starknet-agent/README.md
+++ b/packages/create-starknet-agent/README.md
@@ -7,7 +7,7 @@ Part of the [starknet-agentic](https://github.com/keep-starknet-strange/starknet
 ## Quick Start
 
 ```bash
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 ```
 
 The CLI detects your environment and sets up Starknet accordingly:
@@ -24,11 +24,11 @@ The CLI detects your environment and sets up Starknet accordingly:
 If you're already using OpenClaw, just run the CLI and it configures everything:
 
 ```bash
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 
 # Or let your agent do it:
 # "Hey, I want you to be able to use Starknet"
-# Agent runs: npx create-starknet-agent@latest --non-interactive
+# Agent runs: npx @starknetfoundation/create-starknet-agent@latest --non-interactive
 ```
 
 **What gets configured:**
@@ -46,7 +46,7 @@ npx create-starknet-agent@latest
 ## For Claude Code Users
 
 ```bash
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 ```
 
 **What gets configured:**
@@ -59,7 +59,7 @@ npx create-starknet-agent@latest
 For developers building custom agents from scratch:
 
 ```bash
-npx create-starknet-agent@latest my-agent
+npx @starknetfoundation/create-starknet-agent@latest my-agent
 cd my-agent
 cp .env.example .env
 # Edit .env with your credentials
@@ -123,27 +123,27 @@ my-agent/
 
 ```bash
 # Platform integration (auto-detect)
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
 
 # Force specific platform
-npx create-starknet-agent@latest --platform openclaw
-npx create-starknet-agent@latest --platform claude-code
-npx create-starknet-agent@latest --platform standalone
+npx @starknetfoundation/create-starknet-agent@latest --platform openclaw
+npx @starknetfoundation/create-starknet-agent@latest --platform claude-code
+npx @starknetfoundation/create-starknet-agent@latest --platform standalone
 
 # Select skills
-npx create-starknet-agent@latest --skills starknet-wallet,starknet-defi
+npx @starknetfoundation/create-starknet-agent@latest --skills starknet-wallet,starknet-defi
 
 # Select network
-npx create-starknet-agent@latest --network sepolia
+npx @starknetfoundation/create-starknet-agent@latest --network sepolia
 
 # Non-interactive (for agent self-setup)
-npx create-starknet-agent@latest --non-interactive --json
+npx @starknetfoundation/create-starknet-agent@latest --non-interactive --json
 
 # Verify setup
-npx create-starknet-agent verify
+npx @starknetfoundation/create-starknet-agent verify
 
 # Setup credentials securely
-npx create-starknet-agent credentials
+npx @starknetfoundation/create-starknet-agent credentials
 ```
 
 | Option | Description |
@@ -192,7 +192,7 @@ Once configured, your agent can use these Starknet tools:
 Agents can configure themselves by running the CLI in non-interactive mode:
 
 ```bash
-npx create-starknet-agent@latest --non-interactive --json
+npx @starknetfoundation/create-starknet-agent@latest --non-interactive --json
 ```
 
 Returns:
@@ -219,7 +219,7 @@ Returns:
 Confirm your setup is working:
 
 ```bash
-npx create-starknet-agent verify
+npx @starknetfoundation/create-starknet-agent verify
 ```
 
 Checks:

--- a/packages/create-starknet-agent/docs/ROADMAP.md
+++ b/packages/create-starknet-agent/docs/ROADMAP.md
@@ -27,7 +27,7 @@ Let's continue with implementing:
 │  ──────────────────────────────────────────────                     │
 │  → Lightweight integration: skills + MCP config                     │
 │  → No scaffolding needed, just config files                         │
-│  → Agent can self-install via npx create-starknet-agent             │
+│  → Agent can self-install via npx @starknetfoundation/create-starknet-agent             │
 │                                                                     │
 │  Building a new agent from scratch?  (SECONDARY PATH)               │
 │  ─────────────────────────────────────                              │
@@ -82,7 +82,7 @@ The CLI also scaffolds standalone TypeScript projects with 3 templates:
 
 Core infrastructure to get a basic agent with UI, MCP, and one skill working end-to-end.
 
-**Definition of Done**: User runs `npx create-starknet-agent@latest my-agent`, answers prompts, runs `pnpm start`, and can chat with an autonomous agent that executes Starknet transactions via MCP tools.
+**Definition of Done**: User runs `npx @starknetfoundation/create-starknet-agent@latest my-agent`, answers prompts, runs `pnpm start`, and can chat with an autonomous agent that executes Starknet transactions via MCP tools.
 
 ---
 
@@ -407,7 +407,7 @@ type AgentEvent =
 
 **CLI Flow**:
 ```
-$ npx create-starknet-agent@latest my-agent
+$ npx @starknetfoundation/create-starknet-agent@latest my-agent
 
 ? Project name: my-agent
 ? Select a preset:
@@ -1086,7 +1086,7 @@ This is the target user experience for agent-initiated Starknet setup:
 │  Agent: I'll set up Starknet capabilities now.                       │
 │                                                                      │
 │  *Agent executes:*                                                   │
-│  npx create-starknet-agent@latest \                                  │
+│  npx @starknetfoundation/create-starknet-agent@latest \                                  │
 │    --skills starknet-wallet,starknet-defi \                          │
 │    --network sepolia \                                               │
 │    --non-interactive --json                                          │
@@ -1110,7 +1110,7 @@ This is the target user experience for agent-initiated Starknet setup:
 │         1. Open Ready or Braavos wallet                           │
 │         2. Go to Settings → Export Private Key                       │
 │         3. Run this command and paste when prompted:                 │
-│            npx create-starknet-agent credentials                     │
+│            npx @starknetfoundation/create-starknet-agent credentials                     │
 │                                                                      │
 │         4. Restart me (or wait 30 seconds for auto-reload)           │
 │                                                                      │

--- a/packages/create-starknet-agent/docs/SPEC.md
+++ b/packages/create-starknet-agent/docs/SPEC.md
@@ -34,7 +34,7 @@ Technical architecture and implementation specification for adding Starknet capa
 | **Standalone** | Developers building custom agents | Full project scaffold | Heavy |
 
 ```
-npx create-starknet-agent@latest
+npx @starknetfoundation/create-starknet-agent@latest
          │
          ▼
 ┌─────────────────────┐
@@ -163,7 +163,7 @@ interface AgentSetupResult {
 **CLI Flags for Non-Interactive Mode:**
 
 ```bash
-npx create-starknet-agent@latest \
+npx @starknetfoundation/create-starknet-agent@latest \
   --non-interactive \           # Skip all prompts
   --json \                      # Output JSON result
   --platform openclaw \         # Override detection
@@ -174,7 +174,7 @@ npx create-starknet-agent@latest \
 ### Verification
 
 ```bash
-npx create-starknet-agent verify
+npx @starknetfoundation/create-starknet-agent verify
 ```
 
 Checks:

--- a/packages/create-starknet-agent/package.json
+++ b/packages/create-starknet-agent/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "create-starknet-agent",
-  "version": "0.5.0",
+  "name": "@starknetfoundation/create-starknet-agent",
+  "version": "0.1.0",
   "description": "CLI tool to scaffold a Starknet AI agent project",
   "keywords": [
     "starknet",

--- a/packages/create-starknet-agent/src/credentials.ts
+++ b/packages/create-starknet-agent/src/credentials.ts
@@ -112,7 +112,7 @@ export function parseCredentialsArgs(args: string[]): CredentialsArgs {
 export function printCredentialsHelp(): void {
   console.log(`
 ${pc.bold("Usage:")}
-  npx create-starknet-agent credentials [options]
+  npx @starknetfoundation/create-starknet-agent credentials [options]
 
 ${pc.bold("Description:")}
   Securely configure Starknet credentials for your agent platform.
@@ -134,10 +134,10 @@ ${pc.bold("Storage Locations by Platform:")}
   ${pc.cyan("generic-mcp")}    .env file
 
 ${pc.bold("Examples:")}
-  npx create-starknet-agent credentials
-  npx create-starknet-agent credentials --platform claude-code
-  npx create-starknet-agent credentials --from-env
-  npx create-starknet-agent credentials --from-ready
+  npx @starknetfoundation/create-starknet-agent credentials
+  npx @starknetfoundation/create-starknet-agent credentials --platform claude-code
+  npx @starknetfoundation/create-starknet-agent credentials --from-env
+  npx @starknetfoundation/create-starknet-agent credentials --from-ready
 `);
 }
 

--- a/packages/create-starknet-agent/src/index.ts
+++ b/packages/create-starknet-agent/src/index.ts
@@ -3,7 +3,7 @@
  * create-starknet-agent
  *
  * CLI tool to scaffold a Starknet AI agent project.
- * Run with: npx create-starknet-agent@latest [project-name] [--template <template>]
+ * Run with: npx @starknetfoundation/create-starknet-agent@latest [project-name] [--template <template>]
  */
 
 import fs from "node:fs";
@@ -45,8 +45,8 @@ function printBanner() {
 function printHelp() {
   console.log(`
 ${pc.bold("Usage:")}
-  npx create-starknet-agent [project-name] [options]
-  npx create-starknet-agent credentials [options]
+  npx @starknetfoundation/create-starknet-agent [project-name] [options]
+  npx @starknetfoundation/create-starknet-agent credentials [options]
 
 ${pc.bold("Commands:")}
   ${pc.cyan("credentials")}    Securely configure Starknet wallet credentials
@@ -89,29 +89,29 @@ ${pc.bold("Exit Codes:")}
   3  Platform not supported
 
 ${pc.bold("Examples:")}
-  npx create-starknet-agent my-agent
-  npx create-starknet-agent my-agent --template defi
-  npx create-starknet-agent my-agent --template full --network sepolia
-  npx create-starknet-agent my-agent --platform claude-code
-  npx create-starknet-agent --detect-only
-  npx create-starknet-agent my-agent -y
+  npx @starknetfoundation/create-starknet-agent my-agent
+  npx @starknetfoundation/create-starknet-agent my-agent --template defi
+  npx @starknetfoundation/create-starknet-agent my-agent --template full --network sepolia
+  npx @starknetfoundation/create-starknet-agent my-agent --platform claude-code
+  npx @starknetfoundation/create-starknet-agent --detect-only
+  npx @starknetfoundation/create-starknet-agent my-agent -y
 
 ${pc.bold("Credential Setup:")}
-  npx create-starknet-agent credentials
-  npx create-starknet-agent credentials --from-env
-  npx create-starknet-agent credentials --from-ready
-  npx create-starknet-agent credentials --platform openclaw
+  npx @starknetfoundation/create-starknet-agent credentials
+  npx @starknetfoundation/create-starknet-agent credentials --from-env
+  npx @starknetfoundation/create-starknet-agent credentials --from-ready
+  npx @starknetfoundation/create-starknet-agent credentials --platform openclaw
 
 ${pc.bold("Verification:")}
-  npx create-starknet-agent verify
-  npx create-starknet-agent verify --verbose
-  npx create-starknet-agent verify --skip-e2e
-  npx create-starknet-agent verify --json
+  npx @starknetfoundation/create-starknet-agent verify
+  npx @starknetfoundation/create-starknet-agent verify --verbose
+  npx @starknetfoundation/create-starknet-agent verify --skip-e2e
+  npx @starknetfoundation/create-starknet-agent verify --json
 
 ${pc.bold("Agent Self-Setup (Non-Interactive):")}
-  npx create-starknet-agent --non-interactive --json
-  npx create-starknet-agent --platform openclaw --skills starknet-wallet,starknet-defi --non-interactive --json
-  npx create-starknet-agent verify --json
+  npx @starknetfoundation/create-starknet-agent --non-interactive --json
+  npx @starknetfoundation/create-starknet-agent --platform openclaw --skills starknet-wallet,starknet-defi --non-interactive --json
+  npx @starknetfoundation/create-starknet-agent verify --json
 `);
 }
 
@@ -819,7 +819,7 @@ async function main() {
   // Handle --verify flag (deprecated, redirect to verify subcommand)
   if (parsed.verify) {
     if (!parsed.jsonOutput) {
-      console.log(pc.yellow("Note: --verify flag is deprecated. Use 'npx create-starknet-agent verify' instead."));
+      console.log(pc.yellow("Note: --verify flag is deprecated. Use 'npx @starknetfoundation/create-starknet-agent verify' instead."));
       console.log();
     }
     const verifyArgs = parseVerifyArgs(parsed.jsonOutput ? ["--json"] : []);

--- a/packages/create-starknet-agent/src/verify.ts
+++ b/packages/create-starknet-agent/src/verify.ts
@@ -149,7 +149,7 @@ export function parseVerifyArgs(args: string[]): VerifyArgs {
 export function printVerifyHelp(): void {
   console.log(`
 ${pc.bold("Usage:")}
-  npx create-starknet-agent verify [options]
+  npx @starknetfoundation/create-starknet-agent verify [options]
 
 ${pc.bold("Description:")}
   Verify that your Starknet agent setup is working correctly.
@@ -169,11 +169,11 @@ ${pc.bold("Exit Codes:")}
   2  Missing credentials - setup incomplete
 
 ${pc.bold("Examples:")}
-  npx create-starknet-agent verify
-  npx create-starknet-agent verify --verbose
-  npx create-starknet-agent verify --skip-e2e
-  npx create-starknet-agent verify --platform claude-code
-  npx create-starknet-agent verify --json
+  npx @starknetfoundation/create-starknet-agent verify
+  npx @starknetfoundation/create-starknet-agent verify --verbose
+  npx @starknetfoundation/create-starknet-agent verify --skip-e2e
+  npx @starknetfoundation/create-starknet-agent verify --platform claude-code
+  npx @starknetfoundation/create-starknet-agent verify --json
 `);
 }
 
@@ -880,13 +880,13 @@ export async function runVerification(args: VerifyArgs): Promise<void> {
     // Suggest fixes
     if (!mcpResult.configExists || !mcpResult.serverConfigured) {
       console.log(pc.bold("To configure MCP server:"));
-      console.log(pc.cyan("  npx create-starknet-agent"));
+      console.log(pc.cyan("  npx @starknetfoundation/create-starknet-agent"));
       console.log();
     }
 
     if (!credentialsResult.privateKeyPresent || !credentialsResult.accountAddressPresent) {
       console.log(pc.bold("To add credentials:"));
-      console.log(pc.cyan("  npx create-starknet-agent credentials"));
+      console.log(pc.cyan("  npx @starknetfoundation/create-starknet-agent credentials"));
       console.log();
     }
   }

--- a/website/app/data/get-started.ts
+++ b/website/app/data/get-started.ts
@@ -18,7 +18,7 @@ export const STEPS: Step[] = [
   },
 ];
 
-export const INSTALL_COMMAND = "npx create-starknet-agent@latest";
+export const INSTALL_COMMAND = "npx @starknetfoundation/create-starknet-agent@latest";
 
 export const EXTERNAL_LINKS = {
   github: "https://github.com/keep-starknet-strange/starknet-agentic",


### PR DESCRIPTION
## Summary

Renames the unscoped `create-starknet-agent` package to `@starknetfoundation/create-starknet-agent` so it can be published from CI under the foundation's npm org. The pre-existing unscoped `0.1.0` (owned by a personal account) is left untouched on npm.

## Changes

- `package.json`: name → `@starknetfoundation/create-starknet-agent`, version reset to `0.1.0` for parity with the other `@starknetfoundation/*` first-publishes.
- `bin` entry kept as `create-starknet-agent` — the installed binary name and the self-detection in `src/index.ts` are unaffected.
- All `npx create-starknet-agent` invocations in user-facing docs, help text, and code samples updated to the scoped form.
- `npm view create-starknet-agent` → `npm view @starknetfoundation/create-starknet-agent` in the README sanity check.
- `pnpm-lock.yaml` regenerated.

## User-facing UX

Users can run any of:

```bash
npm create @starknetfoundation/starknet-agent@latest
npx @starknetfoundation/create-starknet-agent@latest
```

(The `npm create @scope/name` form is npm's sugar that resolves to `@scope/create-name`.)

## Test plan

- [x] `pnpm install` resolves cleanly with new name.
- [x] `pnpm --filter @starknetfoundation/create-starknet-agent build` succeeds.
- [ ] After merge, Release workflow publishes `@starknetfoundation/create-starknet-agent@0.1.0`.
- [ ] `npm view @starknetfoundation/create-starknet-agent` shows the published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)