### PR TITLE
docs(security): add explicit links to satisfy Scorecard policy check

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 If you discover a security vulnerability, please report it privately.
 
-- Prefer GitHub Private Vulnerability Reporting in this repository.
+- Preferred: open a private advisory via [GitHub Private Vulnerability Reporting](https://github.com/keep-starknet-strange/starknet-agentic/security/advisories/new).
+  See [GitHub's docs on privately reporting a security vulnerability](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) for the workflow.
 - If private reporting is not available, open a security issue without exploit details and ask for a private channel.
 
 Please include:


### PR DESCRIPTION
## Summary

Closes Scorecard alert [#47](https://github.com/keep-starknet-strange/starknet-agentic/security/code-scanning/47) (Security-Policy: "no linked content found").

The check looks for at least one `http(s)://` URL in `SECURITY.md`. The current file only has a relative link (`docs/security/PROVENANCE_VERIFICATION.md`), which Scorecard doesn't count.

## Changes

Adds two real links to the "Reporting a Vulnerability" section:
1. Direct URL to this repo's GitHub Private Vulnerability Reporting form.
2. GitHub's docs page describing the private-advisory workflow.

No process changes — Private Vulnerability Reporting was already the documented preferred path.

## Test plan

- [ ] After merge + Scorecard re-run, alert #47 closes (check moves from 4/10 to ~10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)