### PR TITLE
fix(security): address CodeQL security-and-quality findings (8 alerts)

### DIFF
--- a/packages/create-starknet-agent/src/credentials.ts
+++ b/packages/create-starknet-agent/src/credentials.ts
@@ -304,14 +304,12 @@ function saveCredentialsJson(
     updatedAt: new Date().toISOString(),
   };
 
-  // Check if file exists to preserve createdAt
-  if (fs.existsSync(filePath)) {
-    try {
-      const existing = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-      credentials.createdAt = existing.createdAt || credentials.createdAt;
-    } catch {
-      // Ignore parse errors
-    }
+  // Preserve createdAt from any pre-existing file
+  try {
+    const existing = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    credentials.createdAt = existing.createdAt || credentials.createdAt;
+  } catch {
+    // File missing or unparsable — keep the new createdAt
   }
 
   fs.writeFileSync(filePath, JSON.stringify(credentials, null, 2), { mode: 0o600 });
@@ -328,9 +326,14 @@ function saveCredentialsEnv(
 ): void {
   const envContent: string[] = [];
 
-  // Read existing .env content if it exists
-  if (fs.existsSync(filePath)) {
-    const existing = fs.readFileSync(filePath, "utf-8");
+  // Read existing .env content if any (file may be absent on first save)
+  let existing = "";
+  try {
+    existing = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    existing = "";
+  }
+  if (existing) {
     const lines = existing.split("\n");
 
     // Filter out existing Starknet vars
@@ -375,8 +378,10 @@ function ensureGitignore(dir: string): void {
   const gitignorePath = path.join(dir, ".gitignore");
 
   let content = "";
-  if (fs.existsSync(gitignorePath)) {
+  try {
     content = fs.readFileSync(gitignorePath, "utf-8");
+  } catch {
+    content = "";
   }
 
   // Check if .env is already ignored

--- a/packages/create-starknet-agent/src/credentials.ts
+++ b/packages/create-starknet-agent/src/credentials.ts
@@ -330,8 +330,8 @@ function saveCredentialsEnv(
   let existing = "";
   try {
     existing = fs.readFileSync(filePath, "utf-8");
-  } catch {
-    existing = "";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
   }
   if (existing) {
     const lines = existing.split("\n");
@@ -380,8 +380,8 @@ function ensureGitignore(dir: string): void {
   let content = "";
   try {
     content = fs.readFileSync(gitignorePath, "utf-8");
-  } catch {
-    content = "";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
   }
 
   // Check if .env is already ignored

--- a/packages/starknet-agent-passport/src/index.ts
+++ b/packages/starknet-agent-passport/src/index.ts
@@ -33,7 +33,7 @@ export function decodeByteArrayAsString(v: unknown): string {
 }
 
 function isByteArray(v: unknown): v is ByteArray {
-  if (typeof v !== "object" || v === null) return false
+  if (v === null || typeof v !== "object") return false
   const obj = v as Record<string, unknown>
   return (
     Array.isArray(obj.data) &&

--- a/packages/starknet-mcp-server/src/services/TokenService.ts
+++ b/packages/starknet-mcp-server/src/services/TokenService.ts
@@ -298,7 +298,7 @@ export class TokenService {
     try {
       // Unwrap { symbol: ... } or { name: ... } responses, unless it's a direct ByteArray
       let value = result;
-      if (result !== null && typeof result === "object" && !Array.isArray(result) && !this.isByteArray(result)) {
+      if (typeof result === "object" && !Array.isArray(result) && !this.isByteArray(result)) {
         const record = result as Record<string, unknown>;
         if ("symbol" in record) value = record.symbol;
         else if ("name" in record) value = record.name;

--- a/packages/starknet-mcp-server/src/services/TokenService.ts
+++ b/packages/starknet-mcp-server/src/services/TokenService.ts
@@ -298,7 +298,7 @@ export class TokenService {
     try {
       // Unwrap { symbol: ... } or { name: ... } responses, unless it's a direct ByteArray
       let value = result;
-      if (typeof result === "object" && result !== null && !Array.isArray(result) && !this.isByteArray(result)) {
+      if (result !== null && typeof result === "object" && !Array.isArray(result) && !this.isByteArray(result)) {
         const record = result as Record<string, unknown>;
         if ("symbol" in record) value = record.symbol;
         else if ("name" in record) value = record.name;

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -26,7 +26,7 @@
 import { RpcProvider, hash } from 'starknet';
 import { WebSocket } from 'ws';
 import { execSync, execFileSync } from 'child_process';
-import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, lstatSync } from 'fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, lstatSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join, basename } from 'path';
 
@@ -121,10 +121,11 @@ exec flock -n "$LOCKFILE" node ${shellQuote(scriptPath)} ${shellQuote(`@${config
     lines.push(cronEntry);
     
     const newCrontab = lines.join('\n') + '\n';
-    const tmpCrontab = join(tmpdir(), `crontab-${process.pid}.tmp`);
-    writeFileSync(tmpCrontab, newCrontab);
+    const tmpDir = mkdtempSync(join(tmpdir(), 'starknet-crontab-'));
+    const tmpCrontab = join(tmpDir, 'crontab.tmp');
+    writeFileSync(tmpCrontab, newCrontab, { mode: 0o600 });
     execFileSync('crontab', [tmpCrontab]);
-    try { unlinkSync(tmpCrontab); } catch (e) { log(`Failed to remove temp crontab (${tmpCrontab}): ${e}`, 'warn'); }
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { log(`Failed to remove temp crontab dir (${tmpDir}): ${e}`, 'warn'); }
 
     return {
       success: true,
@@ -147,7 +148,7 @@ function deriveWebSocketUrl(httpUrl) {
   if (!value) return value;
 
   // Infura Starknet: https://starknet-mainnet.infura.io/v3/<KEY> -> wss://starknet-mainnet.infura.io/ws/v3/<KEY>
-  if (/\.infura\.io\/v3\//i.test(value)) {
+  if (/^https?:\/\/[^/]*\.infura\.io\/v3\//i.test(value)) {
     return value
       .replace(/^https:\/\//i, 'wss://')
       .replace(/^http:\/\//i, 'ws://')
@@ -287,10 +288,11 @@ class SmartEventWatcher {
         const currentCrontab = execSync('crontab -l 2>/dev/null || echo ""').toString();
         const lines = currentCrontab.split('\n').filter(line => !line.includes(shellPath));
         const newCrontab = lines.join('\n') + '\n';
-        const tmpCrontab = join(tmpdir(), `crontab-${process.pid}.tmp`);
-        writeFileSync(tmpCrontab, newCrontab);
+        const tmpDir = mkdtempSync(join(tmpdir(), 'starknet-crontab-'));
+        const tmpCrontab = join(tmpDir, 'crontab.tmp');
+        writeFileSync(tmpCrontab, newCrontab, { mode: 0o600 });
         execFileSync('crontab', [tmpCrontab]);
-        try { unlinkSync(tmpCrontab); } catch (e) { this.log(`Failed to remove temp crontab (${tmpCrontab}): ${e}`, 'warn'); }
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { this.log(`Failed to remove temp crontab dir (${tmpDir}): ${e}`, 'warn'); }
 
         // Delete files
         try { unlinkSync(shellPath); } catch (e) { this.log(`Failed to remove shellPath (${shellPath}): ${e}`, 'warn'); }
@@ -314,10 +316,11 @@ class SmartEventWatcher {
             const currentCrontab = execSync('crontab -l 2>/dev/null || echo ""').toString();
             const lines = currentCrontab.split('\n').filter(line => !line.includes(shellPath));
             const newCrontab = lines.join('\n') + '\n';
-            const tmpCrontab = join(tmpdir(), `crontab-${process.pid}-2.tmp`);
-            writeFileSync(tmpCrontab, newCrontab);
+            const tmpDir = mkdtempSync(join(tmpdir(), 'starknet-crontab-'));
+            const tmpCrontab = join(tmpDir, 'crontab.tmp');
+            writeFileSync(tmpCrontab, newCrontab, { mode: 0o600 });
             execFileSync('crontab', [tmpCrontab]);
-            try { unlinkSync(tmpCrontab); } catch (e) { this.log(`Failed to remove temp crontab (${tmpCrontab}): ${e}`, 'warn'); }
+            try { rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { this.log(`Failed to remove temp crontab dir (${tmpDir}): ${e}`, 'warn'); }
 
             try { unlinkSync(shellPath); } catch (e) { this.log(`Failed to remove shellPath (${shellPath}): ${e}`, 'warn'); }
             const derivedConfigPath = shellPath.replace(/\.sh$/i, '.json');


### PR DESCRIPTION
## Summary
Closes 8 of the 17 security-tagged CodeQL alerts surfaced after #417 enabled the \`security-and-quality\` suite.

| Rule | Count | File(s) |
|---|---|---|
| \`js/comparison-between-incompatible-types\` | 2 | \`packages/starknet-agent-passport/src/index.ts\`, \`packages/starknet-mcp-server/src/services/TokenService.ts\` |
| \`js/regex/missing-regexp-anchor\` | 1 | \`skills/starknet-anonymous-wallet/scripts/watch-events-smart.js\` |
| \`js/insecure-temporary-file\` | 3 | \`skills/starknet-anonymous-wallet/scripts/watch-events-smart.js\` |
| \`js/file-system-race\` | 3 | \`packages/create-starknet-agent/src/credentials.ts\` |

### What changed
- **Comparison fixes** — reorder \`v === null\` ahead of \`typeof v !== "object"\`. Same correctness, but stops CodeQL flagging \`null\` against an object-narrowed type.
- **Regex anchor** — change \`/\\.infura\\.io\\/v3\\//i\` → \`/^https?:\\/\\/[^/]*\\.infura\\.io\\/v3\\//i\` so the path part can't carry the match.
- **Temp files** — replace \`join(tmpdir(), \\\`crontab-\${process.pid}-X.tmp\\\`)\` (predictable, world-readable) with a per-call \`mkdtempSync(...)\` directory, mode 0o600 on the file, and \`rmSync(dir, { recursive: true })\` cleanup.
- **TOCTOU in credentials.ts** — drop the \`existsSync\` + \`readFileSync\` + \`writeFileSync\` pattern in three save paths; try the read directly and treat \`ENOENT\` as "no prior content."

### Verification
- \`pnpm build\` succeeds for all three TS packages I touched.
- \`pnpm -F create-starknet-agent test\` → 75/75 pass.
- \`pnpm -F starknet-mcp-server test\` → 386/386 pass (8 skipped).
- \`pnpm -F starknet-agent-passport test\` → 4/4 pass.

### Deferred (separate follow-up)
- 2× \`js/clear-text-logging\` in \`starknet-wallet/scripts/check-balance{,s}.ts\` — these flag logging the **public** wallet address read from env. Likely a false-positive dismissal rather than a code change.
- 2× \`js/http-to-file-access\` in \`packages/create-starknet-agent/src/wizards.ts\` — skill installer; needs path-traversal validation before the writeFileSync.
- 2× \`js/file-access-to-http\` in \`watch-events-smart.js\` — config-driven webhook fetch; behavior is intentional, will likely dismiss.
- 1× \`js/file-system-race\` in \`watch-events-smart.js\` (lstat→readFile pattern at line 312).
- 1× \`js/file-system-race\` in \`contracts/erc8004-cairo/scripts/deploy.js\` (existsSync→writeFileSync; minor).

## Test plan
- [ ] CodeQL run on this PR passes both matrix entries.
- [ ] After merge, the 8 alerts above transition to \"closed\" automatically.
- [ ] Open follow-up PR(s) for the deferred items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)