### PR TITLE
ci: auto-merge Dependabot patch & minor PRs when CI passes

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,13 +3,19 @@ name: Dependabot auto-merge
 on: pull_request_target
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   auto-merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'keep-starknet-strange/starknet-agentic'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'keep-starknet-strange/starknet-agentic'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch & minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a workflow that enables GitHub's native auto-merge on Dependabot PRs that bump versions by **patch** or **minor** only. Major bumps still need a human (which would have caught last week's `starknet 9.4 → 10.0` group bump and the broken lockfile in PR #429).

### How it works

1. `pull_request_target` event fires when Dependabot opens a PR (so the workflow uses the version on `main`, not whatever Dependabot pushed)
2. `dependabot/fetch-metadata` reads the update type from the PR (`semver-patch` / `semver-minor` / `semver-major`)
3. If patch or minor, the job runs `gh pr merge --auto --squash` — GitHub then waits for required status checks before merging

### Action pinning

`dependabot/fetch-metadata` is pinned to commit SHA `25dd0e34` (v3.1.0), matching the rest of the repo's SHA-pinned actions.

## Required follow-up admin steps (cannot be done in code)

This workflow alone won't auto-merge anything until two repo-level settings are flipped. Both are admin-only:

1. **Enable repo-level auto-merge** — currently `allow_auto_merge: false`
2. **Add Dependabot as a bypass actor on `main`'s branch protection** — currently classic protection requires 1 review + CODEOWNERS, which Dependabot can't satisfy. Needs migration to a ruleset.

I can drive these via API on request — flagged in the next message of the conversation that opened this PR.

## Test plan
- [ ] After merge + admin steps, the next Dependabot patch/minor PR auto-merges once CI passes
- [ ] A simulated semver-major PR (or the next real one) is **not** auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— please give this a human review before merging.