### PR TITLE
fix(security): close remaining file-system-race CodeQL alerts (2)

### DIFF
--- a/contracts/erc8004-cairo/scripts/deploy.js
+++ b/contracts/erc8004-cairo/scripts/deploy.js
@@ -343,9 +343,6 @@ async function main() {
   fs.writeFileSync(outputPath, JSON.stringify(deploymentInfo, null, 2));
 
   const networkOutputPath = path.join(__dirname, "..", `deployed_addresses_${network.slug}.json`);
-  if (fs.existsSync(networkOutputPath)) {
-    console.warn(`⚠️  Overwriting existing ${path.basename(networkOutputPath)} (latest deployment pointer).`);
-  }
   fs.writeFileSync(networkOutputPath, JSON.stringify(deploymentInfo, null, 2));
   const timestampSuffix = deploymentInfo.deployedAt.replace(/[:.]/g, "-");
   const immutableOutputPath = path.join(

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -26,7 +26,7 @@
 import { RpcProvider, hash } from 'starknet';
 import { WebSocket } from 'ws';
 import { execSync, execFileSync } from 'child_process';
-import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, lstatSync, mkdtempSync, rmSync } from 'fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, mkdtempSync, rmSync, openSync, fstatSync, closeSync, constants as fsConstants } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join, basename } from 'path';
 
@@ -308,10 +308,20 @@ class SmartEventWatcher {
         for (const file of files) {
           if (!file.endsWith('.sh')) continue;
           const shellPath = join(cronDir, file);
-          const shellStat = lstatSync(shellPath, { throwIfNoEntry: false });
-          if (!shellStat || !shellStat.isFile() || shellStat.isSymbolicLink()) continue;
-
-          const content = readFileSync(shellPath, 'utf8');
+          // O_NOFOLLOW makes openSync throw ELOOP on symlinks, atomically
+          // ruling out the symlink-swap TOCTOU between stat and read.
+          let content;
+          try {
+            const fd = openSync(shellPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+            try {
+              if (!fstatSync(fd).isFile()) continue;
+              content = readFileSync(fd, 'utf8');
+            } finally {
+              closeSync(fd);
+            }
+          } catch {
+            continue;
+          }
           if (content.includes(knownConfigPath)) {
             const currentCrontab = execSync('crontab -l 2>/dev/null || echo ""').toString();
             const lines = currentCrontab.split('\n').filter(line => !line.includes(shellPath));


### PR DESCRIPTION
## Summary
Closes the two remaining \`js/file-system-race\` high-severity alerts from the \`security-and-quality\` suite (#60, #64). These were the leftovers from #419's deferred list.

| Alert | File | Fix |
|---|---|---|
| #64 | \`skills/starknet-anonymous-wallet/scripts/watch-events-smart.js:312\` | Replace \`lstatSync\` + \`readFileSync\` with atomic \`openSync(O_RDONLY | O_NOFOLLOW)\` + \`fstatSync\` + read-from-fd. Symlink swaps now fail at open (ELOOP) and are skipped, instead of being followed. |
| #60 | \`contracts/erc8004-cairo/scripts/deploy.js:349\` | Drop the \`existsSync\` check fronting the unconditional \`writeFileSync\`. The script's purpose is to publish these pointers; the "overwriting" warning created a TOCTOU window with no security or correctness benefit. |

## Verification
- Both scripts parse under \`node --check\`.

## Status of the broader CodeQL batch
With #419 (merged) + #420 (Pillow) + this PR, plus the two false-positive dismissals on \`js/clear-text-logging\` (#35, #36), every high-severity CodeQL finding from the \`security-and-quality\` suite is addressed.

Remaining open Scorecard items (#45 Maintained, #46 Code-Review) are process/time, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)