### PR TITLE
chore: remove unused imports/vars/functions (45 CodeQL alerts)

### DIFF
--- a/contracts/erc8004-cairo/e2e-tests/check-balance.js
+++ b/contracts/erc8004-cairo/e2e-tests/check-balance.js
@@ -1,4 +1,4 @@
-import { RpcProvider, Account, constants } from 'starknet';
+import { RpcProvider, constants } from 'starknet';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/contracts/erc8004-cairo/e2e-tests/setup.js
+++ b/contracts/erc8004-cairo/e2e-tests/setup.js
@@ -1,4 +1,4 @@
-import { Account, Contract, RpcProvider, cairo, shortString, constants } from 'starknet';
+import { Account, Contract, RpcProvider, cairo, constants } from 'starknet';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/contracts/erc8004-cairo/e2e-tests/test-oz-reputation.js
+++ b/contracts/erc8004-cairo/e2e-tests/test-oz-reputation.js
@@ -1,8 +1,7 @@
-import { Account, Contract, RpcProvider, hash, ec, cairo, CallData, shortString, json } from 'starknet';
+import { Account, Contract, RpcProvider, hash, ec, cairo, shortString } from 'starknet';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import readline from 'readline';
 import dotenv from 'dotenv';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -120,8 +119,8 @@ async function main() {
     
     const funderAddress = validateEnvVar('DEPLOYER_ADDRESS');
     const funderPrivateKey = validateEnvVar('DEPLOYER_PRIVATE_KEY');
-    const funderAccount = new Account({ provider, address: funderAddress, signer: funderPrivateKey });
-    
+    new Account({ provider, address: funderAddress, signer: funderPrivateKey });
+
     console.log(`💰 Funder: ${funderAddress.slice(0, 18)}...`);
     console.log('   ✅ Connected\n');
 

--- a/contracts/erc8004-cairo/e2e-tests/tests/identity.test.js
+++ b/contracts/erc8004-cairo/e2e-tests/tests/identity.test.js
@@ -11,12 +11,6 @@ import {
 import { ec, hash, shortString } from 'starknet';
 
 // SNIP-6 signature helpers for set_agent_wallet
-function toI128BigInt(num) {
-  if (num >= 0) return BigInt(num);
-  const FELT_PRIME = BigInt('0x800000000000011000000000000000000000000000000000000000000000001');
-  return FELT_PRIME - BigInt(Math.abs(num));
-}
-
 function toFeltBigInt(value) {
   if (typeof value === 'bigint') return value;
   if (typeof value === 'number') return BigInt(value);

--- a/contracts/erc8004-cairo/e2e-tests/tests/reputation.test.js
+++ b/contracts/erc8004-cairo/e2e-tests/tests/reputation.test.js
@@ -1,4 +1,4 @@
-import { Account, Contract, RpcProvider, cairo, CallData, hash, byteArray } from 'starknet';
+import { Account, Contract, RpcProvider, cairo, CallData, byteArray } from 'starknet';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -508,10 +508,7 @@ export default async function runTests() {
     
     // Returns: (clients[], indices[], values[], decimals[], tag1s[], tag2s[], revoked[])
     // Access using flattened structure
-    const clientsArr = allFeedback['0'] ?? allFeedback[0] ?? [];
-    const indicesArr = allFeedback['1'] ?? allFeedback[1] ?? [];
     const valuesArr = allFeedback['2'] ?? allFeedback[2] ?? [];
-    const decimalsArr = allFeedback['3'] ?? allFeedback[3] ?? [];
     const revokedArr = allFeedback['6'] ?? allFeedback[6] ?? [];
     
     console.log(`   Total feedback count: ${valuesArr.length}`);

--- a/contracts/erc8004-cairo/e2e-tests/tests/validation.test.js
+++ b/contracts/erc8004-cairo/e2e-tests/tests/validation.test.js
@@ -1,4 +1,4 @@
-import { Account, Contract, RpcProvider, cairo, constants } from 'starknet';
+import { Account, Contract, RpcProvider, constants } from 'starknet';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/examples/controller-calls/run.mjs
+++ b/examples/controller-calls/run.mjs
@@ -15,7 +15,6 @@
  *   STARKNET_PRIVATE_KEY
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
 import { resolveRpcSpecVersion } from "../../scripts/rpc-spec-version.mjs";
 
 // --- Call builder (mirrors starknet_build_calls MCP tool logic) ---
@@ -119,5 +118,5 @@ const result = await account.execute(calls);
 
 console.log(JSON.stringify({ transactionHash: result.transaction_hash }, null, 2));
 
-const receipt = await provider.waitForTransaction(result.transaction_hash);
+await provider.waitForTransaction(result.transaction_hash);
 console.error("Transaction accepted:", result.transaction_hash);

--- a/examples/crosschain-demo/run.ts
+++ b/examples/crosschain-demo/run.ts
@@ -3,17 +3,7 @@ import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import {
-  Account,
-  CallData,
-  ETransactionVersion,
-  PaymasterRpc,
-  type RpcProvider,
-  byteArray,
-  cairo,
-} from "starknet";
 import { Contract, Interface, JsonRpcProvider, Wallet, ZeroAddress } from "ethers";
-import { waitForTransactionWithTimeout } from "@starknetfoundation/starknet-agentic-onboarding-utils";
 import { preflight } from "./steps/preflight.js";
 import { deployAccount } from "./steps/deploy-account.js";
 import { fundDeployer } from "./steps/fund-deployer.js";
@@ -193,75 +183,6 @@ export function parsePositiveIntEnv(value: string | undefined, varName: string, 
     throw new Error(`Invalid ${varName} "${value}". Expected positive integer.`);
   }
   return parsed;
-}
-
-async function updateStarknetUri(args: {
-  provider: RpcProvider;
-  accountAddress: string;
-  privateKey: string;
-  registry: string;
-  agentId: string;
-  uri: string;
-  gasfree: boolean;
-  network: string;
-  paymasterApiKey?: string;
-  paymasterUrl?: string;
-}): Promise<string> {
-  const paymasterUrl =
-    args.paymasterUrl ||
-    (args.network === "sepolia"
-      ? "https://sepolia.paymaster.avnu.fi"
-      : "https://starknet.paymaster.avnu.fi");
-
-  const paymaster = new PaymasterRpc({
-    nodeUrl: paymasterUrl,
-    headers: args.paymasterApiKey
-      ? {
-          "x-paymaster-api-key": args.paymasterApiKey,
-        }
-      : {},
-  });
-
-  const account = new Account({
-    provider: args.provider,
-    address: args.accountAddress,
-    signer: args.privateKey,
-    transactionVersion: ETransactionVersion.V3,
-    paymaster,
-  });
-
-  const call = {
-    contractAddress: args.registry,
-    entrypoint: "set_agent_uri",
-    calldata: CallData.compile({
-      agent_id: cairo.uint256(BigInt(args.agentId)),
-      new_uri: byteArray.byteArrayFromString(args.uri),
-    }),
-  };
-
-  if (!args.gasfree) {
-    const tx = await account.execute(call);
-    await waitForTransactionWithTimeout({
-      provider: args.provider as any,
-      txHash: tx.transaction_hash,
-      timeoutMs: 300_000,
-    });
-    return tx.transaction_hash;
-  }
-
-  if (!args.paymasterApiKey) {
-    throw new Error("--gasfree requires AVNU_PAYMASTER_API_KEY in .env");
-  }
-  const tx = await account.executePaymasterTransaction([call], {
-    feeMode: { mode: "sponsored" },
-  });
-
-  await waitForTransactionWithTimeout({
-    provider: args.provider as any,
-    txHash: tx.transaction_hash,
-    timeoutMs: 300_000,
-  });
-  return tx.transaction_hash;
 }
 
 async function main() {

--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -2,7 +2,7 @@
  * Tests for platform-specific wizards
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   AVAILABLE_SKILLS,
   type WizardResult,
@@ -107,19 +107,6 @@ describe("MCP config generation", () => {
 
     const network = "sepolia";
     const expectedRpcUrl = RPC_URLS[network];
-
-    // The MCP config should include the starknet server
-    const expectedConfig = {
-      mcpServers: {
-        starknet: {
-          command: "npx",
-          args: ["-y", "@starknetfoundation/starknet-agentic-mcp-server@latest"],
-          env: expect.objectContaining({
-            STARKNET_RPC_URL: expectedRpcUrl,
-          }),
-        },
-      },
-    };
 
     expect(expectedRpcUrl).toBe("https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_7/YOUR_API_KEY");
   });

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -806,7 +806,7 @@ export async function cursorWizard(
   defaultNetwork: Network = "sepolia",
   jsonOutput = false,
   customSkills?: string[],
-  defaultConfigScope: ConfigScope = "local"
+  _defaultConfigScope: ConfigScope = "local" // Cursor uses project-local .cursor/ regardless of scope
 ): Promise<WizardResult> {
   if (!jsonOutput) {
     console.log();

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -826,10 +826,6 @@ export async function cursorWizard(
           : await promptSkills();
   const network = skipPrompts ? defaultNetwork : await promptNetwork();
 
-  // For Cursor, config scope doesn't change much (always project-local .cursor/)
-  // but we accept the parameter for API consistency
-  const configScope = defaultConfigScope;
-
   if (!jsonOutput) {
     console.log();
     console.log(pc.cyan("Configuring Starknet..."));

--- a/packages/starknet-a2a/src/index.ts
+++ b/packages/starknet-a2a/src/index.ts
@@ -10,7 +10,6 @@
  */
 
 import { RpcProvider, Contract, Account, shortString } from "starknet";
-import { z } from "zod";
 
 // ============================================================================
 // Type Definitions
@@ -270,12 +269,6 @@ export class StarknetA2AAdapter {
       capabilities?: string[];
     }
   ): Promise<string> {
-    const identityRegistry = new Contract({
-      abi: IDENTITY_REGISTRY_ABI,
-      address: this.identityRegistryAddress,
-      providerOrAccount: account,
-    });
-
     try {
       const capabilities = metadata.capabilities || [];
       const capabilitiesAsFelts = capabilities.map(stringToFelt);

--- a/packages/starknet-mcp-server/__tests__/helpers/sessionKeySigner.test.ts
+++ b/packages/starknet-mcp-server/__tests__/helpers/sessionKeySigner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { ec, hash, num, stark } from "starknet";
 import { SessionKeySigner } from "../../src/helpers/sessionKeySigner.js";
 

--- a/packages/starknet-mcp-server/__tests__/providers/avnu.test.ts
+++ b/packages/starknet-mcp-server/__tests__/providers/avnu.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   mockQuote,
-  mockSwapResult,
-  mockQuoteToCalls,
   createMockAvnu,
   createMockAvnuNoQuotes,
   createMockAvnuWithError,

--- a/packages/starknet-mcp-server/__tests__/services/TokenService.test.ts
+++ b/packages/starknet-mcp-server/__tests__/services/TokenService.test.ts
@@ -19,7 +19,7 @@ vi.mock("starknet", async (importOriginal) => {
 });
 
 import { fetchTokenByAddress, fetchVerifiedTokenBySymbol } from "@avnu/avnu-sdk";
-import { Contract, byteArray } from "starknet";
+import { Contract } from "starknet";
 
 const MOCK_LORDS_TOKEN = {
   address: "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",

--- a/packages/starknet-mcp-server/__tests__/tools/vesu.integration.test.ts
+++ b/packages/starknet-mcp-server/__tests__/tools/vesu.integration.test.ts
@@ -11,7 +11,6 @@ import {
   getVTokenAddress,
   buildDepositCalls,
   buildWithdrawCalls,
-  VESU_POOL_FACTORY,
   VESU_PRIME_POOL,
 } from "../../src/helpers/vesu.js";
 

--- a/packages/starknet-mcp-server/src/index.ts
+++ b/packages/starknet-mcp-server/src/index.ts
@@ -45,7 +45,6 @@ import {
   byteArray,
   ETransactionVersion,
   hash,
-  ec,
   validateAndParseAddress,
   type Call,
 } from "starknet";

--- a/packages/starknet-onboarding-utils/src/index.ts
+++ b/packages/starknet-onboarding-utils/src/index.ts
@@ -12,7 +12,6 @@ import {
   type Call,
   type PaymasterDetails,
 } from "starknet";
-import { trimTrailingChar as trimTrailingCharShared } from "@starknetfoundation/starknet-agentic-shared/string";
 
 export type ProviderLike = Pick<RpcProvider, "getChainId" | "callContract" | "waitForTransaction">;
 

--- a/packages/x402-starknet/src/index.ts
+++ b/packages/x402-starknet/src/index.ts
@@ -1,5 +1,4 @@
 import { Account, RpcProvider, type TypedData } from "starknet"
-import { trimTrailingChar } from "@starknetfoundation/starknet-agentic-shared/string"
 
 export type X402PaymentRequired = {
   /** opaque scheme id, ex: exact-starknet */

--- a/skills/starknet-anonymous-wallet/scripts/loot-survivor.js
+++ b/skills/starknet-anonymous-wallet/scripts/loot-survivor.js
@@ -72,12 +72,6 @@ function lootStateGetLatest(accountAddress) {
   return lootStateGetEntry(map, accountAddress).latestAdventurerId;
 }
 
-function lootStateGetPending(accountAddress) {
-  if (!accountAddress) return false;
-  const map = lootStateLoad();
-  return lootStateGetEntry(map, accountAddress).pendingEncounter;
-}
-
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -192,14 +186,6 @@ function toU8(v, name = 'value') {
   const n = Number(v);
   if (!Number.isInteger(n) || n < 0 || n > 255) fail(`${name} out of u8 range`, { [name]: v });
   return String(n);
-}
-
-function tryDecodeFeltToString(feltHex) {
-  try {
-    return shortString.decodeShortString(feltHex);
-  } catch {
-    return null;
-  }
 }
 
 async function readGameState(provider, adventurerId) {

--- a/skills/starknet-anonymous-wallet/scripts/parse-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/parse-smart.js
@@ -297,8 +297,7 @@ function escapeRegex(s) {
 function extractTokensAndProtocols(prompt, availableTokens, knownProtocols) {
   const doc = nlp(prompt);
   const text = doc.out('text');
-  const lowerText = text.toLowerCase();
-  
+
   const foundTokens = [];
   const foundProtocols = [];
   

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -15,8 +15,6 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, mkdir
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
-import { findCanonicalAction, ALL_SYNONYMS } from './synonyms.js';
-
 import { resolveRpcUrl } from './_rpc.js';
 import { fetchVerifiedTokens } from './_tokens.js';
 import { loadPrivateKeyByAccountAddress } from './_keys.js';
@@ -63,12 +61,6 @@ function lootStateGetLatest(accountAddress) {
   if (!accountAddress) return null;
   const map = lootStateLoad();
   return lootStateGetEntry(map, accountAddress).latestAdventurerId;
-}
-
-function lootStateGetPending(accountAddress) {
-  if (!accountAddress) return false;
-  const map = lootStateLoad();
-  return lootStateGetEntry(map, accountAddress).pendingEncounter;
 }
 
 function sleepSync(ms) {
@@ -128,13 +120,6 @@ function lootStateSetLatest(accountAddress, adventurerId) {
   });
 }
 
-function lootStateSetPending(accountAddress, pending) {
-  if (!accountAddress) return;
-  lootStateMutate(accountAddress, (entry) => {
-    entry.pendingEncounter = Boolean(pending);
-  });
-}
-
 // ============ DYNAMIC REGISTRY LOADING ============
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -186,11 +171,6 @@ function loadRegistry(filename) {
   return {};
 }
 
-function saveRegistry(filename, data) {
-  const filepath = join(SKILL_ROOT, filename);
-  writeFileSync(filepath, JSON.stringify(data, null, 2) + '\n');
-}
-
 function loadProtocols() {
   const registry = loadRegistry('protocols.json');
   const protocols = {};
@@ -219,75 +199,9 @@ async function fetchABI(address, provider) {
   }
 }
 
-async function findBestFunctionAcrossAddresses(protocolName, action, protocols, provider) {
-  const addresses = protocols[protocolName];
-  if (!addresses || addresses.length === 0) {
-    return { error: `No addresses found for protocol ${protocolName}` };
-  }
-  
-  let bestMatch = null;
-  let bestScore = 0;
-  let allFunctions = [];
-  
-  // Scan all addresses
-  for (const address of addresses) {
-    const abi = await fetchABI(address, provider);
-    const functions = extractABIItems(abi).functions;
-    
-    for (const func of functions) {
-      const score = calculateSimilarity(action, func.name);
-      allFunctions.push({
-        name: func.name,
-        address: address,
-        score: score,
-        inputs: func.inputs || [],
-        outputs: func.outputs || [],
-        state_mutability: func.state_mutability || 'external'
-      });
-      
-      if (score > bestScore) {
-        bestScore = score;
-        bestMatch = {
-          name: func.name,
-          address: address,
-          score: score,
-          inputs: func.inputs || [],
-          outputs: func.outputs || [],
-          state_mutability: func.state_mutability || 'external',
-          fullABI: abi
-        };
-      }
-    }
-  }
-  
-  // Sort all functions by score for reference
-  allFunctions.sort((a, b) => b.score - a.score);
-  
-  return {
-    bestMatch: bestMatch,
-    allMatches: allFunctions.slice(0, 10), // Top 10 matches
-    scannedAddresses: addresses.length,
-    protocolName: protocolName
-  };
-}
-
-function loadFriends() {
-  // FRIENDS FEATURE REMOVED - recipients must be addresses
-  return {};
-}
-
 // ============ PROMPT INJECTION PROTECTION ============
 // ============ CONFIGURATION (loaded from JSON files) ============
 // Loaded dynamically in main() to allow registration during execution
-
-// ============ HELPERS ============
-function tryParseJSON(str) {
-  try {
-    return JSON.parse(str);
-  } catch {
-    return null;
-  }
-}
 
 // ============ SECRETS MANAGEMENT (SINGLE ACCESS) ============
 function getSecretsDir() {
@@ -429,58 +343,6 @@ function isComplexAbiType(typeStr) {
   );
 }
 
-function estimateCalldataLenFromInputs(inputs) {
-  if (!Array.isArray(inputs)) return null;
-  let n = 0;
-  for (const inp of inputs) {
-    const t = String(inp?.type || '').toLowerCase();
-    if (!t) return null;
-
-    // Complex types: skip strict length enforcement (avoid false positives)
-    if (isComplexAbiType(t)) {
-      return null;
-    }
-
-    // Cairo u256 / Uint256 is typically 2 felts
-    if (t === 'u256' || t.endsWith('::u256') || t.includes('uint256') || t.includes('core::integer::u256')) {
-      n += 2;
-      continue;
-    }
-
-    // Default: 1 felt
-    n += 1;
-  }
-  return n;
-}
-
-async function resolveFromABI(provider, contractAddress, query, type = 'function') {
-  try {
-    const resp = await provider.getClassAt(contractAddress);
-    if (!resp.abi) return null;
-    
-    const { functions, events } = extractABIItems(resp.abi);
-    const items = type === 'event' ? events : functions;
-    
-    if (items.length === 0) return null;
-    
-    let best = null;
-    let bestScore = 0;
-    
-    for (const item of items) {
-      const score = calculateSimilarity(query, item.name);
-      if (score > bestScore) {
-        bestScore = score;
-        best = item;
-      }
-    }
-    
-    const threshold = query.length <= 3 ? 20 : query.length <= 6 ? 15 : 10;
-    return bestScore >= threshold ? { name: best.name, score: bestScore } : null;
-  } catch (err) {
-    return null;
-  }
-}
-
 // ============ TOKEN OPERATIONS ============
 function formatUnitsSafe(value, decimals, maxFractionDigits = 6) {
   const d = Number(decimals ?? 18);
@@ -494,40 +356,6 @@ function formatUnitsSafe(value, decimals, maxFractionDigits = 6) {
   let fracStr = frac.toString().padStart(d, '0').slice(0, maxFractionDigits);
   fracStr = fracStr.replace(/0+$/, '');
   return fracStr ? `${whole.toString()}.${fracStr}` : whole.toString();
-}
-
-async function getTokenBalance(provider, tokenAddress, accountAddress, decimals) {
-  try {
-    const result = await provider.callContract({
-      contractAddress: tokenAddress,
-      entrypoint: 'balanceOf',
-      calldata: [accountAddress]
-    });
-    const raw = Array.isArray(result) ? result : (result?.result || []);
-    if (raw.length >= 2) {
-      const value = BigInt(raw[0]) + (BigInt(raw[1]) << 128n);
-      return {
-        raw: value.toString(),
-        human: formatUnitsSafe(value, decimals)
-      };
-    }
-  } catch {}
-  return { raw: "0", human: "0" };
-}
-
-async function getTokenAllowance(provider, tokenAddress, owner, spender) {
-  try {
-    const result = await provider.callContract({
-      contractAddress: tokenAddress,
-      entrypoint: 'allowance',
-      calldata: [owner, spender]
-    });
-    const raw = Array.isArray(result) ? result : (result?.result || []);
-    if (raw.length >= 2) {
-      return BigInt(raw[0]) + (BigInt(raw[1]) << 128n);
-    }
-  } catch {}
-  return 0n;
 }
 
 function toUint256(n) {

--- a/skills/starknet-anonymous-wallet/scripts/vesu-pool.js
+++ b/skills/starknet-anonymous-wallet/scripts/vesu-pool.js
@@ -17,7 +17,7 @@
  * }
  */
 
-import { RpcProvider as Provider, Contract } from 'starknet';
+import { RpcProvider as Provider } from 'starknet';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -77,12 +77,6 @@ function parseAmountToBaseUnits(amount, decimals) {
   const fracPadded = (fracRaw + '0'.repeat(dec)).slice(0, dec);
   const fracBI = BigInt(fracPadded || '0');
   return intBI * base + fracBI;
-}
-
-function toUint256(n) {
-  const low = (n & ((1n << 128n) - 1n));
-  const high = (n >> 128n);
-  return { low: low.toString(), high: high.toString() };
 }
 
 function u256ToBigInt(v) {
@@ -505,27 +499,6 @@ async function main() {
   const collateralBase = parseAmountToBaseUnits(collateralAmountHuman, collateralInfo.decimals);
   const debtBase = parseAmountToBaseUnits(debtAmountHuman, debtInfo.decimals);
 
-  // Build ModifyPositionParams
-  // We try to build in a shape that starknet.js CallData can compile.
-  // Because enum encoding differs, we include a primary + fallback key.
-  const collateralAmount = {
-    denomination: { Assets: {} },
-    value: collateralBase.toString()
-  };
-  const debtAmount = {
-    denomination: { Assets: {} },
-    value: debtBase.toString()
-  };
-
-  const params = {
-    collateral_asset: collateralInfo.address,
-    debt_asset: debtInfo.address,
-    user,
-    collateral: collateralAmount,
-    debt: debtAmount
-  };
-
-  // Compile calldata for modify_position
   // For Vesu Pool, we use manual calldata construction since we know the exact structure
   const toFelt = (hex) => String(hex);
   const toU256 = (n) => {

--- a/skills/starkzap-sdk/scripts/staking-pool-discovery.ts
+++ b/skills/starkzap-sdk/scripts/staking-pool-discovery.ts
@@ -6,7 +6,7 @@
 import { StarkSDK } from "starkzap";
 
 async function main() {
-  const sdk = new StarkSDK({ network: "sepolia" });
+  new StarkSDK({ network: "sepolia" });
 
   // Replace with real staking API usage in Starkzap repo context.
   console.log("SDK initialized for staking pool discovery checks (network: sepolia)");

--- a/website/app/components/skills/SkillsGrid.tsx
+++ b/website/app/components/skills/SkillsGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { SKILLS, getAllKeywords, filterSkills } from "@/data/skills";
+import { getAllKeywords, filterSkills } from "@/data/skills";
 import { SkillCard } from "./SkillCard";
 
 export function SkillsGrid() {


### PR DESCRIPTION
## Summary

Closes 45 open CodeQL `js/unused-local-variable` alerts (\"Unused variable, import, function or class\") across the repo by removing dead code: imports that aren't referenced, never-called functions, and assigned-but-unread variables.

Net diff: **+15 / -349 lines** across 24 files. No runtime behavior change.

### What got removed

| Area | Files | Notes |
|------|-------|-------|
| `packages/starknet-mcp-server/src/index.ts` | 1 | unused `ec` import |
| `packages/starknet-a2a/src/index.ts` | 1 | unused `z` import + duplicate `identityRegistry` declaration |
| `packages/x402-starknet/src/index.ts` | 1 | unused `trimTrailingChar` import |
| `packages/starknet-onboarding-utils/src/index.ts` | 1 | unused `trimTrailingCharShared` alias |
| `packages/create-starknet-agent/src/wizards.ts` | 1 | unused `configScope` (Cursor branch) |
| MCP server tests | 4 | unused vitest hooks/mocks |
| `packages/create-starknet-agent/src/__tests__/wizards.test.ts` | 1 | unused `expectedConfig` + lifecycle hooks |
| `examples/crosschain-demo/run.ts` | 1 | dropped never-called `updateStarknetUri` (-67 lines) and now-orphan starknet imports |
| `examples/controller-calls/run.mjs` | 1 | unused `readFileSync`/`writeFileSync` + unused `receipt` binding |
| `skills/starknet-anonymous-wallet/scripts/resolve-smart.js` | 1 | removed 10 dead helpers (`tryParseJSON`, `loadFriends`, `getTokenBalance`, `getTokenAllowance`, `findBestFunctionAcrossAddresses`, `resolveFromABI`, etc.) — biggest contributor at -172 lines |
| Other anonymous-wallet scripts | 3 | dead helpers in `loot-survivor.js`, `vesu-pool.js`, unused `lowerText` in `parse-smart.js` |
| `skills/starkzap-sdk/scripts/staking-pool-discovery.ts` | 1 | dropped unused `sdk` binding |
| `website/app/components/skills/SkillsGrid.tsx` | 1 | unused `SKILLS` import |
| `contracts/erc8004-cairo/e2e-tests/*` | 6 | unused `Account`, `shortString`, `cairo`, `hash`, `readline`, `CallData`, `json` imports + dead `toI128BigInt` helper + unused result arrays from `read_all_feedback` |

### Verification

- [x] `pnpm install` clean
- [x] `pnpm run build` (CI's \"Type Check\" step) — all 9 packages + website build successfully
- [x] `pnpm test` — 11 test suites pass (no regressions)
- [ ] CodeQL re-scan should clear the 45 affected alerts (verified post-merge)

### Notes

- I deliberately did **not** chase the cascade: removing `findBestFunctionAcrossAddresses` and friends from `resolve-smart.js` likely orphans some helper functions (e.g. `fetchABI`, `extractABIItems`). Those will surface as new CodeQL alerts on the next scan and can be tidied in a follow-up — keeping this PR scoped to what CodeQL actually flagged.
- Lint job is pre-existing broken on `main` (Next.js 16 removed `next lint`); unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— please give this a human review before merging.