### PR TITLE
chore(security): bump ip-address floor to >=10.1.1 (CVE-2026-42338)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
       "ajv@^8.0.0": "8.18.0",
       "express-rate-limit": "8.3.0",
       "hono": "^4.12.14",
+      "ip-address": "^10.1.1",
       "postcss": "^8.5.12",
       "qs": "6.14.2",
       "minimatch": "10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ajv@^8.0.0: 8.18.0
   express-rate-limit: 8.3.0
   hono: ^4.12.14
+  ip-address: ^10.1.1
   postcss: ^8.5.12
   qs: 6.14.2
   minimatch: 10.2.3
@@ -2952,8 +2953,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -6894,7 +6895,7 @@ snapshots:
   express-rate-limit@8.3.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -7287,7 +7288,7 @@ snapshots:
       hasown: 2.0.3
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #41 (`ip-address` ≤ 10.1.0, [CVE-2026-42338](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) — XSS in `Address6` HTML-emitting methods).
- Adds `"ip-address": "^10.1.1"` to root `pnpm.overrides`; lockfile now resolves to `10.2.0` everywhere.

## Why this is a low-risk, transitive-only fix
- Pulled in via `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.0 → ip-address`.
- The vulnerable surfaces are `Address6.group()`, `Address6.link()`, `spanAll()`, and `AddressError.parseMessage` rendered as HTML. `express-rate-limit` only uses `ip-address` for IP parsing/comparison in trust-proxy logic — none of the HTML-emitting APIs are called.
- The advisory itself notes "Real-world exposure is believed to be extremely limited… Applications using only the address-parsing and comparison APIs are not affected."
- Same pattern as prior `pnpm.overrides` security floors (postcss, hono, path-to-regexp, etc.).

## Test plan
- [ ] CI green (`pnpm install` no longer hits the vulnerable version)
- [ ] `pnpm why ip-address -r` shows `10.2.0` everywhere
- [ ] Dependabot alert #41 auto-resolves once PR merges to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to ensure consistent package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->