### PR TITLE
chore(security): bump Pillow floor to >=12.2.0

### DIFF
--- a/skills/starknet-mini-pay/requirements.txt
+++ b/skills/starknet-mini-pay/requirements.txt
@@ -5,7 +5,7 @@ starknet-py>=0.6.0
 
 # QR Code generation
 qrcode[pil]>=7.4.2
-Pillow>=10.3.0
+Pillow>=12.2.0
 
 # Telegram Bot
 python-telegram-bot>=20.0


### PR DESCRIPTION
## Summary
Closes Scorecard alert #49 by raising the \`Pillow\` floor in \`skills/starknet-mini-pay/requirements.txt\` from \`>=10.3.0\` to \`>=12.2.0\`.

This clears two high-severity advisories that the previously-allowed range exposed us to:

| GHSA | Severity | Description | Fixed in |
|---|---|---|---|
| GHSA-cfh3-3jmp-rvhc | high | Out-of-bounds write loading PSD images | 12.1.1 |
| GHSA-whj4-6x5x-4v2j | high | FITS GZIP decompression bomb | 12.2.0 |

## Test plan
- [ ] No code changes; just a dependency floor bump.
- [ ] After merge, the next Scorecard run drops alert #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Pillow package dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->