### PR TITLE
ci(release): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Upgrade npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0 (tag object: e87c8ed249971350e47fab7515075f44eb134e5b)
@@ -50,5 +53,4 @@ jobs:
         env:
           # Prefer PAT (if configured) so version PRs can trigger downstream CI.
           GITHUB_TOKEN: "${{ secrets.RELEASE_BOT_PAT || secrets.GITHUB_TOKEN }}"
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Drop `NODE_AUTH_TOKEN` from the release job; rely on npm trusted publishing via the existing `id-token: write` permission.
- Upgrade npm to latest on the runner so OIDC publish (npm ≥ 11.5.1) is supported.
- Compatible with packages that require 2FA on publish — fixes the E403 we hit on run 25182328670 where automation tokens were rejected for `@starknetfoundation/starknet-agentic-{a2a,agent-passport,mcp-server,onboarding-utils}`.

## Required npm-side config (already done)
Each `@starknetfoundation/*` package has a Trusted Publisher entry:
- Publisher: GitHub Actions
- Org/Repo: `keep-starknet-strange/starknet-agentic`
- Workflow: `release.yml`
- Environment: (none)

`Require 2FA to publish` remains enabled per package.

## Follow-ups
- After this lands and a release run succeeds, the `NPM_TOKEN` secret can be revoked and removed from the repo.

## Test plan
- [ ] Merge to `main`.
- [ ] Wait for the next changeset version PR to land, triggering the publish path.
- [ ] Confirm all six `@starknetfoundation/*` packages publish without E403, with provenance attached.
- [ ] Revoke and delete the `NPM_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to optimize the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->