### PR TITLE
skills(cairo-auditor): stop cross-file deduplication and add lead tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,7 @@ jobs:
         run: |
           python3 skills/cairo-auditor/tests/validate_preflight.py
           python3 skills/cairo-auditor/tests/validate_deep_smoke.py
+          python3 skills/cairo-auditor/tests/validate_report_merge.py
 
       - name: Validate skills manifest
         run: |

--- a/skills/cairo-auditor/README.md
+++ b/skills/cairo-auditor/README.md
@@ -518,7 +518,7 @@ cairo-auditor/
     adversarial.md             # adversarial specialist instructions
   references/
     attack-vectors/            # 170 vectors in 4 partitions
-    vulnerability-db/          # 28 canonical vulnerability classes
+    vulnerability-db/          # 34 canonical vulnerability classes
     judging.md                 # FP gate + confidence scoring
     report-formatting.md       # finding template + priority mapping
     threat-intel-sources.md    # source policy for optional web enrichment

--- a/skills/cairo-auditor/SKILL.md
+++ b/skills/cairo-auditor/SKILL.md
@@ -360,7 +360,7 @@ Integrity gate (for hosts where deep-mode enforcement is enabled):
 **Turn 4 — Report.** Merge all agent results and emit the report in canonical order:
 
 0. If `{skill_root}/scripts/quality/structured_report.py` exists, render through it with all `{workdir}/cairo-audit-agent-*-findings.json` files, the preflight JSON path, `{workdir}/cairo-audit-files.txt`, the resolved execution-integrity value, and `--proven-only` when that flag is active. Use its Markdown output as the report body.
-1. Deduplicate by root cause (keep the higher-confidence version, merge broader attack path details; on confidence tie keep higher priority, then more complete path evidence).
+1. Deduplicate by root cause **within a single file** (keep the higher-confidence version, merge broader attack path details; on confidence tie keep higher priority, then more complete path evidence). Never merge candidates across different files: two specialists can describe unrelated bugs in separate files with the same root-cause sentence, and merging those discards a real finding. A proven finding always outranks a lead for the same root cause.
 2. Apply evidence tags per `references/judging.md` Evidence Tags section:
    - Validate every finding has `[CODE-TRACE]`; if a source agent omitted it, add `[CODE-TRACE]` during merge normalization.
    - Add `[PREFLIGHT-HIT]` if the deterministic preflight flagged the same class or entry point.
@@ -371,7 +371,7 @@ Integrity gate (for hosts where deep-mode enforcement is enabled):
 5. Re-number findings sequentially starting at `1`.
 6. Insert one **Below Confidence Threshold** separator row in the findings index immediately before the first finding with confidence < 75.
 7. Print rendered findings directly — do not re-draft or re-describe them.
-8. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, `Findings Index`.
+8. Always include sections in this exact order: `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Leads`, `Dropped Candidates`, `Findings Index`.
 9. Add scope table and findings index table per report-formatting.md.
 10. Add the disclaimer.
 
@@ -436,6 +436,8 @@ Each finding must include:
 - `recommended_fix` (diff block for confidence >= 75)
 - `required_tests` (regression + guard tests)
 - `evidence_tags` (`[CODE-TRACE]` minimum; upgrade when stronger proof exists)
+- `tier` (`finding` by default, or `lead` when the attack path could not be closed)
+- `unverified` (required for leads: the exact link in the path you could not establish)
 
 Specialist final outputs must be structured JSON matching `references/structured-findings.md`; markdown finding blocks are invalid specialist output.
 

--- a/skills/cairo-auditor/references/audit-findings/cairo-security-gap-diff.md
+++ b/skills/cairo-auditor/references/audit-findings/cairo-security-gap-diff.md
@@ -19,7 +19,8 @@ This document is the required pre-deletion coverage check for replacing
 3. Verified source preservation file exists:
    `skills/cairo-auditor/references/audit-findings/source-cairo-security-import.md`.
 4. Verified core security signal packs remain intact:
-   - vulnerability database: 29 class files
+   - vulnerability database: 29 class files (count as of this migration check; see
+     `references/vulnerability-db/README.md` for the current total)
    - attack vectors: 170 vectors across 4 partitions
 
 ## Section Coverage Mapping

--- a/skills/cairo-auditor/references/finding.schema.json
+++ b/skills/cairo-auditor/references/finding.schema.json
@@ -32,6 +32,16 @@
           "root_cause": { "type": "string", "minLength": 1 },
           "file": { "type": "string", "minLength": 1 },
           "line": { "type": ["integer", "null"], "minimum": 1 },
+          "tier": {
+            "enum": ["finding", "lead"],
+            "default": "finding",
+            "description": "A lead is a high-signal trail the specialist could not prove end-to-end. Leads carry no fix and are reported separately from findings."
+          },
+          "unverified": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Required for leads: the specific link in the attack path that could not be established."
+          },
           "priority": { "enum": ["P0", "P1", "P2", "P3"] },
           "severity": { "enum": ["Critical", "High", "Medium", "Low"] },
           "confidence": { "type": "integer", "minimum": 0, "maximum": 100 },
@@ -51,13 +61,36 @@
             "contains": { "const": "[CODE-TRACE]" }
           }
         },
-        "if": {
-          "properties": { "confidence": { "minimum": 75 } },
-          "required": ["confidence"]
-        },
-        "then": {
-          "required": ["recommended_fix", "required_tests"]
-        }
+        "allOf": [
+          {
+            "if": {
+              "allOf": [
+                {
+                  "properties": { "confidence": { "minimum": 75 } },
+                  "required": ["confidence"]
+                },
+                {
+                  "not": {
+                    "properties": { "tier": { "const": "lead" } },
+                    "required": ["tier"]
+                  }
+                }
+              ]
+            },
+            "then": {
+              "required": ["recommended_fix", "required_tests"]
+            }
+          },
+          {
+            "if": {
+              "properties": { "tier": { "const": "lead" } },
+              "required": ["tier"]
+            },
+            "then": {
+              "required": ["unverified"]
+            }
+          }
+        ]
       }
     },
     "dropped_candidates": {

--- a/skills/cairo-auditor/references/finding.schema.json
+++ b/skills/cairo-auditor/references/finding.schema.json
@@ -87,7 +87,11 @@
               "required": ["tier"]
             },
             "then": {
-              "required": ["unverified"]
+              "required": ["unverified"],
+              "properties": {
+                "recommended_fix": { "type": "string", "maxLength": 0 },
+                "required_tests": { "type": "array", "maxItems": 0 }
+              }
             }
           }
         ]

--- a/skills/cairo-auditor/references/judging.md
+++ b/skills/cairo-auditor/references/judging.md
@@ -10,6 +10,19 @@ Drop the finding if any check fails.
 2. **Reachability**: threat actor in scope can call the path under actual access control (`assert_only_*`, role checks, caller checks, account validation paths). If only `owner/admin/governance` can call it, keep it in scope as governance/admin risk and score accordingly.
 3. **No existing guard** blocks the attack (`assert`, non-reentrant lock, OZ component guard, explicit invariant check).
 
+## Leads (Unproven Trails)
+
+A finding that fails only check 1 — you can see the suspicious shape but cannot close the
+attack path to impact — is a **lead**, not a dropped candidate. Emit it with `tier: "lead"`
+and state in `unverified` exactly which link you could not establish.
+
+Leads carry no fix and no confidence score, and are reported in their own section. They exist
+because "I found something structurally wrong here and could not prove exploitability" is the
+most useful thing to hand a human reviewer, and dropping it silently is the worst outcome.
+
+Do not use the lead tier to launder a finding that fails check 2 or check 3: if the path is
+unreachable, or an existing guard blocks it, it is a false positive and stays dropped.
+
 ## Confidence Score
 
 Start at `100`, apply deductions:

--- a/skills/cairo-auditor/references/judging.md
+++ b/skills/cairo-auditor/references/judging.md
@@ -16,7 +16,8 @@ A finding that fails only check 1 — you can see the suspicious shape but canno
 attack path to impact — is a **lead**, not a dropped candidate. Emit it with `tier: "lead"`
 and state in `unverified` exactly which link you could not establish.
 
-Leads carry no fix and no confidence score, and are reported in their own section. They exist
+Leads carry a confidence score, so reviewers can order them, but never a fix block -- there is
+no verified path to fix. They are reported in their own section. They exist
 because "I found something structurally wrong here and could not prove exploitability" is the
 most useful thing to hand a human reviewer, and dropping it silently is the worst outcome.
 

--- a/skills/cairo-auditor/references/report-formatting.md
+++ b/skills/cairo-auditor/references/report-formatting.md
@@ -27,7 +27,7 @@ capping. Use `scripts/quality/structured_report.py` when available.
 
 ## Signal Summary
 
-| Critical | High | Medium | Low | Total |
+| Critical | High | Medium | Low | Total | Leads |
 |----------|------|--------|-----|-------|
 | N        | N    | N      | N   | N     |
 
@@ -162,8 +162,8 @@ When degraded:
 ## Rules
 
 - Follow the template above exactly.
-- Default section order is `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Dropped Candidates`, then `Findings Index`.
-- In `Signal Summary`, `Total` must equal `Critical + High + Medium + Low`. If any input `Total` differs, recompute and overwrite it.
+- Default section order is `Signal Summary`, `Scope`, `Execution Trace`, `Findings`, `Leads`, `Dropped Candidates`, then `Findings Index`.
+- In `Signal Summary`, `Total` must equal `Critical + High + Medium + Low`. If any input `Total` differs, recompute and overwrite it. `Leads` counts `tier: "lead"` entries and is excluded from the severity columns and from `Total`.
 - `Execution Trace` must include scope discovery and Agents 1-4 for every run.
 - In deep mode, `Execution Trace` must include Agent 5 with actual model label and status.
 - In non-deep modes, keep Agent 5 row with `Status: SKIPPED`.
@@ -171,7 +171,7 @@ When degraded:
 - Keep the optional threat-intel row in the execution trace. Use `SKIPPED` when intel fetch is unavailable/offline.
 - For threat-intel stage, include explicit reason details (`SKIPPED: no curl`, `SKIPPED: offline`, or `FAILED: curl error <code>`).
 - If any specialist is unavailable and degraded mode is explicitly enabled, set `Execution Integrity: DEGRADED` and include the warning line under Scope.
-- If scope discovery or any required stage (Agents 1-4 and Agent 5 in deep mode) has `Status: FAILED` and degraded mode is not explicitly enabled, set `Execution Integrity: FAILED` and stop after `Execution Trace` (do not emit `Findings`, `Dropped Candidates`, or `Findings Index`).
+- If scope discovery or any required stage (Agents 1-4 and Agent 5 in deep mode) has `Status: FAILED` and degraded mode is not explicitly enabled, set `Execution Integrity: FAILED` and stop after `Execution Trace` (do not emit `Findings`, `Leads`, `Dropped Candidates`, or `Findings Index`).
 - If degraded execution is used, repeat the warning again immediately before `Findings Index`.
 - Every finding must include `Evidence` tags in the finding line and in `Findings Index`.
 - Allowed evidence tags: `[CODE-TRACE]`, `[PREFLIGHT-HIT]`, `[CROSS-AGENT]`, `[ADVERSARIAL]`.
@@ -188,6 +188,8 @@ When degraded:
 - The orchestrator adds `[CROSS-AGENT]` when 2+ agents independently reported the same root cause before deduplication.
 - The orchestrator adds `[ADVERSARIAL]` when Agent 5 discovered or confirmed the finding.
 - Evidence tags appear in the metadata line after severity and in the Findings Index `Evidence` column.
+- `Execution Trace` carries a `Merge completeness` row reporting how many files with candidates survived the merge; a file lost to `duplicate_root_cause` sets it to `FAILED`.
+- Emit `Leads` after `Findings`, with `No leads.` when there are none. A lead shows its class, location and unverified link, never a fix block, and its confidence score is used for ordering but not rendered.
 - Track dropped candidates in `Dropped Candidates` with one of: `false_positive`, `duplicate_root_cause`, `below_confidence_threshold`, `insufficient_evidence`.
 - If no candidates are dropped, still emit `Dropped Candidates` with a single `none` row.
 

--- a/skills/cairo-auditor/references/structured-findings.md
+++ b/skills/cairo-auditor/references/structured-findings.md
@@ -24,6 +24,8 @@ Each specialist final response must be a JSON object:
 | `root_cause` | yes | Stable dedupe key. Same root cause across agents should match. |
 | `file` | yes | Repo-relative Cairo path. |
 | `line` | no | Best-effort 1-based line. |
+| `tier` | no | `finding` (default) or `lead`. A lead is a high-signal trail you could not prove end-to-end. |
+| `unverified` | yes for leads | The specific link in the attack path you could not establish. |
 | `priority` | yes | `P0`, `P1`, `P2`, or `P3`. |
 | `severity` | yes | `Critical`, `High`, `Medium`, or `Low`. |
 | `confidence` | yes | Integer `0..100` after FP-gate deductions. |

--- a/skills/cairo-auditor/references/structured-findings.md
+++ b/skills/cairo-auditor/references/structured-findings.md
@@ -32,8 +32,8 @@ Each specialist final response must be a JSON object:
 | `description` | yes | Concrete exploit path and impact. |
 | `attack_path` | yes | Caller -> entrypoint -> state transition -> impact. |
 | `guard_analysis` | yes | Existing guards and why they do or do not block impact. |
-| `recommended_fix` | yes for confidence >= 75 | Diff text or exact remediation. |
-| `required_tests` | yes for confidence >= 75 | Regression and guard tests. |
+| `recommended_fix` | yes for confidence >= 75, and never on leads | Diff text or exact remediation. |
+| `required_tests` | yes for confidence >= 75, and never on leads | Regression and guard tests. |
 | `evidence_tags` | yes | Must include `[CODE-TRACE]`; Agent 5 also includes `[ADVERSARIAL]`. |
 
 `dropped_candidates` entries use:
@@ -48,8 +48,11 @@ Each specialist final response must be a JSON object:
 
 - Parse specialist JSON before rendering any Markdown.
 - Reject malformed specialist output and rerun that specialist once.
-- Deduplicate by `root_cause`, then keep higher confidence, then higher priority,
-  then more complete path evidence.
+- Deduplicate by `(file, root_cause)`. Never merge candidates across files: two
+  specialists can describe unrelated bugs in different files with the same
+  root-cause sentence, and collapsing those silently discards a real finding.
+- Within one key, a proven finding outranks a lead; then keep higher confidence,
+  then higher priority, then more complete path evidence.
 - Add `[CROSS-AGENT]` when the same root cause appears from two or more agents.
 - Add `[PREFLIGHT-HIT]` when deterministic preflight flagged the same class or
   entry point.

--- a/skills/cairo-auditor/references/vulnerability-db/CONTROLLED-LIBRARY-CALL.md
+++ b/skills/cairo-auditor/references/vulnerability-db/CONTROLLED-LIBRARY-CALL.md
@@ -1,0 +1,42 @@
+# CONTROLLED-LIBRARY-CALL
+
+## Class
+
+`library_call_syscall` invoked with a caller-controlled class hash.
+
+## Description
+
+`library_call_syscall` executes the target class's code in the calling contract's own context: its
+storage, its address, its permissions. It is the Starknet analogue of `delegatecall`. When the class
+hash reaches the syscall from calldata, an attacker declares a malicious class and has the victim
+contract execute it against its own storage — arbitrary write, owner takeover, and asset drain in a
+single call.
+
+## Detection Heuristic
+
+Flag when a class hash reaches `library_call_syscall` from an untrusted source:
+
+- the class hash is a function parameter on an externally reachable entrypoint, or
+- it is read from storage that an unprivileged path can write, or
+- it is taken from a registry whose entries are not access-controlled
+
+Trace the value backwards to its origin rather than matching on the syscall alone.
+
+## Secure Pattern
+
+- resolve class hashes from immutable or owner-only storage
+- validate against an explicit allowlist of declared class hashes before dispatch
+- prefer `call_contract_syscall` when the callee should execute in its own context
+- gate any setter for the class hash behind the same guard as an upgrade
+
+## False Positive Caveat
+
+Proxy and upgrade patterns legitimately call a class hash from storage. Those are only findings when
+the write path to that storage is unprivileged or missing a non-zero guard, which is a different
+class (see `UPGRADE-CLASS-HASH-WITHOUT-NONZERO-GUARD`). A hash hardcoded as a constant is safe.
+
+## Required Tests
+
+- unprivileged caller cannot supply a class hash that gets executed
+- allowlisted class hash dispatches correctly
+- setter for the class hash reverts for non-owner

--- a/skills/cairo-auditor/references/vulnerability-db/FELT252-UNSAFE-ARITHMETIC.md
+++ b/skills/cairo-auditor/references/vulnerability-db/FELT252-UNSAFE-ARITHMETIC.md
@@ -13,8 +13,11 @@ choice of type is the safety mechanism.
 Using `felt252` for balances, amounts, supplies, or indices means an attacker who controls an
 operand can wrap a subtraction past zero into a value near the prime, or wrap an addition back down
 to a small number. Comparisons compound the problem: `felt252` has no meaningful ordering, so code
-that needs `<` or `>` must convert first, and an unchecked `try_into().unwrap()` on the way turns a
-wrap into a panic or a truncation.
+that needs `<` or `>` must convert first. Note what that conversion does and does not do:
+`TryInto` is checked, so an out-of-range `felt252 -> u128` yields `None` and `.unwrap()` panics --
+it never truncates -- while `felt252 -> u256` is infallible through `Into`. The class here is the
+silent wrap on `felt252` arithmetic itself; the conversion failure mode is a panic/DoS, which
+`UNSAFE-TYPE-CONVERSION` already covers.
 
 ## Detection Heuristic
 

--- a/skills/cairo-auditor/references/vulnerability-db/FELT252-UNSAFE-ARITHMETIC.md
+++ b/skills/cairo-auditor/references/vulnerability-db/FELT252-UNSAFE-ARITHMETIC.md
@@ -1,0 +1,45 @@
+# FELT252-UNSAFE-ARITHMETIC
+
+## Class
+
+Value-bearing arithmetic performed on `felt252` instead of a bounded integer type.
+
+## Description
+
+`felt252` is a field element: arithmetic is modulo the STARK prime and wraps silently. It has no
+overflow or underflow trap. Bounded integer types (`u8` through `u256`) panic on overflow, so the
+choice of type is the safety mechanism.
+
+Using `felt252` for balances, amounts, supplies, or indices means an attacker who controls an
+operand can wrap a subtraction past zero into a value near the prime, or wrap an addition back down
+to a small number. Comparisons compound the problem: `felt252` has no meaningful ordering, so code
+that needs `<` or `>` must convert first, and an unchecked `try_into().unwrap()` on the way turns a
+wrap into a panic or a truncation.
+
+## Detection Heuristic
+
+Flag arithmetic on a `felt252` when all of these hold:
+
+- an operand is caller-controlled or derived from caller-controlled input
+- the result is stored, transferred, or compared as a quantity
+- there is no preceding bound check or conversion to a bounded integer type
+
+Pay particular attention to subtraction, and to `felt252` used as a loop bound or array index.
+
+## Secure Pattern
+
+- use `u256` / `u128` for balances and amounts and let the overflow trap fire
+- convert at the boundary with a checked path, not `unwrap()` on untrusted input
+- keep `felt252` for identifiers, selectors, hashes, and addresses, not quantities
+
+## False Positive Caveat
+
+`felt252` is the correct type for non-arithmetic values: addresses, selectors, class hashes, Poseidon
+inputs, and short strings. Arithmetic on constants or on values proven bounded upstream is safe. Do
+not report a `felt252` that is only ever hashed, compared for equality, or emitted.
+
+## Required Tests
+
+- underflow attempt on the quantity path reverts instead of wrapping
+- boundary value at the type maximum behaves as specified
+- conversion from untrusted input rejects out-of-range values

--- a/skills/cairo-auditor/references/vulnerability-db/L1-HANDLER-UNCHECKED-FROM.md
+++ b/skills/cairo-auditor/references/vulnerability-db/L1-HANDLER-UNCHECKED-FROM.md
@@ -1,0 +1,46 @@
+# L1-HANDLER-UNCHECKED-FROM
+
+## Class
+
+`#[l1_handler]` entrypoint that does not authenticate `from_address`.
+
+## Description
+
+The sequencer injects `from_address` into every `#[l1_handler]` as the L1 sender of the message.
+It is the only authentication an L1->L2 handler has. A handler that does not constrain it can be
+driven by any L1 address that can pay to send a message to the Starknet core contract, so mint,
+release, and state-transition handlers become permissionless.
+
+This is the canonical bridge failure: the L2 side trusts that only its paired L1 escrow can call
+`handle_deposit`, but never checks.
+
+## Detection Heuristic
+
+Flag any `#[l1_handler]` function where all of these hold:
+
+- the body has no comparison of the `from_address` parameter against a stored or constant L1 address
+- the handler writes storage, mints, transfers, or changes access-control state
+- `from_address` is unused, or used only as event data
+
+Also flag handlers that compare against a stored address that has no initialiser guard, or that can
+be reset by an unprivileged path.
+
+## Secure Pattern
+
+- store the paired L1 contract at construction and assert on every handler:
+  `assert(from_address == self.l1_bridge.read(), 'INVALID_L1_SENDER');`
+- treat the stored L1 address as privileged configuration with the same guards as an owner change
+- never derive trust from calldata contents alone
+
+## False Positive Caveat
+
+A handler that is genuinely permissionless by design — for example one that only emits an event or
+increments a public counter with no privileged effect — is not vulnerable. Require a concrete
+privileged effect before reporting. Some designs also authenticate one level deeper, dispatching to
+an internal function that performs the check; follow the call before flagging.
+
+## Required Tests
+
+- handler called with an unexpected `from_address` reverts
+- handler called with the configured L1 address succeeds
+- the stored L1 address cannot be changed by a non-owner

--- a/skills/cairo-auditor/references/vulnerability-db/READ-ONLY-REENTRANCY.md
+++ b/skills/cairo-auditor/references/vulnerability-db/READ-ONLY-REENTRANCY.md
@@ -1,0 +1,45 @@
+# READ-ONLY-REENTRANCY
+
+## Class
+
+View function exposes storage that a state-changing path writes only after an external call.
+
+## Description
+
+A function makes an external call while its storage is mid-update, and a view function reads that
+same storage. A reentrancy guard on the mutating entrypoint does not help: the attacker does not
+re-enter the guarded function, they call the unguarded view from inside the callback and read a
+state the contract never intended to publish.
+
+The damage lands on integrators. A lending market pricing collateral from the victim's
+`get_total_assets()` during the callback window sees a stale total and mints against it.
+
+## Detection Heuristic
+
+Flag when all of these hold:
+
+- a state-changing function performs an external call (`call_contract_syscall`, ERC-20 transfer,
+  callback hook) before writing a storage variable
+- a view entrypoint reads that same storage variable
+- the value participates in pricing, share accounting, collateral, or supply
+
+A reentrancy guard on the mutating function does not clear the finding; check whether the view is
+guarded or whether the write precedes the call.
+
+## Secure Pattern
+
+- apply checks-effects-interactions: commit all storage writes before the external call
+- where the ordering cannot change, have the view revert or return a staleness flag while a
+  transition is in flight
+- extend the reentrancy guard to the read path when the value is externally consumed
+
+## False Positive Caveat
+
+Not a finding when the view is consumed only internally, when the value cannot influence economic
+decisions, or when the external call is to a trusted immutable contract that cannot re-enter. A
+benign write after a call with no corresponding view reader is `CEI-VIOLATION` at most, not this.
+
+## Required Tests
+
+- a malicious callee querying the view mid-callback observes consistent state
+- the reentrancy regression test asserts on the view's return value, not just on revert

--- a/skills/cairo-auditor/references/vulnerability-db/READ-ONLY-REENTRANCY.md
+++ b/skills/cairo-auditor/references/vulnerability-db/READ-ONLY-REENTRANCY.md
@@ -37,7 +37,7 @@ guarded or whether the write precedes the call.
 
 Not a finding when the view is consumed only internally, when the value cannot influence economic
 decisions, or when the external call is to a trusted immutable contract that cannot re-enter. A
-benign write after a call with no corresponding view reader is `CEI-VIOLATION` at most, not this.
+benign write after a call with no corresponding view reader is `CEI-VIOLATION-ERC1155` at most, not this.
 
 ## Required Tests
 

--- a/skills/cairo-auditor/references/vulnerability-db/README.md
+++ b/skills/cairo-auditor/references/vulnerability-db/README.md
@@ -14,7 +14,7 @@ One file per class with:
 
 Current classes:
 
-This table currently lists **28 vulnerability classes**.
+This table currently lists **34 vulnerability classes**.
 
 | Doc Slug | Detector Class ID |
 | --- | --- |
@@ -46,3 +46,9 @@ This table currently lists **28 vulnerability classes**.
 | `UNSAFE-TYPE-CONVERSION` | `UNSAFE_TYPE_CONVERSION` |
 | `INCORRECT-LIST-REMOVAL` | `INCORRECT_LIST_REMOVAL` |
 | `STALE-SNAPSHOT-READ` | `STALE_SNAPSHOT_READ` |
+| `L1-HANDLER-UNCHECKED-FROM` | `L1_HANDLER_UNCHECKED_FROM` |
+| `CONTROLLED-LIBRARY-CALL` | `CONTROLLED_LIBRARY_CALL` |
+| `FELT252-UNSAFE-ARITHMETIC` | `FELT252_UNSAFE_ARITHMETIC` |
+| `READ-ONLY-REENTRANCY` | `READ_ONLY_REENTRANCY` |
+| `UNENFORCED-VIEW` | `UNENFORCED_VIEW` |
+| `USE-AFTER-POP-FRONT` | `USE_AFTER_POP_FRONT` |

--- a/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
+++ b/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
@@ -10,24 +10,34 @@ Callers and off-chain integrators treat ABI state mutability as a contract. A `v
 assumed free of side effects: indexers call it speculatively, wallets simulate it, and other
 contracts read from it without accounting for state change.
 
-**Scope this narrowly on Cairo 2.** A function taking `self: @ContractState` cannot write its own
-storage — the type system already forbids it — so "a view that writes locally" is not the reachable
-case and flagging it produces false positives. The reachable case is a `view` that **calls out**:
-a `call_contract_syscall` or `library_call_syscall` from a read path can mutate state in the callee,
-or re-enter and mutate here, while the ABI still advertises the entrypoint as side-effect free. A
-mismatch between a hand-written interface trait and the implementation is the other real case,
-because the declared mutability in the ABI is what integrators consume.
+**Scope this precisely on Cairo 2.** `@ContractState` blocks the *high-level* storage API only: the
+compiler rejects `self.var.write()` in a view, so flagging that is a false positive — it does not
+compile. It does **not** make a view side-effect free. Three paths remain open:
+
+- **`storage_write_syscall`.** The low-level syscall operates outside the `ContractState` abstraction
+  and is not blocked by the snapshot, so a `view` can write its own storage through it and compile.
+- **Calling out.** A `call_contract_syscall` or `library_call_syscall` on a read path can mutate the
+  callee, or re-enter and mutate here.
+- **Trait/ABI mismatch.** The declared mutability in the generated ABI is what integrators consume;
+  a hand-written interface trait that says `view` over a `ref self` implementation misreports it.
+
+Worth stating plainly because it drives severity: **view-ness is not enforced by the Starknet
+protocol.** Entrypoints are only side-effect free by convention, and a view executed as part of an
+invoke transaction can change state. An integrator that assumes otherwise is relying on a guarantee
+that was never made.
 
 ## Detection Heuristic
 
 Flag an entrypoint whose declared state mutability is `view` when the body:
 
+- calls `storage_write_syscall` (or any raw storage-write syscall) on the read path, or
 - issues a `call_contract_syscall` or `library_call_syscall` on the read path that can reach a write
   or re-enter this contract, or
 - emits an event as a side effect of the read path, or
 - takes `ref self: ContractState` while the interface trait or ABI still declares it `view`
 
-Do not flag a function taking `self: @ContractState` for writing local storage; that cannot compile.
+Do not flag `self.var.write()` under `self: @ContractState`; the compiler already rejects it, so it
+cannot appear in a building contract. The raw syscall is the reachable form of the same defect.
 Resolve the declared mutability from the interface trait and the generated ABI, not from the
 function name.
 
@@ -45,9 +55,10 @@ function name.
 A view that calls another contract's view is fine, and is the common shape — do not flag a syscall
 merely for existing on a read path; the callee must be able to write or re-enter. Lazy-cache patterns
 that update on read are a genuine finding only when the update is reachable by an untrusted caller or
-has an economic effect; otherwise report as a low-severity note. Because `@ContractState` already
-rules out the local-write case, treat a bare "view writes storage" claim as a false positive unless a
-call-out or a trait/ABI mismatch is named.
+has an economic effect; otherwise report as a low-severity note. Treat a bare "view writes storage"
+claim as a false positive unless the finding names the mechanism: a raw storage-write syscall, a
+call-out that reaches a write, or a trait/ABI mismatch. "It uses `self.var.write()`" is not a
+finding — that code does not compile.
 
 ## Required Tests
 

--- a/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
+++ b/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
@@ -1,0 +1,41 @@
+# UNENFORCED-VIEW
+
+## Class
+
+Entrypoint published as `view` in the ABI whose implementation can mutate state.
+
+## Description
+
+Callers and off-chain integrators treat ABI state mutability as a contract. A `view` entrypoint is
+assumed free of side effects: indexers call it speculatively, wallets simulate it, and other
+contracts read from it without accounting for state change. When the implementation mutates — either
+directly or through a syscall to a contract that calls back — that assumption breaks silently, and
+the mutation happens in contexts no one reviewed.
+
+## Detection Heuristic
+
+Flag an entrypoint whose declared state mutability is `view` when the body:
+
+- writes storage, or
+- issues a `call_contract_syscall` or `library_call_syscall` that can reach a write, or
+- emits an event as a side effect of the read path
+
+Resolve the declared mutability from the interface trait and the generated ABI, not from the
+function name.
+
+## Secure Pattern
+
+- take `self: @ContractState` for genuinely read-only functions and let the type system enforce it
+- expose any mutating behaviour as an external function with explicit access control
+- split read and write halves rather than making a read opportunistically update a cache
+
+## False Positive Caveat
+
+A view that calls another contract's view is fine. Lazy-cache patterns that update on read are a
+genuine finding only when the update is reachable by an untrusted caller or has an economic effect;
+otherwise report as a low-severity note.
+
+## Required Tests
+
+- calling the view does not change any observable storage
+- static-call simulation of the view succeeds

--- a/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
+++ b/skills/cairo-auditor/references/vulnerability-db/UNENFORCED-VIEW.md
@@ -8,17 +8,28 @@ Entrypoint published as `view` in the ABI whose implementation can mutate state.
 
 Callers and off-chain integrators treat ABI state mutability as a contract. A `view` entrypoint is
 assumed free of side effects: indexers call it speculatively, wallets simulate it, and other
-contracts read from it without accounting for state change. When the implementation mutates — either
-directly or through a syscall to a contract that calls back — that assumption breaks silently, and
-the mutation happens in contexts no one reviewed.
+contracts read from it without accounting for state change.
+
+**Scope this narrowly on Cairo 2.** A function taking `self: @ContractState` cannot write its own
+storage — the type system already forbids it — so "a view that writes locally" is not the reachable
+case and flagging it produces false positives. The reachable case is a `view` that **calls out**:
+a `call_contract_syscall` or `library_call_syscall` from a read path can mutate state in the callee,
+or re-enter and mutate here, while the ABI still advertises the entrypoint as side-effect free. A
+mismatch between a hand-written interface trait and the implementation is the other real case,
+because the declared mutability in the ABI is what integrators consume.
 
 ## Detection Heuristic
 
 Flag an entrypoint whose declared state mutability is `view` when the body:
 
-- writes storage, or
-- issues a `call_contract_syscall` or `library_call_syscall` that can reach a write, or
-- emits an event as a side effect of the read path
+- issues a `call_contract_syscall` or `library_call_syscall` on the read path that can reach a write
+  or re-enter this contract, or
+- emits an event as a side effect of the read path, or
+- takes `ref self: ContractState` while the interface trait or ABI still declares it `view`
+
+Do not flag a function taking `self: @ContractState` for writing local storage; that cannot compile.
+Resolve the declared mutability from the interface trait and the generated ABI, not from the
+function name.
 
 Resolve the declared mutability from the interface trait and the generated ABI, not from the
 function name.
@@ -31,9 +42,12 @@ function name.
 
 ## False Positive Caveat
 
-A view that calls another contract's view is fine. Lazy-cache patterns that update on read are a
-genuine finding only when the update is reachable by an untrusted caller or has an economic effect;
-otherwise report as a low-severity note.
+A view that calls another contract's view is fine, and is the common shape — do not flag a syscall
+merely for existing on a read path; the callee must be able to write or re-enter. Lazy-cache patterns
+that update on read are a genuine finding only when the update is reachable by an untrusted caller or
+has an economic effect; otherwise report as a low-severity note. Because `@ContractState` already
+rules out the local-write case, treat a bare "view writes storage" claim as a false positive unless a
+call-out or a trait/ABI mismatch is named.
 
 ## Required Tests
 

--- a/skills/cairo-auditor/references/vulnerability-db/USE-AFTER-POP-FRONT.md
+++ b/skills/cairo-auditor/references/vulnerability-db/USE-AFTER-POP-FRONT.md
@@ -1,0 +1,45 @@
+# USE-AFTER-POP-FRONT
+
+## Class
+
+`Array` or `Span` accessed using a length or index captured before `pop_front`.
+
+## Description
+
+`pop_front` advances a `Span` and shortens it. Code that captures `len()` or builds an index before
+popping, then indexes with that stale value afterwards, reads the wrong element or panics out of
+bounds. The same shape appears when a loop pops from one span while indexing a parallel span with a
+counter that no longer lines up.
+
+The consequence is either a panic — a denial of service on the entrypoint — or, when the mismatched
+index still lands in range, a silent misattribution: the amount from entry `i` applied to the
+recipient at entry `i+1`.
+
+## Detection Heuristic
+
+Flag when all of these hold:
+
+- `len()` is bound to a variable, or an index counter is initialised, before a `pop_front` on the
+  same span
+- that variable is used to index or bound a loop after the pop
+- the span is caller-supplied or its length is caller-influenced
+
+Also flag parallel iteration where one collection is popped and another is indexed by counter.
+
+## Secure Pattern
+
+- iterate with `while let Option::Some(item) = span.pop_front()` and let the span own its cursor
+- re-read `len()` after mutation rather than caching it
+- when iterating parallel collections, assert equal lengths up front and index both, or zip them
+
+## False Positive Caveat
+
+Capturing `len()` before a loop that does not pop is correct and common. Popping from a span whose
+length is a compile-time constant, or where the cached length is only used for an equality assertion
+before iteration begins, is safe.
+
+## Required Tests
+
+- empty span input does not panic
+- length-mismatched parallel inputs revert rather than misattributing
+- single-element and maximum-length spans iterate completely

--- a/skills/cairo-auditor/scripts/quality/deep_integrity.py
+++ b/skills/cairo-auditor/scripts/quality/deep_integrity.py
@@ -68,7 +68,54 @@ def _type_ok(value: Any, type_spec: Any) -> bool:
     return True
 
 
+# Keywords this validator actually evaluates, and metadata it may safely ignore.
+# Anything outside both sets is reported rather than skipped: a schema keyword the
+# validator does not understand is a silent hole in the gate, not a no-op. Moving
+# the finding schema's conditionals under `allOf` previously disabled both of them
+# here while a spec-compliant validator still enforced them.
+_VALIDATED_KEYWORDS = frozenset(
+    {
+        "type", "enum", "const", "minLength", "minimum", "maximum", "required",
+        "properties", "if", "then", "else", "items", "contains",
+        "allOf", "anyOf", "oneOf", "not",
+    }
+)
+_IGNORED_KEYWORDS = frozenset(
+    {"$schema", "$comment", "_comment", "title", "description", "default", "examples", "additionalProperties"}
+)
+
+
+def _unsupported_keywords(schema: dict) -> list[str]:
+    return sorted(set(schema) - _VALIDATED_KEYWORDS - _IGNORED_KEYWORDS)
+
+
+def _matches(value: Any, schema: dict) -> bool:
+    trial: list[str] = []
+    _validate(value, schema, "", trial)
+    return not trial
+
+
 def _validate(value: Any, schema: dict, path: str, errors: list[str]) -> None:
+    unsupported = _unsupported_keywords(schema)
+    if unsupported:
+        errors.append(
+            f"{path}: schema uses keyword(s) {unsupported} this validator does not evaluate; "
+            f"refusing to pass silently"
+        )
+    for sub in schema.get("allOf", []):
+        if isinstance(sub, dict):
+            _validate(value, sub, path, errors)
+    if isinstance(schema.get("anyOf"), list):
+        branches = [s for s in schema["anyOf"] if isinstance(s, dict)]
+        if branches and not any(_matches(value, s) for s in branches):
+            errors.append(f"{path}: value matches none of the anyOf branches")
+    if isinstance(schema.get("oneOf"), list):
+        branches = [s for s in schema["oneOf"] if isinstance(s, dict)]
+        matched = sum(1 for s in branches if _matches(value, s))
+        if branches and matched != 1:
+            errors.append(f"{path}: value matches {matched} oneOf branches, expected exactly 1")
+    if isinstance(schema.get("not"), dict) and _matches(value, schema["not"]):
+        errors.append(f"{path}: value must not match the 'not' schema")
     if "type" in schema and not _type_ok(value, schema["type"]):
         errors.append(f"{path}: expected type {schema['type']}, got {type(value).__name__}")
         return

--- a/skills/cairo-auditor/scripts/quality/deep_integrity.py
+++ b/skills/cairo-auditor/scripts/quality/deep_integrity.py
@@ -75,7 +75,8 @@ def _type_ok(value: Any, type_spec: Any) -> bool:
 # here while a spec-compliant validator still enforced them.
 _VALIDATED_KEYWORDS = frozenset(
     {
-        "type", "enum", "const", "minLength", "minimum", "maximum", "required",
+        "type", "enum", "const", "minLength", "maxLength", "minimum", "maximum", "required",
+        "maxItems",
         "properties", "if", "then", "else", "items", "contains",
         "allOf", "anyOf", "oneOf", "not",
     }
@@ -125,6 +126,10 @@ def _validate(value: Any, schema: dict, path: str, errors: list[str]) -> None:
         errors.append(f"{path}: value {value!r} != const {schema['const']!r}")
     if isinstance(value, str) and "minLength" in schema and len(value) < schema["minLength"]:
         errors.append(f"{path}: string shorter than minLength {schema['minLength']}")
+    if isinstance(value, str) and "maxLength" in schema and len(value) > schema["maxLength"]:
+        errors.append(f"{path}: string longer than maxLength {schema['maxLength']}")
+    if isinstance(value, list) and "maxItems" in schema and len(value) > schema["maxItems"]:
+        errors.append(f"{path}: array longer than maxItems {schema['maxItems']}")
     if isinstance(value, int) and not isinstance(value, bool):
         if "minimum" in schema and value < schema["minimum"]:
             errors.append(f"{path}: {value} < minimum {schema['minimum']}")

--- a/skills/cairo-auditor/scripts/quality/structured_report.py
+++ b/skills/cairo-auditor/scripts/quality/structured_report.py
@@ -149,8 +149,10 @@ def _normalize_finding(row: dict[str, Any], source: Path) -> dict[str, Any]:
     if tier not in {"finding", "lead"}:
         tier = "finding"
     unverified = str(row.get("unverified", "")).strip()
-    if tier == "lead" and not unverified:
-        unverified = "Specialist did not record which link in the attack path is unproven."
+    # A lead whose unproven link is unrecorded is not a usable lead. Inventing a
+    # placeholder would launder the schema requirement whenever the integrity gate
+    # is skipped, so the row is marked and dropped as insufficient evidence instead.
+    unusable_lead = tier == "lead" and not unverified
 
     confidence = max(0, min(100, _safe_int(row.get("confidence"), 75)))
     priority = str(row.get("priority", "P3")).strip().upper()
@@ -173,8 +175,16 @@ def _normalize_finding(row: dict[str, Any], source: Path) -> dict[str, Any]:
         "description": str(row.get("description", "")).strip(),
         "attack_path": str(row.get("attack_path", "")).strip(),
         "guard_analysis": str(row.get("guard_analysis", "")).strip(),
-        "recommended_fix": str(row.get("recommended_fix", "")).strip(),
-        "required_tests": [str(item) for item in _as_list(row.get("required_tests")) if str(item)],
+        # Leads carry no remediation in any representation. Hiding the Fix block in
+        # markdown while leaving the fields populated in JSON lets a consumer of
+        # payload["leads"] treat an unproven trail as a verified patch.
+        "recommended_fix": "" if tier == "lead" else str(row.get("recommended_fix", "")).strip(),
+        "required_tests": (
+            []
+            if tier == "lead"
+            else [str(item) for item in _as_list(row.get("required_tests")) if str(item)]
+        ),
+        "_unusable_lead": unusable_lead,
         "evidence_tags": evidence,
         "root_cause": str(row.get("root_cause", "")).strip(),
         "agent_id": agent_id,
@@ -581,7 +591,8 @@ def _render_report(
     if leads:
         lines += [
             "Unproven trails. A specialist saw something structurally suspicious here but could not close the",
-            "attack path. These carry no confidence score and no fix — they are review targets, not findings.",
+            "attack path. Each carries a confidence score used only for ordering, omitted here, and never a",
+            "fix — these are review targets, not findings.",
             "",
         ]
         for idx, lead in enumerate(leads, 1):
@@ -665,6 +676,18 @@ def main() -> int:
         raw_dropped.extend(drops)
 
     preflight = _load_preflight(preflight_path)
+    # A lead with no recorded unproven link is dropped rather than given a placeholder.
+    unusable = [row for row in raw_findings if row.pop("_unusable_lead", False)]
+    raw_findings = [row for row in raw_findings if row not in unusable]
+    raw_dropped += [
+        {
+            "candidate": str(row.get("title", "lead")),
+            "class": str(row.get("class_id", "UNKNOWN")),
+            "drop_reason": "insufficient_evidence",
+            "file": str(row.get("file", "")),
+        }
+        for row in unusable
+    ]
     merged, dropped = _dedupe_and_tag(raw_findings, preflight, proven_only=args.proven_only)
     dropped = raw_dropped + dropped
     completeness = _completeness(raw_findings, merged, dropped)

--- a/skills/cairo-auditor/scripts/quality/structured_report.py
+++ b/skills/cairo-auditor/scripts/quality/structured_report.py
@@ -186,7 +186,10 @@ def _root_key(finding: dict[str, Any]) -> str:
     # File scope is always part of the key. Two specialists can describe unrelated
     # bugs in different files with the same root-cause sentence; merging those
     # silently discards a real finding, so cross-file merges are never allowed.
-    file_scope = str(finding.get("file", "")).lower()
+    # The path keeps its case: `src/Foo.cairo` and `src/foo.cairo` are different
+    # files on a case-sensitive filesystem, and folding them would reintroduce
+    # exactly the cross-file merge this key exists to prevent.
+    file_scope = str(finding.get("file", ""))
     explicit = str(finding.get("root_cause", "")).strip()
     if explicit:
         return f"{file_scope}|{explicit.lower()}"
@@ -299,16 +302,27 @@ def _completeness(
     merged: list[dict[str, Any]],
     dropped: list[dict[str, str]],
 ) -> tuple[int, int, list[str]]:
-    """Every file that produced a candidate must survive into the report.
+    """Every file that produced a candidate must SURVIVE into the merged output.
 
-    Dedupe collapsing a file out of the output entirely is a merge bug, not a
-    result. Returns (covered, total, missing_files) so the report can show it.
+    Only the merged set counts as coverage. Counting dropped candidates would
+    defeat the metric: a file whose sole finding was wrongly collapsed into
+    another file's would appear as covered precisely when the merge bug this
+    exists to surface had occurred.
+
+    `dropped` is still consulted, but only to classify a missing file -- a file
+    lost to `duplicate_root_cause` is a merge suspect, while one dropped as a
+    false positive is an expected outcome.
     """
     produced = {str(row.get("file", "")) for row in raw_findings if str(row.get("file", ""))}
     covered = {str(row.get("file", "")) for row in merged if str(row.get("file", ""))}
-    covered |= {str(row.get("file", "")) for row in dropped if str(row.get("file", ""))}
     missing = sorted(produced - covered)
-    return len(produced & covered), len(produced), missing
+    dup_only = {
+        str(row.get("file", ""))
+        for row in dropped
+        if str(row.get("file", "")) and row.get("drop_reason") == "duplicate_root_cause"
+    }
+    suspects = sorted(f for f in missing if f in dup_only)
+    return len(produced & covered), len(produced), suspects
 
 
 _SCOPE_FILE_BYTES_CAP = 10 * 1024 * 1024  # 10 MiB per file is more than any realistic Cairo source.
@@ -515,13 +529,16 @@ def _render_report(
         agent5_status = "MISSING"
         agent5_evidence = f"`{agent5_findings_path}` (not produced)"
     agent5_model = _agent_model(agent_models, 5, fallback_keys=("adversarial", "default"))
-    covered_files, produced_files, missing_files = completeness
-    if missing_files:
+    covered_files, produced_files, suspect_files = completeness
+    if suspect_files:
         completeness_status = "FAILED"
-        completeness_evidence = f"dropped without trace: {', '.join(f'`{_md_cell(p)}`' for p in missing_files[:5])}"
+        completeness_evidence = (
+            "lost to duplicate_root_cause: "
+            + ", ".join(f"`{_md_cell(p)}`" for p in suspect_files[:5])
+        )
     else:
         completeness_status = "OK"
-        completeness_evidence = "every file with a candidate is represented"
+        completeness_evidence = "no file lost to a cross-file merge"
     lines += [
         f"| Agent 5 adversarial (deep only) | {_md_cell(agent5_model)} | {agent5_evidence} | {agent5_status} |",
         f"| Merge completeness | n/a | {covered_files}/{produced_files} files · {completeness_evidence} | {completeness_status} |",
@@ -655,7 +672,7 @@ def main() -> int:
     scope_paths, total_lines = _read_scope(scope_file, repo_root, merged)
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
 
-    covered_files, produced_files, missing_files = completeness
+    covered_files, produced_files, suspect_files = completeness
     payload = {
         "generated_at": generated_at,
         "repo_root": repo_root.as_posix(),
@@ -667,7 +684,7 @@ def main() -> int:
         "merge_completeness": {
             "files_with_candidates": produced_files,
             "files_covered": covered_files,
-            "missing_files": missing_files,
+            "merge_suspect_files": suspect_files,
         },
     }
     out_json = Path(args.output_json).resolve()

--- a/skills/cairo-auditor/scripts/quality/structured_report.py
+++ b/skills/cairo-auditor/scripts/quality/structured_report.py
@@ -145,6 +145,13 @@ def _normalize_finding(row: dict[str, Any], source: Path) -> dict[str, Any]:
     if agent_id == "5" and "[ADVERSARIAL]" not in evidence:
         evidence.append("[ADVERSARIAL]")
 
+    tier = str(row.get("tier", "finding")).strip().lower()
+    if tier not in {"finding", "lead"}:
+        tier = "finding"
+    unverified = str(row.get("unverified", "")).strip()
+    if tier == "lead" and not unverified:
+        unverified = "Specialist did not record which link in the attack path is unproven."
+
     confidence = max(0, min(100, _safe_int(row.get("confidence"), 75)))
     priority = str(row.get("priority", "P3")).strip().upper()
     if priority not in PRIORITY_RANK:
@@ -158,6 +165,8 @@ def _normalize_finding(row: dict[str, Any], source: Path) -> dict[str, Any]:
         "class_id": class_id or "UNKNOWN",
         "file": file_path or "unknown",
         "line": row.get("line"),
+        "tier": tier,
+        "unverified": unverified,
         "priority": priority,
         "severity": severity,
         "confidence": confidence,
@@ -174,31 +183,36 @@ def _normalize_finding(row: dict[str, Any], source: Path) -> dict[str, Any]:
 
 
 def _root_key(finding: dict[str, Any]) -> str:
+    # File scope is always part of the key. Two specialists can describe unrelated
+    # bugs in different files with the same root-cause sentence; merging those
+    # silently discards a real finding, so cross-file merges are never allowed.
+    file_scope = str(finding.get("file", "")).lower()
     explicit = str(finding.get("root_cause", "")).strip()
     if explicit:
-        return explicit.lower()
+        return f"{file_scope}|{explicit.lower()}"
     return "|".join(
         [
+            file_scope,
             str(finding.get("class_id", "")).lower(),
-            str(finding.get("file", "")).lower(),
             str(finding.get("line", "")),
             str(finding.get("title", "")).lower(),
         ]
     )
 
 
+def _rank(finding: dict[str, Any]) -> tuple[int, int, int, int]:
+    # A proven finding always outranks a lead for the same root cause: if one
+    # specialist closed the path, the unproven version is the duplicate.
+    return (
+        0 if str(finding.get("tier", "finding")) == "lead" else 1,
+        _safe_int(finding.get("confidence")),
+        -PRIORITY_RANK.get(str(finding.get("priority", "P3")), 3),
+        len(str(finding.get("attack_path", ""))),
+    )
+
+
 def _better(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
-    a_key = (
-        _safe_int(a.get("confidence")),
-        -PRIORITY_RANK.get(str(a.get("priority", "P3")), 3),
-        len(str(a.get("attack_path", ""))),
-    )
-    b_key = (
-        _safe_int(b.get("confidence")),
-        -PRIORITY_RANK.get(str(b.get("priority", "P3")), 3),
-        len(str(b.get("attack_path", ""))),
-    )
-    return a if a_key >= b_key else b
+    return a if _rank(a) >= _rank(b) else b
 
 
 def _load_preflight(path: Path | None) -> list[dict[str, Any]]:
@@ -258,6 +272,7 @@ def _dedupe_and_tag(
                     "candidate": str(loser.get("title", "duplicate")),
                     "class": str(loser.get("class_id", "UNKNOWN")),
                     "drop_reason": "duplicate_root_cause",
+                    "file": str(loser.get("file", "")),
                 }
             )
 
@@ -269,6 +284,31 @@ def _dedupe_and_tag(
         )
     )
     return merged, dropped
+
+
+def _partition_tiers(
+    merged: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    findings = [row for row in merged if str(row.get("tier", "finding")) != "lead"]
+    leads = [row for row in merged if str(row.get("tier", "finding")) == "lead"]
+    return findings, leads
+
+
+def _completeness(
+    raw_findings: list[dict[str, Any]],
+    merged: list[dict[str, Any]],
+    dropped: list[dict[str, str]],
+) -> tuple[int, int, list[str]]:
+    """Every file that produced a candidate must survive into the report.
+
+    Dedupe collapsing a file out of the output entirely is a merge bug, not a
+    result. Returns (covered, total, missing_files) so the report can show it.
+    """
+    produced = {str(row.get("file", "")) for row in raw_findings if str(row.get("file", ""))}
+    covered = {str(row.get("file", "")) for row in merged if str(row.get("file", ""))}
+    covered |= {str(row.get("file", "")) for row in dropped if str(row.get("file", ""))}
+    missing = sorted(produced - covered)
+    return len(produced & covered), len(produced), missing
 
 
 _SCOPE_FILE_BYTES_CAP = 10 * 1024 * 1024  # 10 MiB per file is more than any realistic Cairo source.
@@ -387,6 +427,7 @@ def _render_report(
     mode: str,
     workdir: Path,
     findings: list[dict[str, Any]],
+    leads: list[dict[str, Any]],
     dropped: list[dict[str, str]],
     scope_paths: list[str],
     total_lines: int,
@@ -395,6 +436,7 @@ def _render_report(
     generated_at: str,
     integrity: str,
     threat_intel_status: str,
+    completeness: tuple[int, int, list[str]],
 ) -> str:
     counts = Counter(str(row.get("severity", "Low")) for row in findings)
     total = sum(counts.values())
@@ -407,9 +449,9 @@ def _render_report(
         "",
         "## Signal Summary",
         "",
-        "| Critical | High | Medium | Low | Total |",
-        "|----------|------|--------|-----|-------|",
-        f"| {counts.get('Critical', 0)} | {counts.get('High', 0)} | {counts.get('Medium', 0)} | {counts.get('Low', 0)} | {total} |",
+        "| Critical | High | Medium | Low | Total | Leads |",
+        "|----------|------|--------|-----|-------|-------|",
+        f"| {counts.get('Critical', 0)} | {counts.get('High', 0)} | {counts.get('Medium', 0)} | {counts.get('Low', 0)} | {total} | {len(leads)} |",
         "",
         "---",
         "",
@@ -473,8 +515,16 @@ def _render_report(
         agent5_status = "MISSING"
         agent5_evidence = f"`{agent5_findings_path}` (not produced)"
     agent5_model = _agent_model(agent_models, 5, fallback_keys=("adversarial", "default"))
+    covered_files, produced_files, missing_files = completeness
+    if missing_files:
+        completeness_status = "FAILED"
+        completeness_evidence = f"dropped without trace: {', '.join(f'`{_md_cell(p)}`' for p in missing_files[:5])}"
+    else:
+        completeness_status = "OK"
+        completeness_evidence = "every file with a candidate is represented"
     lines += [
         f"| Agent 5 adversarial (deep only) | {_md_cell(agent5_model)} | {agent5_evidence} | {agent5_status} |",
+        f"| Merge completeness | n/a | {covered_files}/{produced_files} files · {completeness_evidence} | {completeness_status} |",
         "",
         "---",
         "",
@@ -509,6 +559,31 @@ def _render_report(
                     lines.append(f"- {test}")
                 lines.append("")
         lines += ["---", ""]
+
+    lines += ["## Leads", ""]
+    if leads:
+        lines += [
+            "Unproven trails. A specialist saw something structurally suspicious here but could not close the",
+            "attack path. These carry no confidence score and no fix — they are review targets, not findings.",
+            "",
+        ]
+        for idx, lead in enumerate(leads, 1):
+            line = lead.get("line")
+            location = f"{lead.get('file')}:{line}" if line else str(lead.get("file"))
+            tags = " ".join(_extract_tags(lead.get("evidence_tags")))
+            lines += [
+                f"[LEAD] **{idx}. {_md_cell(lead.get('title'))}**",
+                "",
+                f"`Class: {lead.get('class_id')}` · `{_md_cell(location)}` · `{tags}`",
+                "",
+                str(lead.get("description") or lead.get("attack_path") or "Structural suspicion reported by specialist."),
+                "",
+                f"**Could not verify.** {_md_cell(lead.get('unverified'))}",
+                "",
+            ]
+        lines += ["---", ""]
+    else:
+        lines += ["No leads.", "", "---", ""]
 
     lines += ["## Dropped Candidates", "", "| Candidate | Class | Drop Reason |", "|-----------|-------|-------------|"]
     if dropped:
@@ -573,18 +648,27 @@ def main() -> int:
         raw_dropped.extend(drops)
 
     preflight = _load_preflight(preflight_path)
-    findings, dropped = _dedupe_and_tag(raw_findings, preflight, proven_only=args.proven_only)
+    merged, dropped = _dedupe_and_tag(raw_findings, preflight, proven_only=args.proven_only)
     dropped = raw_dropped + dropped
-    scope_paths, total_lines = _read_scope(scope_file, repo_root, findings)
+    completeness = _completeness(raw_findings, merged, dropped)
+    findings, leads = _partition_tiers(merged)
+    scope_paths, total_lines = _read_scope(scope_file, repo_root, merged)
     generated_at = datetime.now(UTC).replace(microsecond=0).isoformat()
 
+    covered_files, produced_files, missing_files = completeness
     payload = {
         "generated_at": generated_at,
         "repo_root": repo_root.as_posix(),
         "mode": args.mode,
         "execution_integrity": args.execution_integrity,
         "findings": findings,
+        "leads": leads,
         "dropped_candidates": dropped,
+        "merge_completeness": {
+            "files_with_candidates": produced_files,
+            "files_covered": covered_files,
+            "missing_files": missing_files,
+        },
     }
     out_json = Path(args.output_json).resolve()
     out_md = Path(args.output_md).resolve()
@@ -597,6 +681,7 @@ def main() -> int:
             mode=args.mode,
             workdir=workdir,
             findings=findings,
+            leads=leads,
             dropped=dropped,
             scope_paths=scope_paths,
             total_lines=total_lines,
@@ -605,10 +690,20 @@ def main() -> int:
             generated_at=generated_at,
             integrity=args.execution_integrity,
             threat_intel_status=args.threat_intel_status,
+            completeness=completeness,
         ),
         encoding="utf-8",
     )
-    print(json.dumps({"findings": len(findings), "output_md": out_md.as_posix(), "output_json": out_json.as_posix()}))
+    print(
+        json.dumps(
+            {
+                "findings": len(findings),
+                "leads": len(leads),
+                "output_md": out_md.as_posix(),
+                "output_json": out_json.as_posix(),
+            }
+        )
+    )
     return 0
 
 

--- a/skills/cairo-auditor/tests/validate_report_merge.py
+++ b/skills/cairo-auditor/tests/validate_report_merge.py
@@ -139,6 +139,14 @@ def check_lead_partition() -> tuple[bool, str]:
         return False, "lead partition: report is missing the Leads section"
     if "Could not prove the callback" not in report:
         return False, "lead partition: report does not surface the unverified link"
+    # Fix-free must hold in the JSON too, not only in the rendered markdown. The
+    # `_finding()` helper supplies remediation by default, so this asserts the
+    # normalizer strips it rather than the fixture happening to omit it.
+    lead = payload["leads"][0]
+    if lead.get("recommended_fix") or lead.get("required_tests"):
+        return False, f"lead retained remediation in JSON: {lead.get('recommended_fix')!r} {lead.get('required_tests')!r}"
+    if not payload["findings"][0].get("recommended_fix"):
+        return False, "control: the proven finding lost its fix, so the strip is too broad"
     # The lead is Medium; it must not be counted in the Medium severity column.
     # Expected row: Critical=1, High=0, Medium=0, Low=0, Total=1, Leads=1.
     if "| 1 | 0 | 0 | 0 | 1 | 1 |" not in report:
@@ -206,11 +214,15 @@ def check_schema_conditionals_enforced_at_runtime() -> tuple[bool, str]:
     spec.loader.exec_module(module)
     schema = json.loads((ROOT / "references" / "finding.schema.json").read_text(encoding="utf-8"))
 
+    # Leads must arrive with remediation cleared, which is what the normalizer now
+    # guarantees; a lead that still carries a fix is itself a schema violation.
+    clean_lead = {"recommended_fix": "", "required_tests": []}
     cases = [
         ("high-confidence finding without a fix", _finding(recommended_fix=None, required_tests=None), False),
         ("high-confidence finding with a fix", _finding(), True),
-        ("lead with unverified", _finding(tier="lead", unverified="u"), True),
-        ("lead without unverified", _finding(tier="lead"), False),
+        ("lead with unverified", _finding(tier="lead", unverified="u", **clean_lead), True),
+        ("lead without unverified", _finding(tier="lead", **clean_lead), False),
+        ("lead carrying a fix", _finding(tier="lead", unverified="u"), False),
         ("invalid tier value", _finding(tier="maybe"), False),
     ]
     for name, finding, should_pass in cases:
@@ -243,11 +255,33 @@ def check_completeness_reported() -> tuple[bool, str]:
     return True, "completeness: every file with a candidate survives the merge"
 
 
+def check_lead_without_unverified_is_dropped() -> tuple[bool, str]:
+    """A lead with no recorded unproven link is dropped, not given a placeholder."""
+    payload, _ = _run(
+        [
+            _finding(title="Real finding"),
+            _finding(
+                title="Lead with no unverified link",
+                file="src/router.cairo",
+                root_cause="something suspicious",
+                tier="lead",
+            ),
+        ]
+    )
+    if payload["leads"]:
+        return False, f"a lead with no `unverified` survived: {payload['leads']}"
+    reasons = {row["drop_reason"] for row in payload["dropped_candidates"]}
+    if "insufficient_evidence" not in reasons:
+        return False, f"unusable lead was not dropped as insufficient_evidence: {reasons}"
+    return True, "leads: missing `unverified` is dropped rather than papered over"
+
+
 CHECKS = (
     check_no_cross_file_merge,
     check_case_distinct_files_stay_separate,
     check_same_file_still_merges,
     check_lead_partition,
+    check_lead_without_unverified_is_dropped,
     check_completeness_ignores_dropped_coverage,
     check_completeness_reported,
     check_schema_conditionals_enforced_at_runtime,

--- a/skills/cairo-auditor/tests/validate_report_merge.py
+++ b/skills/cairo-auditor/tests/validate_report_merge.py
@@ -147,6 +147,84 @@ def check_lead_partition() -> tuple[bool, str]:
     return True, "leads: partitioned, fix-free, and excluded from severity counts"
 
 
+def check_case_distinct_files_stay_separate() -> tuple[bool, str]:
+    """Paths differing only by case are different files on a case-sensitive FS."""
+    payload, _ = _run(
+        [
+            _finding(title="Missing access control in Foo", file="src/Foo.cairo"),
+            _finding(title="Missing access control in foo", file="src/foo.cairo"),
+        ]
+    )
+    if len(payload["findings"]) != 2:
+        dropped = [row.get("candidate") for row in payload["dropped_candidates"]]
+        return False, f"case-distinct files merged: got {len(payload['findings'])} finding(s), dropped {dropped}"
+    return True, "case: paths differing only by case are not merged"
+
+
+def check_completeness_ignores_dropped_coverage() -> tuple[bool, str]:
+    """A file present only in dropped candidates must not count as covered.
+
+    Exercised as a unit because the end-to-end path can no longer produce a
+    cross-file merge -- which is the point, but it means the masking bug this
+    guards against has to be constructed directly.
+    """
+    sys.path.insert(0, str(ROOT / "scripts" / "quality"))
+    from structured_report import _completeness  # noqa: PLC0415 - deliberate late import
+
+    raw = [{"file": "src/a.cairo"}, {"file": "src/b.cairo"}]
+    merged = [{"file": "src/a.cairo"}]
+    dropped = [{"file": "src/b.cairo", "drop_reason": "duplicate_root_cause"}]
+    covered, total, suspects = _completeness(raw, merged, dropped)
+    if covered != 1 or total != 2:
+        return False, f"completeness miscounted: covered={covered} total={total} (expected 1/2)"
+    if suspects != ["src/b.cairo"]:
+        return False, f"completeness did not flag the merge-lost file: {suspects}"
+
+    # A file dropped as a false positive is an expected outcome, not a merge bug.
+    fp_dropped = [{"file": "src/b.cairo", "drop_reason": "false_positive"}]
+    _, _, fp_suspects = _completeness(raw, merged, fp_dropped)
+    if fp_suspects:
+        return False, f"false-positive drop wrongly flagged as a merge suspect: {fp_suspects}"
+    return True, "completeness: dropped candidates never count as coverage"
+
+
+def check_schema_conditionals_enforced_at_runtime() -> tuple[bool, str]:
+    """deep_integrity must enforce the schema's conditionals, not just ajv.
+
+    The finding schema expresses its conditionals under `allOf`. The bundled
+    validator previously evaluated only a top-level `if`, so both requirements
+    passed silently there while a spec-compliant validator still enforced them.
+    """
+    import importlib.util  # noqa: PLC0415 - deliberate late import
+
+    spec = importlib.util.spec_from_file_location(
+        "deep_integrity_probe", ROOT / "scripts" / "quality" / "deep_integrity.py"
+    )
+    if spec is None or spec.loader is None:
+        return False, "could not load deep_integrity for validation probe"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    schema = json.loads((ROOT / "references" / "finding.schema.json").read_text(encoding="utf-8"))
+
+    cases = [
+        ("high-confidence finding without a fix", _finding(recommended_fix=None, required_tests=None), False),
+        ("high-confidence finding with a fix", _finding(), True),
+        ("lead with unverified", _finding(tier="lead", unverified="u"), True),
+        ("lead without unverified", _finding(tier="lead"), False),
+        ("invalid tier value", _finding(tier="maybe"), False),
+    ]
+    for name, finding, should_pass in cases:
+        finding = {k: v for k, v in finding.items() if v is not None}
+        errors: list[str] = []
+        module._validate(
+            {"agent_id": 1, "findings": [finding], "dropped_candidates": []}, schema, "$", errors
+        )
+        if (not errors) != should_pass:
+            verb = "accepted" if not errors else "rejected"
+            return False, f"deep_integrity {verb} {name}; expected the opposite"
+    return True, "schema: deep_integrity enforces both allOf conditionals"
+
+
 def check_completeness_reported() -> tuple[bool, str]:
     """Every file that produced a candidate is accounted for in the report."""
     payload, report = _run(
@@ -156,8 +234,8 @@ def check_completeness_reported() -> tuple[bool, str]:
         ]
     )
     completeness = payload["merge_completeness"]
-    if completeness["missing_files"]:
-        return False, f"completeness: files lost in merge {completeness['missing_files']}"
+    if completeness["merge_suspect_files"]:
+        return False, f"completeness: files lost to a cross-file merge {completeness['merge_suspect_files']}"
     if completeness["files_covered"] != completeness["files_with_candidates"]:
         return False, f"completeness: coverage mismatch {completeness}"
     if "| Merge completeness |" not in report:
@@ -167,9 +245,12 @@ def check_completeness_reported() -> tuple[bool, str]:
 
 CHECKS = (
     check_no_cross_file_merge,
+    check_case_distinct_files_stay_separate,
     check_same_file_still_merges,
     check_lead_partition,
+    check_completeness_ignores_dropped_coverage,
     check_completeness_reported,
+    check_schema_conditionals_enforced_at_runtime,
 )
 
 

--- a/skills/cairo-auditor/tests/validate_report_merge.py
+++ b/skills/cairo-auditor/tests/validate_report_merge.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Merge-stage regression tests for structured_report.py.
+
+Covers two guarantees the report contract depends on:
+
+1. Dedupe never merges findings across files. Two specialists can describe
+   unrelated bugs in different files with the same root-cause sentence; merging
+   those silently discards a real finding.
+2. Leads are reported separately from findings, carry no fix, and never inflate
+   the severity counts.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "quality" / "structured_report.py"
+
+
+def _finding(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "title": "Missing access control",
+        "class_id": "NO_ACCESS_CONTROL_MUTATION",
+        "root_cause": "privileged setter lacks caller assertion",
+        "file": "src/vault.cairo",
+        "line": 42,
+        "priority": "P0",
+        "severity": "Critical",
+        "confidence": 90,
+        "description": "Unprivileged caller reaches the setter.",
+        "attack_path": "caller -> set_fee -> fee storage -> value extraction",
+        "guard_analysis": "No assert_only_owner on the write path.",
+        "recommended_fix": "+ self.ownable.assert_only_owner();",
+        "required_tests": ["non-owner call reverts"],
+        "evidence_tags": ["[CODE-TRACE]"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _run(findings: list[dict[str, Any]]) -> tuple[dict[str, Any], str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        workdir = tmpdir / "wd"
+        workdir.mkdir()
+        agent_output = tmpdir / "agent-1.json"
+        agent_output.write_text(
+            json.dumps({"agent_id": 1, "findings": findings, "dropped_candidates": []}),
+            encoding="utf-8",
+        )
+        out_md = tmpdir / "report.md"
+        out_json = tmpdir / "report.json"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(tmpdir),
+                "--mode",
+                "deep",
+                "--workdir",
+                str(workdir),
+                "--agent-output",
+                str(agent_output),
+                "--output-md",
+                str(out_md),
+                "--output-json",
+                str(out_json),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"structured_report.py failed: {proc.stderr.strip()}")
+        return json.loads(out_json.read_text(encoding="utf-8")), out_md.read_text(encoding="utf-8")
+
+
+def check_no_cross_file_merge() -> tuple[bool, str]:
+    """Same root_cause in two different files must yield two findings."""
+    payload, _ = _run(
+        [
+            _finding(title="Missing access control on set_fee", file="src/vault.cairo", line=42),
+            _finding(title="Missing access control on set_oracle", file="src/oracle.cairo", line=17),
+        ]
+    )
+    titles = sorted(row["title"] for row in payload["findings"])
+    if len(titles) != 2:
+        dropped = [row.get("candidate") for row in payload["dropped_candidates"]]
+        return False, f"cross-file merge: expected 2 findings, got {titles} (dropped {dropped})"
+    return True, "cross-file: two files with one shared root cause stay separate"
+
+
+def check_same_file_still_merges() -> tuple[bool, str]:
+    """Same root_cause in the same file must still collapse to one finding."""
+    payload, _ = _run(
+        [
+            _finding(title="Missing access control on set_fee", confidence=90),
+            _finding(title="Setter lacks owner assertion", confidence=80),
+        ]
+    )
+    if len(payload["findings"]) != 1:
+        return False, f"same-file dedupe broke: expected 1 finding, got {len(payload['findings'])}"
+    reasons = {row["drop_reason"] for row in payload["dropped_candidates"]}
+    if reasons != {"duplicate_root_cause"}:
+        return False, f"same-file dedupe: unexpected drop reasons {reasons}"
+    return True, "same-file: duplicate root cause still collapses to one finding"
+
+
+def check_lead_partition() -> tuple[bool, str]:
+    """Leads are separated, keep no fix block, and stay out of severity counts."""
+    payload, report = _run(
+        [
+            _finding(title="Missing access control on set_fee"),
+            _finding(
+                title="Possible cross-contract desync",
+                class_id="STALE_SNAPSHOT_READ",
+                root_cause="snapshot may be stale across callback",
+                file="src/router.cairo",
+                line=88,
+                tier="lead",
+                severity="Medium",
+                confidence=40,
+                unverified="Could not prove the callback re-enters before the snapshot is consumed.",
+            ),
+        ]
+    )
+    if len(payload["findings"]) != 1:
+        return False, f"lead partition: expected 1 finding, got {len(payload['findings'])}"
+    if len(payload["leads"]) != 1:
+        return False, f"lead partition: expected 1 lead, got {len(payload['leads'])}"
+    if "## Leads" not in report:
+        return False, "lead partition: report is missing the Leads section"
+    if "Could not prove the callback" not in report:
+        return False, "lead partition: report does not surface the unverified link"
+    # The lead is Medium; it must not be counted in the Medium severity column.
+    # Expected row: Critical=1, High=0, Medium=0, Low=0, Total=1, Leads=1.
+    if "| 1 | 0 | 0 | 0 | 1 | 1 |" not in report:
+        summary_rows = [line for line in report.splitlines() if line.startswith("| ") and "|" in line][:3]
+        return False, f"lead partition: severity counts include the lead: {summary_rows}"
+    return True, "leads: partitioned, fix-free, and excluded from severity counts"
+
+
+def check_completeness_reported() -> tuple[bool, str]:
+    """Every file that produced a candidate is accounted for in the report."""
+    payload, report = _run(
+        [
+            _finding(file="src/vault.cairo"),
+            _finding(title="Other bug", file="src/oracle.cairo", root_cause="unbounded loop"),
+        ]
+    )
+    completeness = payload["merge_completeness"]
+    if completeness["missing_files"]:
+        return False, f"completeness: files lost in merge {completeness['missing_files']}"
+    if completeness["files_covered"] != completeness["files_with_candidates"]:
+        return False, f"completeness: coverage mismatch {completeness}"
+    if "| Merge completeness |" not in report:
+        return False, "completeness: report is missing the merge completeness row"
+    return True, "completeness: every file with a candidate survives the merge"
+
+
+CHECKS = (
+    check_no_cross_file_merge,
+    check_same_file_still_merges,
+    check_lead_partition,
+    check_completeness_reported,
+)
+
+
+def main() -> int:
+    if not SCRIPT.exists():
+        print(f"missing report script: {SCRIPT}", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for check in CHECKS:
+        try:
+            ok, msg = check()
+        except Exception as exc:  # noqa: BLE001 - surface the failure verbatim
+            ok, msg = False, f"{check.__name__} raised: {exc}"
+        print(msg)
+        if not ok:
+            failures.append(msg)
+
+    if failures:
+        print("\nreport merge validation failed", file=sys.stderr)
+        return 1
+
+    print("\nall report merge checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The merge stage keyed deduplication on `root_cause` alone:

```python
if explicit:
    return explicit.lower()
```

Two specialists reporting unrelated bugs in **different files** that happen to share a root-cause sentence — "privileged setter lacks caller assertion" is a realistic collision — collapsed into one finding. The loser was recorded as `duplicate_root_cause` and disappeared from the report.

Reproduced against the current merge code: a **Critical / P0 / confidence-85** finding in a second file was silently discarded.

```
OLD findings : ['Missing access control on set_fee']
OLD dropped  : [('Missing access control on set_oracle', 'duplicate_root_cause')]

NEW findings : ['Missing access control on set_fee', 'Missing access control on set_oracle']
```

## What changed

**1. Dedupe is scoped to the file.** Same-file duplicates still collapse exactly as before; cross-file merges are now impossible.

**2. New `lead` tier.** A trail a specialist could not close end to end is now reported as a lead rather than dropped or padded into a low-confidence finding. Leads render in their own section, state the unverified link explicitly, carry no fix, and are excluded from the severity counts. "I found something structurally wrong and could not prove exploitability" is the most useful thing to hand a reviewer, and it was previously indistinguishable from a suppressed false positive.

`judging.md` scopes this deliberately: only a finding failing check 1 (cannot close the path to impact) qualifies. Unreachable paths and guard-blocked paths stay dropped, so the tier cannot be used to launder false positives.

**3. Merge-completeness accounting.** The report now shows how many files with candidates survived the merge, so a future merge bug surfaces in the output instead of hiding.

**4. Six vulnerability classes.** Real Cairo/Starknet bug classes the DB did not cover, documented from Cairo semantics:

| Class | Note |
|---|---|
| `L1-HANDLER-UNCHECKED-FROM` | `#[l1_handler]` that never authenticates `from_address` — the canonical bridge failure |
| `CONTROLLED-LIBRARY-CALL` | caller-controlled class hash reaching `library_call_syscall`, running foreign code against local storage |
| `FELT252-UNSAFE-ARITHMETIC` | quantities held in `felt252`, where field arithmetic wraps instead of trapping |
| `READ-ONLY-REENTRANCY` | view exposing storage a mutating path writes only after an external call |
| `UNENFORCED-VIEW` | entrypoint published as `view` whose body can mutate |
| `USE-AFTER-POP-FRONT` | span indexed with a length captured before `pop_front` |

These classes are also what Caracal detects, which is how they were surfaced. **They are documentation-only here and this PR takes no dependency on Caracal** — see the correction below.

## Acceptance test

`skills/cairo-auditor/tests/validate_report_merge.py`, wired into the existing fixture-smoke step in `ci.yml`. Four checks:

- same root cause in two files stays two findings
- same root cause in one file still collapses, with `duplicate_root_cause`
- leads partition out, keep no fix, and stay out of severity counts
- every file with a candidate survives the merge

**It fails against the previous merge code** with `cross-file merge: expected 2 findings, got [...] (dropped [...])`, and passes on this branch.

## Gates run locally

| Gate | Result |
|---|---|
| `validate_report_merge.py` | pass (new) |
| `validate_preflight.py` | pass |
| `validate_deep_smoke.py` | pass |
| `validate_skills.py` | pass |
| `check_vulndb_parity.py` | pass — 34 classes |
| `check_attack_vector_coverage.py` | pass |
| `finding.schema.json` via pinned `ajv` | 7/7 conditional cases correct |

Schema cases verified: high-confidence findings still require `recommended_fix` + `required_tests`; leads are exempt but must supply `unverified`; an invalid `tier` is rejected.

## Correction: do not wire Caracal

An earlier revision of this description proposed wiring `caracal detect` into `detector_bridge.py` as a `[PREFLIGHT-HIT]` source. **That is not viable and the suggestion is withdrawn.**

- Caracal's last commit is 2024-01-25; last release v0.2.3, January 2024.
- It pins `cairo-lang` to git tag **v2.5.0**, embedding a compiler frontend nine minor versions behind this repo's Cairo 2.14.0. It cannot parse modern Cairo source.
- The only recently-pushed fork (`adrienlacombe/caracal`) carries the same commits and the same v2.5.0 pin — no new work.
- This repo already documents the problem in `references/audit-findings/source-cairo-security-import.md`, which warns Caracal is "effectively unusable for any project on Cairo 2.7+".

For the record, the surrounding ecosystem is in the same state: **Thoth** (FuzzingLabs) was archived in April 2025, and **cairo-lint** (Software Mansion) is alive but is a style/correctness linter shipped as `scarb lint`, not a security analyzer.

There is currently **no maintained Sierra-level security static analyzer for current Cairo.** The commit message on the second commit still frames these six classes as Caracal-derived; it is left as-is rather than force-pushing a published branch, and this section is the correction of record.

## Notes and follow-ups

- **`VERSION` is deliberately not bumped.** The release-hygiene gate requires a matching git tag or GitHub release, which is a release action rather than a PR change. Worth flagging separately that `VERSION` has stayed at `0.2.2` across roughly 2,200 lines of skill changes, so the skill's own upstream staleness check currently cannot warn users.
- The six new classes have no deterministic detector, joining the fifteen documentation-only classes already tracked. Given the tooling vacuum above, the path to detection is extending this repo's own `surface_map.py` — which analyses source and therefore keeps line numbers, something a Sierra-level tool structurally cannot do.
- Not included, and worth discussing separately: promoting gate-failed findings when 2+ agents independently flag the same area (the `[CROSS-AGENT]` signal is computed but only used as a label), and a hard admin-amplifier gate for privileged-only paths.

## Spec impact

**None.** No public interface, skill contract, or consumer-visible behaviour is removed or renamed.

- `finding.schema.json` gains two OPTIONAL fields (`tier`, `unverified`). Existing agent
  output without them validates unchanged, and `tier` defaults to `finding`.
- The report gains a `Leads` section between `Findings` and `Dropped Candidates`. Section
  order is documented in `SKILL.md`; no existing section is renamed or removed.
- Report JSON gains `leads` and `merge_completeness`. `findings` keeps its meaning, except
  that entries explicitly marked `tier: "lead"` now appear under `leads` instead.
- `deep_integrity` becomes STRICTER: it now enforces the two schema conditionals it had been
  silently skipping, and reports unknown schema keywords rather than ignoring them. Agent
  output that was already schema-valid is unaffected; output that only passed because of the
  gap will now be rejected, which is the intended correction.

No migration needed for consumers of the markdown report. A consumer parsing the JSON that
wants leads included must read the new `leads` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six vulnerability classes covering controlled library calls, unsafe arithmetic, L1 authentication, read-only reentrancy, unenforced views, and use-after-`pop_front` patterns.
  * Reports now distinguish confirmed findings from unproven leads, include verification details, show merge completeness, and track leads separately.
  * Deduplication is scoped to individual files.

* **Bug Fixes**
  * Improved schema validation for conditional, composite, unsupported, length, and item-count rules.
  * Reports now clearly indicate execution-integrity failures.

* **Documentation**
  * Updated vulnerability counts, guidance, detection criteria, mitigations, and testing recommendations.

* **Tests**
  * Added report-merging regression checks to continuous validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->