### PR TITLE
ci: pin CodeQL Action to v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7 (tag object: faaa5d804fc648d0fdb28822a8e36cf7d0a6132c)
         with:
           languages: ${{ matrix.language }}
           queries: ${{ matrix.queries }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7 (tag object: faaa5d804fc648d0fdb28822a8e36cf7d0a6132c)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7 (tag object: faaa5d804fc648d0fdb28822a8e36cf7d0a6132c)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.35.2 (tag object: 7fc6561ed893d15cec696e062df840b21db27eb0)
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7 (tag object: faaa5d804fc648d0fdb28822a8e36cf7d0a6132c)
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pin `github/codeql-action` `init`, `autobuild`, `analyze`, and `upload-sarif` to v4.37.7 (`ff2f1c62`), which runs on Node 24.
- Correct the stale `# v4.35.2` comments so the pin version matches the commit.

These annotations come from CodeQL Action v3 (Node 20), which GitHub is deprecating in December 2026. v4 is the supported line.

## Test plan
- [ ] Confirm the CodeQL workflow on this PR no longer reports "Node.js 20 actions are deprecated" or "CodeQL Action v3 will be deprecated".
- [ ] Confirm both `Analyze (javascript-typescript)` and `Analyze (actions)` succeed.
- [ ] After merge, confirm the next Scorecard SARIF upload still succeeds.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflows to use the latest pinned CodeQL action version.
  * Improved the reliability and maintenance of automated code and supply-chain security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->