### PR TITLE
ci(codeql): enable security-and-quality suite for JS/TS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript-typescript', 'actions']
+        include:
+          - language: javascript-typescript
+            queries: security-and-quality
+          - language: actions
 
     steps:
       - name: Checkout
@@ -32,6 +35,7 @@ jobs:
         uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
         with:
           languages: ${{ matrix.language }}
+          queries: ${{ matrix.queries }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a


### PR DESCRIPTION
## Summary
- Switch the `javascript-typescript` CodeQL matrix entry to the `security-and-quality` query suite. Adds maintainability/quality queries (e.g. `js/unused-local-variable`) on top of the default security pack.
- The `actions` language entry keeps the default suite — quality queries aren't supported there.

## Why
Surfaces Code Quality findings (e.g. the rule visible at `/security/quality/rules/js%2Funused-local-variable`) as standard code-scanning alerts so they're addressable via the same workflow as security findings.

## Test plan
- [ ] CodeQL workflow runs successfully on this PR for both matrix entries.
- [ ] After merge, the next `main` analysis populates additional alerts from the quality queries.
- [ ] Open a follow-up to triage / fix the new findings batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)