### PR TITLE
ci(release): bump release runner to Node 24 for npm 11 OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Upgrade npm for trusted publishing (OIDC)
-        run: npm install -g npm@latest
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary
- Bump release job's Node version from 22 → 24. Node 24 ships npm 11.x out of the box, which supports trusted publishing.
- Drop the `npm install -g npm@latest` step added in #415 — it hit npm's self-upgrade `MODULE_NOT_FOUND ('promise-retry')` bug on Node 22.

## Context
PR #415's release run failed at the npm upgrade step (run 25202889616). Self-upgrading npm in place is fragile; using a Node version that already bundles npm 11 avoids the issue entirely.

## Test plan
- [ ] Merge to `main`.
- [ ] Wait for the next changeset version PR to land, triggering the publish path.
- [ ] Confirm all six `@starknetfoundation/*` packages publish via OIDC without E403.
- [ ] Revoke and delete the `NPM_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)