### PR TITLE
ci: bump github/codeql-action v3 -> v4.35.2 (Node 24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
         with:
           languages: ${{ matrix.language }}
           queries: ${{ matrix.queries }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Bump all four `github/codeql-action/*` SHAs to v4.35.2 (commit `95e58e9a`).
- Covers `init`, `autobuild`, `analyze` in `codeql.yml` and `upload-sarif` in `scorecard.yml`.

## Why
Clears two GitHub deprecation warnings observed on the latest CodeQL run:
- CodeQL Action v3 sunset → December 2026.
- Node 20 actions forced to Node 24 → June 2, 2026. v4 of the action ships on Node 24.

Pinned by commit SHA per repo convention; tag object SHA noted in the trailing comment so dependabot/scorecard hashlock checks remain happy.

## Test plan
- [ ] CodeQL job on this PR runs cleanly on both `javascript-typescript` and `actions` matrix entries.
- [ ] Scorecard SARIF upload on the next scheduled run succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)