### PR TITLE
fix(security): close open Dependabot and CodeQL alerts

### DIFF
--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   AVAILABLE_SKILLS,
+  sanitizeDownloadedText,
   trustedSkillApiUrl,
   trustedSkillDownloadUrl,
   type WizardResult,
@@ -63,6 +64,11 @@ describe("wizards", () => {
         expect(skill.description).toBeTruthy();
         expect(typeof skill.recommended).toBe("boolean");
       }
+    });
+
+    it("has unique ids so CLI --skills can derive its allowlist from this list", () => {
+      const ids = AVAILABLE_SKILLS.map((skill) => skill.id);
+      expect(new Set(ids).size).toBe(ids.length);
     });
   });
 
@@ -150,6 +156,25 @@ describe("trustedSkillDownloadUrl", () => {
         "https://objects.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-wallet/SKILL.md"
       )
     ).toBeNull();
+  });
+});
+
+describe("sanitizeDownloadedText", () => {
+  it("accepts a normal UTF-8 skill file", () => {
+    const result = sanitizeDownloadedText("# Skill\n");
+    expect(result).toEqual({ status: "ok", content: "# Skill\n" });
+  });
+
+  it("rejects empty, NUL, and oversized files with distinct reasons", () => {
+    expect(sanitizeDownloadedText("")).toEqual({ status: "rejected", reason: "empty file" });
+    expect(sanitizeDownloadedText("ok\0no")).toEqual({
+      status: "rejected",
+      reason: "file contains a NUL byte",
+    });
+    expect(sanitizeDownloadedText("a".repeat(1_048_577))).toEqual({
+      status: "rejected",
+      reason: "file exceeds 1 MiB",
+    });
   });
 });
 

--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -135,6 +135,14 @@ describe("trustedSkillDownloadUrl", () => {
       )
     ).toBeNull();
   });
+
+  it("rejects valid-host URLs outside the skills/ tree", () => {
+    expect(
+      trustedSkillDownloadUrl(
+        "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/packages/create-starknet-agent/package.json"
+      )
+    ).toBeNull();
+  });
 });
 
 describe("trustedSkillApiUrl", () => {

--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -143,6 +143,14 @@ describe("trustedSkillDownloadUrl", () => {
       )
     ).toBeNull();
   });
+
+  it("rejects objects.githubusercontent.com (path shape never matches this repo)", () => {
+    expect(
+      trustedSkillDownloadUrl(
+        "https://objects.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-wallet/SKILL.md"
+      )
+    ).toBeNull();
+  });
 });
 
 describe("trustedSkillApiUrl", () => {

--- a/packages/create-starknet-agent/src/__tests__/wizards.test.ts
+++ b/packages/create-starknet-agent/src/__tests__/wizards.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   AVAILABLE_SKILLS,
+  trustedSkillApiUrl,
+  trustedSkillDownloadUrl,
   type WizardResult,
 } from "../wizards.js";
 
@@ -109,5 +111,44 @@ describe("MCP config generation", () => {
     const expectedRpcUrl = RPC_URLS[network];
 
     expect(expectedRpcUrl).toBe("https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_7/YOUR_API_KEY");
+  });
+});
+
+describe("trustedSkillDownloadUrl", () => {
+  it("accepts raw.githubusercontent.com URLs for this repo", () => {
+    const url =
+      "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/starknet-wallet/SKILL.md";
+    expect(trustedSkillDownloadUrl(url)).toBe(url);
+  });
+
+  it("rejects non-https, foreign hosts, credentials, and traversal", () => {
+    expect(trustedSkillDownloadUrl("http://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/x")).toBeNull();
+    expect(trustedSkillDownloadUrl("https://evil.example/keep-starknet-strange/starknet-agentic/main/skills/x")).toBeNull();
+    expect(
+      trustedSkillDownloadUrl(
+        "https://user:pass@raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills/x"
+      )
+    ).toBeNull();
+    expect(
+      trustedSkillDownloadUrl(
+        "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/../other/skills/x"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("trustedSkillApiUrl", () => {
+  it("accepts GitHub Contents API URLs under skills/", () => {
+    const url =
+      "https://api.github.com/repos/keep-starknet-strange/starknet-agentic/contents/skills/starknet-wallet";
+    expect(trustedSkillApiUrl(url)).toBe(url);
+  });
+
+  it("rejects other GitHub API paths", () => {
+    expect(
+      trustedSkillApiUrl(
+        "https://api.github.com/repos/keep-starknet-strange/starknet-agentic/contents/packages/create-starknet-agent"
+      )
+    ).toBeNull();
   });
 });

--- a/packages/create-starknet-agent/src/credentials.ts
+++ b/packages/create-starknet-agent/src/credentials.ts
@@ -450,22 +450,24 @@ export async function runCredentialsSetup(args: CredentialsArgs): Promise<void> 
     console.log();
   }
 
-  // Initialize credentials from environment if --from-env
+  // Initialize credentials from environment if --from-env.
+  // Private keys from env are only used for presence logging, never as a
+  // prompt initial value (password fields must not echo a default).
   let initialAddress: string | undefined;
-  let initialPrivateKey: string | undefined;
   let initialRpcUrl: string | undefined;
+  let envHasPrivateKey = false;
 
   if (args.fromEnv) {
     const envCreds = loadFromEnv();
     initialAddress = envCreds.address;
-    initialPrivateKey = envCreds.privateKey;
+    envHasPrivateKey = Boolean(envCreds.privateKey);
     initialRpcUrl = envCreds.rpcUrl;
 
     if (!args.jsonOutput) {
-      if (envCreds.address || envCreds.privateKey || envCreds.rpcUrl) {
+      if (envCreds.address || envHasPrivateKey || envCreds.rpcUrl) {
         console.log(pc.green("✓ Loaded credentials from environment"));
         if (envCreds.address) console.log(pc.dim(`  Address: ${envCreds.address.slice(0, 10)}...`));
-        if (envCreds.privateKey) console.log(pc.dim("  Private key: ****"));
+        if (envHasPrivateKey) console.log(pc.dim("  Private key: ****"));
         if (envCreds.rpcUrl) console.log(pc.dim(`  RPC URL: ${envCreds.rpcUrl}`));
         console.log();
       } else {

--- a/packages/create-starknet-agent/src/credentials.ts
+++ b/packages/create-starknet-agent/src/credentials.ts
@@ -121,7 +121,7 @@ ${pc.bold("Description:")}
 ${pc.bold("Options:")}
   --platform <name>    Target platform (openclaw, claude-code, cursor, generic-mcp)
   --network <name>     Network (mainnet, sepolia)
-  --from-env           Import credentials from current environment variables
+  --from-env           Prefill address and RPC from the environment; with --json, also import the private key
   --from-ready         Show guide for exporting from Ready wallet
   --from-braavos       Show guide for exporting from Braavos wallet
   --json               Output machine-readable JSON
@@ -451,23 +451,23 @@ export async function runCredentialsSetup(args: CredentialsArgs): Promise<void> 
   }
 
   // Initialize credentials from environment if --from-env.
-  // Private keys from env are only used for presence logging, never as a
-  // prompt initial value (password fields must not echo a default).
+  // Interactive password prompts never echo a default. --json uses the env
+  // private key directly so --from-env --json can run non-interactively.
   let initialAddress: string | undefined;
   let initialRpcUrl: string | undefined;
-  let envHasPrivateKey = false;
+  let envPrivateKey: string | undefined;
 
   if (args.fromEnv) {
     const envCreds = loadFromEnv();
     initialAddress = envCreds.address;
-    envHasPrivateKey = Boolean(envCreds.privateKey);
+    envPrivateKey = envCreds.privateKey;
     initialRpcUrl = envCreds.rpcUrl;
 
     if (!args.jsonOutput) {
-      if (envCreds.address || envHasPrivateKey || envCreds.rpcUrl) {
+      if (envCreds.address || envPrivateKey || envCreds.rpcUrl) {
         console.log(pc.green("✓ Loaded credentials from environment"));
         if (envCreds.address) console.log(pc.dim(`  Address: ${envCreds.address.slice(0, 10)}...`));
-        if (envHasPrivateKey) console.log(pc.dim("  Private key: ****"));
+        if (envPrivateKey) console.log(pc.dim("  Private key: ****"));
         if (envCreds.rpcUrl) console.log(pc.dim(`  RPC URL: ${envCreds.rpcUrl}`));
         console.log();
       } else {
@@ -477,60 +477,63 @@ export async function runCredentialsSetup(args: CredentialsArgs): Promise<void> 
     }
   }
 
-  // Cancel handler
-  const onCancel = () => {
-    console.log(pc.red("\nOperation cancelled."));
-    process.exit(0);
-  };
+  let address: string;
+  let privateKey: string;
+  let rpcUrl: string;
 
-  // Show link to docs for setting up an account
-  if (!args.jsonOutput) {
+  if (args.jsonOutput) {
+    address = initialAddress ?? "";
+    privateKey = envPrivateKey ?? "";
+    rpcUrl = initialRpcUrl || RPC_URLS.sepolia;
+  } else {
+    const onCancel = () => {
+      console.log(pc.red("\nOperation cancelled."));
+      process.exit(0);
+    };
+
     console.log(pc.dim("  Don't have a Starknet account? Follow the guide:"));
     console.log(pc.cyan("  https://www.starknet-agentic.com/docs/getting-started/quick-start#getting-your-credentials"));
     console.log();
+
+    const rpcResponse = await prompts(
+      {
+        type: "text",
+        name: "rpcUrl",
+        message: "Starknet RPC URL:",
+        initial: initialRpcUrl || RPC_URLS.sepolia,
+        validate: (value: string) =>
+          isValidRpcUrl(value) || "Invalid URL format (must be http:// or https://)",
+      },
+      { onCancel }
+    );
+
+    const addressResponse = await prompts(
+      {
+        type: "text",
+        name: "address",
+        message: "Starknet account address:",
+        initial: initialAddress,
+        validate: (value: string) =>
+          isValidAddress(value) || "Invalid address format (expected 0x + 1-64 hex characters)",
+      },
+      { onCancel }
+    );
+
+    const keyResponse = await prompts(
+      {
+        type: "password",
+        name: "privateKey",
+        message: "Private key:",
+        validate: (value: string) =>
+          isValidPrivateKey(value) || "Invalid key format (expected 0x + 1-64 hex characters)",
+      },
+      { onCancel }
+    );
+
+    address = addressResponse.address;
+    privateKey = keyResponse.privateKey;
+    rpcUrl = rpcResponse.rpcUrl;
   }
-
-  // Prompt for RPC URL first
-  const rpcResponse = await prompts(
-    {
-      type: "text",
-      name: "rpcUrl",
-      message: "Starknet RPC URL:",
-      initial: initialRpcUrl || RPC_URLS.sepolia,
-      validate: (value: string) =>
-        isValidRpcUrl(value) || "Invalid URL format (must be http:// or https://)",
-    },
-    { onCancel }
-  );
-
-  // Prompt for account address
-  const addressResponse = await prompts(
-    {
-      type: "text",
-      name: "address",
-      message: "Starknet account address:",
-      initial: initialAddress,
-      validate: (value: string) =>
-        isValidAddress(value) || "Invalid address format (expected 0x + 1-64 hex characters)",
-    },
-    { onCancel }
-  );
-
-  // Prompt for private key (password type - hidden input)
-  const keyResponse = await prompts(
-    {
-      type: "password",
-      name: "privateKey",
-      message: "Private key:",
-      validate: (value: string) =>
-        isValidPrivateKey(value) || "Invalid key format (expected 0x + 1-64 hex characters)",
-    },
-    { onCancel }
-  );
-
-  const address = addressResponse.address;
-  const privateKey = keyResponse.privateKey;
-  const rpcUrl = rpcResponse.rpcUrl;
 
   // Validate credentials
   if (!args.jsonOutput) {

--- a/packages/create-starknet-agent/src/index.ts
+++ b/packages/create-starknet-agent/src/index.ts
@@ -68,7 +68,7 @@ ${pc.bold("Options:")}
   --version, -v         Show version number
 
 ${pc.bold("Credentials Options:")}
-  --from-env            Import credentials from current environment variables
+  --from-env            Prefill address and RPC from the environment; with --json, also import the private key
   --from-ready          Show guide for exporting from Ready wallet
   --from-braavos        Show guide for exporting from Braavos wallet
 

--- a/packages/create-starknet-agent/src/index.ts
+++ b/packages/create-starknet-agent/src/index.ts
@@ -27,7 +27,7 @@ import {
   getPlatformByType,
   isValidPlatformType,
 } from "./platform.js";
-import { runWizard } from "./wizards.js";
+import { AVAILABLE_SKILLS, runWizard } from "./wizards.js";
 import { parseCredentialsArgs, runCredentialsSetup } from "./credentials.js";
 import { parseVerifyArgs, runVerification } from "./verify.js";
 
@@ -143,8 +143,7 @@ interface ParsedArgs {
   showVersion: boolean;
 }
 
-// Valid skill IDs
-const VALID_SKILLS = ["starknet-wallet", "starknet-defi", "starknet-identity", "starknet-anonymous-wallet"];
+const VALID_SKILLS = AVAILABLE_SKILLS.map((skill) => skill.id);
 
 /**
  * Parse and validate skill list from CLI argument

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -484,6 +484,8 @@ async function downloadFile(url: string): Promise<SkillDownloadResult> {
     return { status: "rejected", reason: "URL is not a trusted GitHub skill download" };
   }
   try {
+    // Response bytes are skill install content from this repo's skills/ tree.
+    // codeql[js/http-to-file-access]: allowlisted GitHub raw URL, no redirects, 1 MiB cap, NUL rejected, written only under the local skill dir.
     const response = await fetch(trustedUrl, { redirect: "manual" });
     if (!response.ok) {
       return { status: "fetch_failed" };
@@ -492,6 +494,21 @@ async function downloadFile(url: string): Promise<SkillDownloadResult> {
   } catch {
     return { status: "fetch_failed" };
   }
+}
+
+/**
+ * Persist a downloaded skill file after the download pipeline's checks.
+ * js/http-to-file-access flags any HTTP body that reaches disk; this installer
+ * must write SKILL.md and skill scripts, and has no CodeQL sanitizer for that.
+ */
+function writeDownloadedSkillFile(filePath: string, content: string): boolean {
+  const sanitized = sanitizeDownloadedText(content);
+  if (sanitized.status !== "ok") {
+    return false;
+  }
+  // codeql[js/http-to-file-access]: skill install from allowlisted GitHub raw URLs after host/path checks, no-follow redirects, 1 MiB cap, and NUL rejection.
+  fs.writeFileSync(filePath, sanitized.content, "utf-8");
+  return true;
 }
 
 /**
@@ -552,8 +569,11 @@ async function downloadSkillDirectory(
       const downloaded = await downloadFile(item.download_url);
       switch (downloaded.status) {
         case "ok":
-          fs.writeFileSync(localPath, downloaded.content, "utf-8");
-          fileCount++;
+          if (writeDownloadedSkillFile(localPath, downloaded.content)) {
+            fileCount++;
+          } else {
+            console.log(pc.yellow(`  Warning: skipped ${item.name} in ${skillId}: failed content checks`));
+          }
           break;
         case "rejected":
           console.log(pc.yellow(`  Warning: skipped ${item.name} in ${skillId}: ${downloaded.reason}`));
@@ -627,8 +647,7 @@ async function installSkills(
     } else {
       // Fallback to just SKILL.md if API fails (rate limiting, etc.)
       const content = await fetchSkillMdOnly(skillId);
-      if (content) {
-        fs.writeFileSync(path.join(skillDir, "SKILL.md"), content, "utf-8");
+      if (content && writeDownloadedSkillFile(path.join(skillDir, "SKILL.md"), content)) {
         if (!silent) {
           console.log(pc.dim(`  ✓ Installed ${skillId} (SKILL.md only)`));
         }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -134,30 +134,39 @@ export function trustedSkillApiUrl(url: string): string | null {
   return `https://api.github.com${parsed.pathname}${parsed.search}`;
 }
 
-function sanitizeDownloadedText(content: string): string | null {
-  if (typeof content !== "string") {
-    return null;
+export type SkillDownloadResult =
+  | { status: "ok"; content: string }
+  | { status: "fetch_failed" }
+  | { status: "rejected"; reason: string };
+
+export function sanitizeDownloadedText(content: string): SkillDownloadResult {
+  if (content.length === 0) {
+    return { status: "rejected", reason: "empty file" };
   }
-  if (content.length === 0 || Buffer.byteLength(content, "utf8") > MAX_SKILL_FILE_BYTES) {
-    return null;
+  if (Buffer.byteLength(content, "utf8") > MAX_SKILL_FILE_BYTES) {
+    return { status: "rejected", reason: "file exceeds 1 MiB" };
   }
   if (content.includes("\0")) {
-    return null;
+    return { status: "rejected", reason: "file contains a NUL byte" };
   }
-  return Buffer.from(content, "utf8").toString("utf8");
+  return { status: "ok", content };
 }
 
-async function readBoundedUtf8Text(response: Response): Promise<string | null> {
+async function readBoundedUtf8Text(response: Response): Promise<SkillDownloadResult> {
   const contentLength = response.headers.get("content-length");
   if (contentLength !== null) {
     const declared = Number(contentLength);
     if (!Number.isFinite(declared) || declared < 0 || declared > MAX_SKILL_FILE_BYTES) {
-      return null;
+      return { status: "rejected", reason: "file exceeds 1 MiB or has an invalid Content-Length" };
     }
   }
 
   if (!response.body) {
-    return sanitizeDownloadedText(await response.text());
+    try {
+      return sanitizeDownloadedText(await response.text());
+    } catch {
+      return { status: "fetch_failed" };
+    }
   }
 
   const reader = response.body.getReader();
@@ -172,17 +181,16 @@ async function readBoundedUtf8Text(response: Response): Promise<string | null> {
       totalBytes += value.byteLength;
       if (totalBytes > MAX_SKILL_FILE_BYTES) {
         await reader.cancel();
-        return null;
+        return { status: "rejected", reason: "file exceeds 1 MiB" };
       }
       chunks.push(value);
     }
   } catch {
     await reader.cancel().catch(() => undefined);
-    return null;
+    return { status: "fetch_failed" };
   }
 
-  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
-  return sanitizeDownloadedText(bytes.toString("utf8"));
+  return sanitizeDownloadedText(Buffer.concat(chunks).toString("utf8"));
 }
 
 /**
@@ -470,19 +478,19 @@ async function fetchGitHubDirectory(skillId: string): Promise<GitHubContentItem[
 /**
  * Download a single file from a trusted GitHub URL.
  */
-async function downloadFile(url: string): Promise<string | null> {
+async function downloadFile(url: string): Promise<SkillDownloadResult> {
   const trustedUrl = trustedSkillDownloadUrl(url);
   if (!trustedUrl) {
-    return null;
+    return { status: "rejected", reason: "URL is not a trusted GitHub skill download" };
   }
   try {
     const response = await fetch(trustedUrl, { redirect: "manual" });
     if (!response.ok) {
-      return null;
+      return { status: "fetch_failed" };
     }
     return await readBoundedUtf8Text(response);
   } catch {
-    return null;
+    return { status: "fetch_failed" };
   }
 }
 
@@ -541,11 +549,22 @@ async function downloadSkillDirectory(
       const subPathNew = subPath ? `${subPath}/${item.name}` : item.name;
       fileCount += await downloadSkillDirectory(skillId, localPath, subPathNew);
     } else if (item.type === "file" && item.download_url) {
-      // Download file
-      const content = await downloadFile(item.download_url);
-      if (content !== null) {
-        fs.writeFileSync(localPath, content, "utf-8");
-        fileCount++;
+      const downloaded = await downloadFile(item.download_url);
+      switch (downloaded.status) {
+        case "ok":
+          fs.writeFileSync(localPath, downloaded.content, "utf-8");
+          fileCount++;
+          break;
+        case "rejected":
+          console.log(pc.yellow(`  Warning: skipped ${item.name} in ${skillId}: ${downloaded.reason}`));
+          break;
+        case "fetch_failed":
+          console.log(pc.yellow(`  Warning: failed to fetch ${item.name} in ${skillId}`));
+          break;
+        default: {
+          const _exhaustive: never = downloaded;
+          throw new Error(`Unhandled skill download status: ${_exhaustive}`);
+        }
       }
     }
   }
@@ -562,7 +581,8 @@ async function fetchSkillMdOnly(skillId: string): Promise<string | null> {
     return null;
   }
 
-  return downloadFile(skill.rawUrl);
+  const downloaded = await downloadFile(skill.rawUrl);
+  return downloaded.status === "ok" ? downloaded.content : null;
 }
 
 /**
@@ -583,6 +603,9 @@ async function installSkills(
 
   for (const skillId of selectedSkills) {
     if (!AVAILABLE_SKILLS.some((skill) => skill.id === skillId)) {
+      if (!silent) {
+        console.log(pc.yellow(`  ✗ Failed to install ${skillId}: unknown skill`));
+      }
       failed.push(skillId);
       continue;
     }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -39,6 +39,7 @@ const TRUSTED_SKILL_DOWNLOAD_HOSTS = new Set([
   "raw.githubusercontent.com",
 ]);
 const MAX_SKILL_FILE_BYTES = 1_048_576;
+const SKILL_FETCH_TIMEOUT_MS = 15_000;
 
 export const AVAILABLE_SKILLS: SkillInfo[] = [
   {
@@ -453,6 +454,7 @@ async function fetchGitHubDirectory(skillId: string): Promise<GitHubContentItem[
   try {
     const response = await fetch(apiUrl, {
       redirect: "manual",
+      signal: AbortSignal.timeout(SKILL_FETCH_TIMEOUT_MS),
       headers: {
         "Accept": "application/vnd.github.v3+json",
         "User-Agent": "create-starknet-agent",
@@ -486,7 +488,10 @@ async function downloadFile(url: string): Promise<SkillDownloadResult> {
   try {
     // Response bytes are skill install content from this repo's skills/ tree.
     // codeql[js/http-to-file-access]: allowlisted GitHub raw URL, no redirects, 1 MiB cap, NUL rejected, written only under the local skill dir.
-    const response = await fetch(trustedUrl, { redirect: "manual" });
+    const response = await fetch(trustedUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(SKILL_FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       return { status: "fetch_failed" };
     }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -37,7 +37,6 @@ const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/keep-starknet-strange
 const GITHUB_OWNER_REPO = "keep-starknet-strange/starknet-agentic";
 const TRUSTED_SKILL_DOWNLOAD_HOSTS = new Set([
   "raw.githubusercontent.com",
-  "objects.githubusercontent.com",
 ]);
 const MAX_SKILL_FILE_BYTES = 1_048_576;
 
@@ -73,7 +72,7 @@ export const AVAILABLE_SKILLS: SkillInfo[] = [
 ];
 
 /**
- * HTTPS GitHub download URLs for skill files (raw / objects).
+ * HTTPS GitHub download URLs for skill files (raw.githubusercontent.com).
  * Rejects other hosts, credentials, and path traversal before fetch.
  */
 export function trustedSkillDownloadUrl(url: string): string | null {
@@ -445,6 +444,7 @@ async function fetchGitHubDirectory(skillId: string): Promise<GitHubContentItem[
 
   try {
     const response = await fetch(apiUrl, {
+      redirect: "manual",
       headers: {
         "Accept": "application/vnd.github.v3+json",
         "User-Agent": "create-starknet-agent",
@@ -476,11 +476,11 @@ async function downloadFile(url: string): Promise<string | null> {
     return null;
   }
   try {
-    const response = await fetch(trustedUrl);
+    const response = await fetch(trustedUrl, { redirect: "manual" });
     if (!response.ok) {
       return null;
     }
-    return readBoundedUtf8Text(response);
+    return await readBoundedUtf8Text(response);
   } catch {
     return null;
   }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -93,8 +93,17 @@ export function trustedSkillDownloadUrl(url: string): string | null {
   if (!TRUSTED_SKILL_DOWNLOAD_HOSTS.has(host)) {
     return null;
   }
-  const prefix = `/${GITHUB_OWNER_REPO}/`;
-  if (!parsed.pathname.startsWith(prefix) || parsed.pathname.includes("..")) {
+  const repoPrefix = `/${GITHUB_OWNER_REPO}/`;
+  if (!parsed.pathname.startsWith(repoPrefix) || parsed.pathname.includes("..")) {
+    return null;
+  }
+  const rest = parsed.pathname.slice(repoPrefix.length);
+  const skillsIdx = rest.indexOf("/skills/");
+  if (skillsIdx <= 0) {
+    return null;
+  }
+  const ref = rest.slice(0, skillsIdx);
+  if (ref.length === 0 || ref.includes("/")) {
     return null;
   }
   return `https://${host}${parsed.pathname}${parsed.search}`;
@@ -130,13 +139,51 @@ function sanitizeDownloadedText(content: string): string | null {
   if (typeof content !== "string") {
     return null;
   }
-  if (content.length === 0 || content.length > MAX_SKILL_FILE_BYTES) {
+  if (content.length === 0 || Buffer.byteLength(content, "utf8") > MAX_SKILL_FILE_BYTES) {
     return null;
   }
   if (content.includes("\0")) {
     return null;
   }
   return Buffer.from(content, "utf8").toString("utf8");
+}
+
+async function readBoundedUtf8Text(response: Response): Promise<string | null> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const declared = Number(contentLength);
+    if (!Number.isFinite(declared) || declared < 0 || declared > MAX_SKILL_FILE_BYTES) {
+      return null;
+    }
+  }
+
+  if (!response.body) {
+    return sanitizeDownloadedText(await response.text());
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_SKILL_FILE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    await reader.cancel().catch(() => undefined);
+    return null;
+  }
+
+  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  return sanitizeDownloadedText(bytes.toString("utf8"));
 }
 
 /**
@@ -433,8 +480,7 @@ async function downloadFile(url: string): Promise<string | null> {
     if (!response.ok) {
       return null;
     }
-    const content = await response.text();
-    return sanitizeDownloadedText(content);
+    return readBoundedUtf8Text(response);
   } catch {
     return null;
   }

--- a/packages/create-starknet-agent/src/wizards.ts
+++ b/packages/create-starknet-agent/src/wizards.ts
@@ -34,6 +34,12 @@ export interface SkillInfo {
 
 const GITHUB_API_BASE = "https://api.github.com/repos/keep-starknet-strange/starknet-agentic/contents/skills";
 const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/keep-starknet-strange/starknet-agentic/main/skills";
+const GITHUB_OWNER_REPO = "keep-starknet-strange/starknet-agentic";
+const TRUSTED_SKILL_DOWNLOAD_HOSTS = new Set([
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+]);
+const MAX_SKILL_FILE_BYTES = 1_048_576;
 
 export const AVAILABLE_SKILLS: SkillInfo[] = [
   {
@@ -65,6 +71,73 @@ export const AVAILABLE_SKILLS: SkillInfo[] = [
     rawUrl: `${GITHUB_RAW_BASE}/starknet-anonymous-wallet/SKILL.md`,
   },
 ];
+
+/**
+ * HTTPS GitHub download URLs for skill files (raw / objects).
+ * Rejects other hosts, credentials, and path traversal before fetch.
+ */
+export function trustedSkillDownloadUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") {
+    return null;
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!TRUSTED_SKILL_DOWNLOAD_HOSTS.has(host)) {
+    return null;
+  }
+  const prefix = `/${GITHUB_OWNER_REPO}/`;
+  if (!parsed.pathname.startsWith(prefix) || parsed.pathname.includes("..")) {
+    return null;
+  }
+  return `https://${host}${parsed.pathname}${parsed.search}`;
+}
+
+/**
+ * HTTPS GitHub Contents API URLs under this repo's skills/ tree.
+ */
+export function trustedSkillApiUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") {
+    return null;
+  }
+  if (parsed.hostname.toLowerCase() !== "api.github.com") {
+    return null;
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    return null;
+  }
+  const prefix = `/repos/${GITHUB_OWNER_REPO}/contents/skills/`;
+  if (!parsed.pathname.startsWith(prefix) || parsed.pathname.includes("..")) {
+    return null;
+  }
+  return `https://api.github.com${parsed.pathname}${parsed.search}`;
+}
+
+function sanitizeDownloadedText(content: string): string | null {
+  if (typeof content !== "string") {
+    return null;
+  }
+  if (content.length === 0 || content.length > MAX_SKILL_FILE_BYTES) {
+    return null;
+  }
+  if (content.includes("\0")) {
+    return null;
+  }
+  return Buffer.from(content, "utf8").toString("utf8");
+}
 
 /**
  * Setup modes for non-standalone platforms
@@ -318,7 +391,10 @@ interface GitHubContentItem {
  * Fetch directory contents from GitHub API
  */
 async function fetchGitHubDirectory(skillId: string): Promise<GitHubContentItem[] | null> {
-  const apiUrl = `${GITHUB_API_BASE}/${skillId}`;
+  const apiUrl = trustedSkillApiUrl(`${GITHUB_API_BASE}/${skillId}`);
+  if (!apiUrl) {
+    return null;
+  }
 
   try {
     const response = await fetch(apiUrl, {
@@ -345,15 +421,20 @@ async function fetchGitHubDirectory(skillId: string): Promise<GitHubContentItem[
 }
 
 /**
- * Download a single file from GitHub
+ * Download a single file from a trusted GitHub URL.
  */
 async function downloadFile(url: string): Promise<string | null> {
+  const trustedUrl = trustedSkillDownloadUrl(url);
+  if (!trustedUrl) {
+    return null;
+  }
   try {
-    const response = await fetch(url);
+    const response = await fetch(trustedUrl);
     if (!response.ok) {
       return null;
     }
-    return await response.text();
+    const content = await response.text();
+    return sanitizeDownloadedText(content);
   } catch {
     return null;
   }
@@ -435,15 +516,7 @@ async function fetchSkillMdOnly(skillId: string): Promise<string | null> {
     return null;
   }
 
-  try {
-    const response = await fetch(skill.rawUrl);
-    if (!response.ok) {
-      return null;
-    }
-    return await response.text();
-  } catch {
-    return null;
-  }
+  return downloadFile(skill.rawUrl);
 }
 
 /**
@@ -463,6 +536,10 @@ async function installSkills(
   }
 
   for (const skillId of selectedSkills) {
+    if (!AVAILABLE_SKILLS.some((skill) => skill.id === skillId)) {
+      failed.push(skillId);
+      continue;
+    }
     const skillDir = path.join(skillsPath, skillId);
 
     // Create skill directory

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -189,16 +189,6 @@ function loadProtocols() {
   return protocols;
 }
 
-// ============ MULTI-ADDRESS ABI SCANNING ============
-async function fetchABI(address, provider) {
-  try {
-    const response = await provider.getClassAt(address);
-    return response.abi || [];
-  } catch (e) {
-    return [];
-  }
-}
-
 // ============ PROMPT INJECTION PROTECTION ============
 // ============ CONFIGURATION (loaded from JSON files) ============
 // Loaded dynamically in main() to allow registration during execution
@@ -248,49 +238,6 @@ function loadAccount(index = 0) {
 }
 
 // ============ ABI ANALYSIS ============
-function tokenize(str) {
-  return str.replace(/([A-Z])/g, '_$1').replace(/^_/, '').toLowerCase().split(/[_\-]+/).filter(Boolean);
-}
-
-function calculateSimilarity(query, target) {
-  const q = String(query || '').toLowerCase();
-  const t = String(target || '').toLowerCase();
-  if (!q || !t) return 0;
-  
-  if (t === q) return 100;
-  if (t.includes(q)) return 70 + (q.length / t.length) * 20;
-  if (q.includes(t)) return 60 + (t.length / q.length) * 15;
-  
-  let score = 0;
-  const qTokens = tokenize(q);
-  const tTokens = tokenize(t);
-  const MAX_SUBSTRING_LEN = 6;
-  const MAX_SUBSTRING_STARTS = 12;
-  
-  for (const qt of qTokens) {
-    for (const tt of tTokens) {
-      if (qt === tt) score += 30;
-      else if (tt.includes(qt)) score += 20;
-      else if (qt.includes(tt)) score += 15;
-      else {
-        // Common substrings (bounded to avoid runaway O(n^3)-style costs)
-        const maxLen = Math.min(MAX_SUBSTRING_LEN, qt.length, tt.length);
-        for (let len = 3; len <= maxLen; len++) {
-          const maxStarts = Math.min(qt.length - len + 1, MAX_SUBSTRING_STARTS);
-          for (let i = 0; i < maxStarts; i++) {
-            if (tt.includes(qt.substring(i, i + len))) {
-              score += len * 2;
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-  
-  return score;
-}
-
 function extractABIItems(abi) {
   const functions = [];
   const events = [];
@@ -344,20 +291,6 @@ function isComplexAbiType(typeStr) {
 }
 
 // ============ TOKEN OPERATIONS ============
-function formatUnitsSafe(value, decimals, maxFractionDigits = 6) {
-  const d = Number(decimals ?? 18);
-  if (!Number.isInteger(d) || d < 0) return value.toString();
-
-  const base = 10n ** BigInt(d);
-  const whole = value / base;
-  const frac = value % base;
-
-  if (d === 0) return whole.toString();
-  let fracStr = frac.toString().padStart(d, '0').slice(0, maxFractionDigits);
-  fracStr = fracStr.replace(/0+$/, '');
-  return fracStr ? `${whole.toString()}.${fracStr}` : whole.toString();
-}
-
 function toUint256(n) {
   return [(n & ((1n << 128n) - 1n)).toString(), (n >> 128n).toString()];
 }
@@ -482,7 +415,7 @@ async function main() {
       orchestration: [{ step: 0, name: "Using LLM-parsed data" }]
     };
     
-    const { operations = [], operationType, abis = {}, addresses = {} } = parsed || {};
+    const { operations = [], operationType, abis = {}, addresses = {} } = parsed;
     
     result.parsed = parsed;
     result.operationType = operationType;

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -21,6 +21,51 @@ import { loadPrivateKeyByAccountAddress } from './_keys.js';
 
 const AVNU_VIRTUAL_SENTINELS = new Set(['__avnu_virtual__', '0x01']);
 const VESU_VIRTUAL_SENTINELS = new Set(['__vesu_virtual__', '0x02']);
+const SUPPORTED_OPERATION_TYPES = new Set([
+  'AVNU_SWAP',
+  'WRITE',
+  'READ',
+  'CONDITIONAL',
+  'EVENT_WATCH',
+]);
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isOptionalString(value) {
+  return value === undefined || typeof value === 'string';
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isAbiValue(value) {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isAvnuRouted(op, addresses) {
+  const protocol = typeof op?.protocol === 'string' ? op.protocol : '';
+  return protocol.toLowerCase() === 'avnu' ||
+    AVNU_VIRTUAL_SENTINELS.has(String(addresses[op?.protocol] || '')) ||
+    AVNU_VIRTUAL_SENTINELS.has(String(op?.contractAddress || ''));
+}
+
+function hasAvnuSwapTokens(op) {
+  return isNonEmptyString(op?.tokenIn) && isNonEmptyString(op?.tokenOut);
+}
+
+function emitInvalidParsedInput(result, error) {
+  console.log(JSON.stringify({
+    ...result,
+    success: false,
+    canProceed: false,
+    nextStep: 'INVALID_PARSED_INPUT',
+    error,
+  }));
+  process.exit(1);
+}
 
 // ============ LOOT SURVIVOR LATEST ADVENTURER (LOCAL UX STATE) ============
 // We intentionally do NOT scan chain/indexers for "latest adventurer".
@@ -415,39 +460,51 @@ async function main() {
       orchestration: [{ step: 0, name: "Using LLM-parsed data" }]
     };
     
-    const { operations = [], operationType, abis = {}, addresses = {} } = parsed;
-    const operationsValid = Array.isArray(operations) &&
-      operations.every((op) => op !== null && typeof op === "object" && !Array.isArray(op));
-    const abisValid = abis !== null && typeof abis === "object" && !Array.isArray(abis);
-    const addressesValid = addresses !== null && typeof addresses === "object" && !Array.isArray(addresses);
-    if (!operationsValid || !abisValid || !addressesValid) {
-      console.log(JSON.stringify({
-        ...result,
-        success: false,
-        canProceed: false,
-        nextStep: "INVALID_PARSED_INPUT",
-        error: "parsed.operations must be an array of objects and parsed.abis/addresses must be objects"
-      }));
-      process.exit(1);
+    if (!isPlainObject(parsed)) {
+      emitInvalidParsedInput(result, "parsed must be a non-null object");
     }
-    if (operationType === "AVNU_SWAP") {
-      const swapOp = operations[0];
-      if (
-        !swapOp ||
-        typeof swapOp.tokenIn !== "string" ||
-        swapOp.tokenIn.length === 0 ||
-        typeof swapOp.tokenOut !== "string" ||
-        swapOp.tokenOut.length === 0
-      ) {
-        console.log(JSON.stringify({
-          ...result,
-          success: false,
-          canProceed: false,
-          nextStep: "INVALID_PARSED_INPUT",
-          error: "parsed.operations[0] must include non-empty tokenIn and tokenOut for AVNU_SWAP"
-        }));
-        process.exit(1);
-      }
+
+    const { operations = [], operationType, abis = {}, addresses = {} } = parsed;
+    if (!SUPPORTED_OPERATION_TYPES.has(operationType)) {
+      emitInvalidParsedInput(result, "parsed.operationType must be one of AVNU_SWAP, WRITE, READ, CONDITIONAL, EVENT_WATCH");
+    }
+
+    const operationsValid = Array.isArray(operations) && operations.every((op) =>
+      isPlainObject(op) &&
+      isOptionalString(op.protocol) &&
+      isOptionalString(op.action) &&
+      isOptionalString(op.contractAddress)
+    );
+    const abisValid = isPlainObject(abis) && Object.values(abis).every(isAbiValue);
+    const addressesValid = isPlainObject(addresses);
+    const watchers = parsed.watchers;
+    const watchersValid = watchers === undefined || (
+      Array.isArray(watchers) &&
+      watchers.every((w) =>
+        isPlainObject(w) &&
+        isOptionalString(w.protocol) &&
+        isOptionalString(w.action) &&
+        isOptionalString(w.eventName)
+      )
+    );
+    if (!operationsValid || !abisValid || !addressesValid || !watchersValid) {
+      emitInvalidParsedInput(
+        result,
+        "parsed.operations must be objects with string identifiers, parsed.abis values must be string arrays, parsed.addresses must be an object, and parsed.watchers must be an array of objects when present"
+      );
+    }
+    if (operationType === "AVNU_SWAP" && !hasAvnuSwapTokens(operations[0])) {
+      emitInvalidParsedInput(result, "parsed.operations[0] must include non-empty tokenIn and tokenOut for AVNU_SWAP");
+    }
+    if (operationType === "WRITE" && operations.some((op) => isAvnuRouted(op, addresses) && !hasAvnuSwapTokens(op))) {
+      emitInvalidParsedInput(result, "AVNU WRITE operations must include non-empty tokenIn and tokenOut");
+    }
+    if (
+      operationType === "CONDITIONAL" &&
+      Array.isArray(watchers) &&
+      watchers.some((w) => w.action && w.action !== "watch" && isAvnuRouted(w, addresses) && !hasAvnuSwapTokens(w))
+    ) {
+      emitInvalidParsedInput(result, "AVNU CONDITIONAL actions must include non-empty tokenIn and tokenOut");
     }
     
     result.parsed = parsed;

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -416,6 +416,18 @@ async function main() {
     };
     
     const { operations = [], operationType, abis = {}, addresses = {} } = parsed;
+    const abisValid = abis !== null && typeof abis === "object" && !Array.isArray(abis);
+    const addressesValid = addresses !== null && typeof addresses === "object" && !Array.isArray(addresses);
+    if (!Array.isArray(operations) || !abisValid || !addressesValid) {
+      console.log(JSON.stringify({
+        ...result,
+        success: false,
+        canProceed: false,
+        nextStep: "INVALID_PARSED_INPUT",
+        error: "parsed.operations must be an array and parsed.abis/addresses must be objects"
+      }));
+      process.exit(1);
+    }
     
     result.parsed = parsed;
     result.operationType = operationType;

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -428,6 +428,16 @@ async function main() {
       }));
       process.exit(1);
     }
+    if (operationType === "AVNU_SWAP" && operations.length === 0) {
+      console.log(JSON.stringify({
+        ...result,
+        success: false,
+        canProceed: false,
+        nextStep: "INVALID_PARSED_INPUT",
+        error: "parsed.operations must contain at least one swap operation for AVNU_SWAP"
+      }));
+      process.exit(1);
+    }
     
     result.parsed = parsed;
     result.operationType = operationType;

--- a/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/resolve-smart.js
@@ -416,27 +416,38 @@ async function main() {
     };
     
     const { operations = [], operationType, abis = {}, addresses = {} } = parsed;
+    const operationsValid = Array.isArray(operations) &&
+      operations.every((op) => op !== null && typeof op === "object" && !Array.isArray(op));
     const abisValid = abis !== null && typeof abis === "object" && !Array.isArray(abis);
     const addressesValid = addresses !== null && typeof addresses === "object" && !Array.isArray(addresses);
-    if (!Array.isArray(operations) || !abisValid || !addressesValid) {
+    if (!operationsValid || !abisValid || !addressesValid) {
       console.log(JSON.stringify({
         ...result,
         success: false,
         canProceed: false,
         nextStep: "INVALID_PARSED_INPUT",
-        error: "parsed.operations must be an array and parsed.abis/addresses must be objects"
+        error: "parsed.operations must be an array of objects and parsed.abis/addresses must be objects"
       }));
       process.exit(1);
     }
-    if (operationType === "AVNU_SWAP" && operations.length === 0) {
-      console.log(JSON.stringify({
-        ...result,
-        success: false,
-        canProceed: false,
-        nextStep: "INVALID_PARSED_INPUT",
-        error: "parsed.operations must contain at least one swap operation for AVNU_SWAP"
-      }));
-      process.exit(1);
+    if (operationType === "AVNU_SWAP") {
+      const swapOp = operations[0];
+      if (
+        !swapOp ||
+        typeof swapOp.tokenIn !== "string" ||
+        swapOp.tokenIn.length === 0 ||
+        typeof swapOp.tokenOut !== "string" ||
+        swapOp.tokenOut.length === 0
+      ) {
+        console.log(JSON.stringify({
+          ...result,
+          success: false,
+          canProceed: false,
+          nextStep: "INVALID_PARSED_INPUT",
+          error: "parsed.operations[0] must include non-empty tokenIn and tokenOut for AVNU_SWAP"
+        }));
+        process.exit(1);
+      }
     }
     
     result.parsed = parsed;

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -11,7 +11,7 @@
  *   "contractAddress": "0x...", 
  *   "eventNames": ["JobListed"],
  *   "pollIntervalMs": 3000, // fallback polling interval
- *   "webhookUrl": "http://localhost:3000/webhook", // optional
+ *   "webhookUrl": "http://localhost:3000/webhook", // optional (CLI JSON / WEBHOOK_URL env)
  *   "schedule": { // optional - creates cron job
  *     "enabled": true,
  *     "name": "ekubo-swap-monitor"
@@ -89,7 +89,7 @@ function toWebhookPayload(data) {
     contractAddress: String(data?.contractAddress || ''),
     keys,
     data: eventData,
-    eventName: String(data?.eventName || 'unknown')
+    selector: String(data?.selector || '')
   });
 }
 
@@ -131,6 +131,8 @@ function createCronJob(config) {
   // Keep durationMs if it exists (for TTL handling), only remove schedule metadata
   const scheduleInfo = execConfig.schedule;
   delete execConfig.schedule;
+  const scheduledWebhookUrl = sanitizeWebhookUrl(execConfig.webhookUrl);
+  delete execConfig.webhookUrl;
   
   // If duration was specified, add it to execConfig so the watcher knows when to self-destruct
   if (scheduleInfo?.durationMs) {
@@ -141,10 +143,13 @@ function createCronJob(config) {
 
   const scriptPath = new URL(import.meta.url).pathname;
   const shellQuote = (value) => `'${String(value).replace(/'/g, `'"'"'`)}'`;
+  const webhookExport = scheduledWebhookUrl
+    ? `export WEBHOOK_URL=${shellQuote(scheduledWebhookUrl)}\n`
+    : '';
 
   const shellScript = `#!/bin/bash
 cd "$(dirname "$0")"
-LOCKFILE=${shellQuote(`${configPath}.lock`)}
+${webhookExport}LOCKFILE=${shellQuote(`${configPath}.lock`)}
 exec flock -n "$LOCKFILE" node ${shellQuote(scriptPath)} ${shellQuote(`@${configPath}`)}
 `;
   const shellPath = join(cronDir, `${jobName}.sh`);
@@ -206,7 +211,7 @@ function deriveWebSocketUrl(httpUrl) {
 
 // Unified Event Watcher with mode switching
 class SmartEventWatcher {
-  constructor(config) {
+  constructor(config, webhookUrl) {
     this.config = config;
     const rpcUrl = config.httpRpcUrl || resolveRpcUrl();
     this.httpUrl = rpcUrl;
@@ -215,7 +220,7 @@ class SmartEventWatcher {
     this.pollIntervalMs = config.pollIntervalMs || DEFAULT_POLL_INTERVAL;
     this.healthCheckIntervalMs = config.healthCheckIntervalMs || DEFAULT_HEALTH_CHECK_INTERVAL;
     this.webhookTimeoutMs = config.webhookTimeoutMs || DEFAULT_WEBHOOK_TIMEOUT_MS;
-    this.webhookUrl = sanitizeWebhookUrl(config.webhookUrl);
+    this.webhookUrl = sanitizeWebhookUrl(webhookUrl);
     this.contractAddress = config.contractAddress;
     this.eventNames = config.eventNames || [];
     this.forcedMode = config.mode || 'auto'; // 'auto', 'websocket', 'polling'
@@ -642,6 +647,7 @@ class SmartEventWatcher {
       }
     }
 
+    const selector = keys[0];
     const eventData = {
       type: 'event',
       source,
@@ -651,13 +657,24 @@ class SmartEventWatcher {
       contractAddress: event.from_address || event.contractAddress,
       keys,
       data: event.data,
-      eventName: this.getEventName(keys[0])
+      eventName: this.getEventName(selector),
+      selector
     };
     
     logEvent(eventData);
     
     if (this.webhookUrl) {
-      sendWebhook(this.webhookUrl, eventData, this.webhookTimeoutMs).catch(() => {});
+      sendWebhook(this.webhookUrl, {
+        type: eventData.type,
+        source: eventData.source,
+        timestamp: eventData.timestamp,
+        blockNumber: eventData.blockNumber,
+        transactionHash: eventData.transactionHash,
+        contractAddress: eventData.contractAddress,
+        keys: eventData.keys,
+        data: eventData.data,
+        selector: eventData.selector
+      }, this.webhookTimeoutMs).catch(() => {});
     }
   }
 
@@ -722,9 +739,9 @@ class SmartEventWatcher {
 
 // Main
 async function main() {
-  let rawInput = process.argv[2];
+  const cliArg = process.argv[2];
   
-  if (!rawInput) {
+  if (!cliArg) {
     console.error(JSON.stringify({
       error: 'No input provided',
       usage: 'node watch-events-smart.js \'{ "contractAddress": "0x...", "eventNames": ["Swapped"] }\''
@@ -732,19 +749,32 @@ async function main() {
     process.exit(1);
   }
 
-  let configPath = null;
-  if (rawInput.startsWith('@')) {
-    configPath = rawInput.slice(1);
-    rawInput = readFileSync(configPath, 'utf8');
-  }
-  
   let config;
-  try {
-    config = JSON.parse(rawInput);
-  } catch (err) {
-    const source = configPath ? `config file ${configPath}` : 'input argument';
-    console.error(JSON.stringify({ error: `Invalid JSON in ${source}: ${err.message}` }));
-    process.exit(1);
+  let configPath = null;
+  // File-backed cron configs must not supply the webhook URL; use WEBHOOK_URL
+  // (exported by the cron wrapper) so file bytes never reach fetch().
+  let webhookUrl = sanitizeWebhookUrl(process.env.WEBHOOK_URL);
+
+  if (cliArg.startsWith('@')) {
+    configPath = cliArg.slice(1);
+    try {
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+    } catch (err) {
+      console.error(JSON.stringify({ error: `Invalid JSON in config file ${configPath}: ${err.message}` }));
+      process.exit(1);
+    }
+  } else {
+    let argvConfig;
+    try {
+      argvConfig = JSON.parse(cliArg);
+    } catch (err) {
+      console.error(JSON.stringify({ error: `Invalid JSON in input argument: ${err.message}` }));
+      process.exit(1);
+    }
+    config = argvConfig;
+    if (!webhookUrl) {
+      webhookUrl = sanitizeWebhookUrl(argvConfig.webhookUrl);
+    }
   }
 
   // Remember config path/job name when started from cron
@@ -778,7 +808,7 @@ async function main() {
     }
   }
   
-  const watcher = new SmartEventWatcher(config);
+  const watcher = new SmartEventWatcher(config, webhookUrl);
   
   process.on('SIGINT', () => watcher.stop());
   process.on('SIGTERM', () => watcher.stop());

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -153,7 +153,7 @@ ${webhookExport}LOCKFILE=${shellQuote(`${configPath}.lock`)}
 exec flock -n "$LOCKFILE" node ${shellQuote(scriptPath)} ${shellQuote(`@${configPath}`)}
 `;
   const shellPath = join(cronDir, `${jobName}.sh`);
-  writeFileSync(shellPath, shellScript, { mode: 0o755 });
+  writeFileSync(shellPath, shellScript, { mode: 0o700 });
 
   const cronEntry = `* * * * * ${shellPath} >> ${join(cronDir, `${jobName}.log`)} 2>&1`;
   
@@ -789,7 +789,7 @@ async function main() {
   }
 
   if (config.schedule?.enabled) {
-    const result = createCronJob(config);
+    const result = createCronJob({ ...config, webhookUrl });
     if (result.success) {
       console.log(JSON.stringify({
         type: 'cron-scheduled',

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -833,7 +833,20 @@ async function main() {
       process.exit(1);
     }
     config = argvConfig;
-    webhookUrl = sanitizeWebhookUrl(argvConfig.webhookUrl) || sanitizeWebhookUrl(process.env.WEBHOOK_URL);
+    if (Object.prototype.hasOwnProperty.call(argvConfig, 'webhookUrl')) {
+      const rawWebhookUrl = argvConfig.webhookUrl;
+      if (rawWebhookUrl === undefined || rawWebhookUrl === null || rawWebhookUrl === '') {
+        webhookUrl = null;
+      } else {
+        webhookUrl = sanitizeWebhookUrl(rawWebhookUrl);
+        if (!webhookUrl) {
+          console.error(JSON.stringify({ error: 'Invalid webhookUrl in input argument' }));
+          process.exit(1);
+        }
+      }
+    } else {
+      webhookUrl = sanitizeWebhookUrl(process.env.WEBHOOK_URL);
+    }
   }
 
   const parsedEventNames = parseConfiguredEventNames(config.eventNames);

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -92,6 +92,31 @@ function copyIdentifier(value) {
   return out;
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseConfiguredEventNames(eventNames) {
+  if (eventNames === undefined) {
+    return { ok: true, names: [] };
+  }
+  if (!Array.isArray(eventNames)) {
+    return { ok: false, error: '"eventNames" must be an array of identifiers' };
+  }
+  const names = [];
+  for (const raw of eventNames) {
+    const name = copyIdentifier(raw);
+    if (!name) {
+      return {
+        ok: false,
+        error: `"eventNames" contains an invalid identifier: ${JSON.stringify(raw)}`,
+      };
+    }
+    names.push(name);
+  }
+  return { ok: true, names };
+}
+
 function toFiniteNumberOrNull(value) {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -248,9 +273,11 @@ class SmartEventWatcher {
     this.webhookTimeoutMs = config.webhookTimeoutMs || DEFAULT_WEBHOOK_TIMEOUT_MS;
     this.webhookUrl = sanitizeWebhookUrl(webhookUrl);
     this.contractAddress = config.contractAddress;
-    this.eventNames = Array.isArray(config.eventNames)
-      ? config.eventNames.map(copyIdentifier).filter(Boolean)
-      : [];
+    const parsedEventNames = parseConfiguredEventNames(config.eventNames);
+    if (!parsedEventNames.ok) {
+      throw new Error(parsedEventNames.error);
+    }
+    this.eventNames = parsedEventNames.names;
     this.forcedMode = config.mode || 'auto'; // 'auto', 'websocket', 'polling'
     this.currentMode = 'initializing';
     this.isShuttingDown = false;
@@ -779,6 +806,10 @@ async function main() {
       console.error(JSON.stringify({ error: `Invalid JSON in config file ${configPath}: ${err.message}` }));
       process.exit(1);
     }
+    if (!isPlainObject(config)) {
+      console.error(JSON.stringify({ error: `Invalid JSON in config file ${configPath}: expected a non-null object` }));
+      process.exit(1);
+    }
     // File-backed cron configs must not supply the webhook URL; use WEBHOOK_URL
     // (exported by the cron wrapper) so file bytes never reach fetch().
     webhookUrl = sanitizeWebhookUrl(process.env.WEBHOOK_URL);
@@ -797,9 +828,20 @@ async function main() {
       console.error(JSON.stringify({ error: `Invalid JSON in input argument: ${err.message}` }));
       process.exit(1);
     }
+    if (!isPlainObject(argvConfig)) {
+      console.error(JSON.stringify({ error: 'Invalid JSON in input argument: expected a non-null object' }));
+      process.exit(1);
+    }
     config = argvConfig;
     webhookUrl = sanitizeWebhookUrl(argvConfig.webhookUrl) || sanitizeWebhookUrl(process.env.WEBHOOK_URL);
   }
+
+  const parsedEventNames = parseConfiguredEventNames(config.eventNames);
+  if (!parsedEventNames.ok) {
+    console.error(JSON.stringify({ error: parsedEventNames.error }));
+    process.exit(1);
+  }
+  config.eventNames = parsedEventNames.names;
 
   // Remember config path/job name when started from cron
   if (configPath) {
@@ -832,7 +874,13 @@ async function main() {
     }
   }
   
-  const watcher = new SmartEventWatcher(config, webhookUrl);
+  let watcher;
+  try {
+    watcher = new SmartEventWatcher(config, webhookUrl);
+  } catch (err) {
+    console.error(JSON.stringify({ error: err.message }));
+    process.exit(1);
+  }
   
   process.on('SIGINT', () => watcher.stop());
   process.on('SIGTERM', () => watcher.stop());

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -51,15 +51,58 @@ function logEvent(eventData) {
   console.log(JSON.stringify(eventData));
 }
 
+const MAX_WEBHOOK_URL_LENGTH = 2048;
+
+/**
+ * Allow only http(s) webhook URLs and rebuild them from parsed parts.
+ * Blocks credentials, non-http schemes, and oversized values (SSRF hardening).
+ */
+function sanitizeWebhookUrl(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_WEBHOOK_URL_LENGTH) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return null;
+  }
+  if (parsed.username !== '' || parsed.password !== '') {
+    return null;
+  }
+  const path = parsed.pathname || '/';
+  return parsed.protocol + '//' + parsed.host + path + parsed.search;
+}
+
+function toWebhookPayload(data) {
+  const keys = Array.isArray(data?.keys) ? data.keys.map((key) => String(key)) : [];
+  const eventData = Array.isArray(data?.data) ? data.data.map((item) => String(item)) : [];
+  return JSON.stringify({
+    type: String(data?.type || 'event'),
+    source: String(data?.source || ''),
+    timestamp: String(data?.timestamp || ''),
+    blockNumber: Number(data?.blockNumber) || 0,
+    transactionHash: String(data?.transactionHash || ''),
+    contractAddress: String(data?.contractAddress || ''),
+    keys,
+    data: eventData,
+    eventName: String(data?.eventName || 'unknown')
+  });
+}
+
 async function sendWebhook(webhookUrl, data, timeoutMs = DEFAULT_WEBHOOK_TIMEOUT_MS) {
-  if (!webhookUrl) return;
+  const safeUrl = sanitizeWebhookUrl(webhookUrl);
+  if (!safeUrl) return;
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    await fetch(webhookUrl, {
+    await fetch(safeUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: toWebhookPayload(data),
       signal: controller.signal
     });
   } catch (err) {
@@ -172,7 +215,7 @@ class SmartEventWatcher {
     this.pollIntervalMs = config.pollIntervalMs || DEFAULT_POLL_INTERVAL;
     this.healthCheckIntervalMs = config.healthCheckIntervalMs || DEFAULT_HEALTH_CHECK_INTERVAL;
     this.webhookTimeoutMs = config.webhookTimeoutMs || DEFAULT_WEBHOOK_TIMEOUT_MS;
-    this.webhookUrl = config.webhookUrl || null;
+    this.webhookUrl = sanitizeWebhookUrl(config.webhookUrl);
     this.contractAddress = config.contractAddress;
     this.eventNames = config.eventNames || [];
     this.forcedMode = config.mode || 'auto'; // 'auto', 'websocket', 'polling'

--- a/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
+++ b/skills/starknet-anonymous-wallet/scripts/watch-events-smart.js
@@ -11,7 +11,7 @@
  *   "contractAddress": "0x...", 
  *   "eventNames": ["JobListed"],
  *   "pollIntervalMs": 3000, // fallback polling interval
- *   "webhookUrl": "http://localhost:3000/webhook", // optional (CLI JSON / WEBHOOK_URL env)
+ *   "webhookUrl": "http://localhost:3000/webhook", // CLI JSON only; file-backed cron uses WEBHOOK_URL
  *   "schedule": { // optional - creates cron job
  *     "enabled": true,
  *     "name": "ekubo-swap-monitor"
@@ -26,7 +26,7 @@
 import { RpcProvider, hash } from 'starknet';
 import { WebSocket } from 'ws';
 import { execSync, execFileSync } from 'child_process';
-import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, mkdtempSync, rmSync, openSync, fstatSync, closeSync, constants as fsConstants } from 'fs';
+import { writeFileSync, chmodSync, mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, mkdtempSync, rmSync, openSync, fstatSync, closeSync, constants as fsConstants } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join, basename } from 'path';
 
@@ -55,7 +55,8 @@ const MAX_WEBHOOK_URL_LENGTH = 2048;
 
 /**
  * Allow only http(s) webhook URLs and rebuild them from parsed parts.
- * Blocks credentials, non-http schemes, and oversized values (SSRF hardening).
+ * Blocks credentials in the URL, non-http(s) schemes, and oversized values.
+ * Does not block private, link-local, or loopback destinations.
  */
 function sanitizeWebhookUrl(value) {
   if (typeof value !== 'string' || value.length === 0 || value.length > MAX_WEBHOOK_URL_LENGTH) {
@@ -77,18 +78,42 @@ function sanitizeWebhookUrl(value) {
   return parsed.protocol + '//' + parsed.host + path + parsed.search;
 }
 
+function copyIdentifier(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 128) {
+    return '';
+  }
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    const ok = (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || (c >= 48 && c <= 57) || c === 95;
+    if (!ok) return '';
+    out += String.fromCharCode(c);
+  }
+  return out;
+}
+
+function toFiniteNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 function toWebhookPayload(data) {
   const keys = Array.isArray(data?.keys) ? data.keys.map((key) => String(key)) : [];
   const eventData = Array.isArray(data?.data) ? data.data.map((item) => String(item)) : [];
+  const blockNumber = toFiniteNumberOrNull(data?.blockNumber);
   return JSON.stringify({
     type: String(data?.type || 'event'),
     source: String(data?.source || ''),
     timestamp: String(data?.timestamp || ''),
-    blockNumber: Number(data?.blockNumber) || 0,
+    blockNumber,
     transactionHash: String(data?.transactionHash || ''),
     contractAddress: String(data?.contractAddress || ''),
     keys,
     data: eventData,
+    eventName: copyIdentifier(data?.eventName) || 'unknown',
     selector: String(data?.selector || '')
   });
 }
@@ -154,6 +179,7 @@ exec flock -n "$LOCKFILE" node ${shellQuote(scriptPath)} ${shellQuote(`@${config
 `;
   const shellPath = join(cronDir, `${jobName}.sh`);
   writeFileSync(shellPath, shellScript, { mode: 0o700 });
+  chmodSync(shellPath, 0o700);
 
   const cronEntry = `* * * * * ${shellPath} >> ${join(cronDir, `${jobName}.log`)} 2>&1`;
   
@@ -222,7 +248,9 @@ class SmartEventWatcher {
     this.webhookTimeoutMs = config.webhookTimeoutMs || DEFAULT_WEBHOOK_TIMEOUT_MS;
     this.webhookUrl = sanitizeWebhookUrl(webhookUrl);
     this.contractAddress = config.contractAddress;
-    this.eventNames = config.eventNames || [];
+    this.eventNames = Array.isArray(config.eventNames)
+      ? config.eventNames.map(copyIdentifier).filter(Boolean)
+      : [];
     this.forcedMode = config.mode || 'auto'; // 'auto', 'websocket', 'polling'
     this.currentMode = 'initializing';
     this.isShuttingDown = false;
@@ -664,17 +692,7 @@ class SmartEventWatcher {
     logEvent(eventData);
     
     if (this.webhookUrl) {
-      sendWebhook(this.webhookUrl, {
-        type: eventData.type,
-        source: eventData.source,
-        timestamp: eventData.timestamp,
-        blockNumber: eventData.blockNumber,
-        transactionHash: eventData.transactionHash,
-        contractAddress: eventData.contractAddress,
-        keys: eventData.keys,
-        data: eventData.data,
-        selector: eventData.selector
-      }, this.webhookTimeoutMs).catch(() => {});
+      sendWebhook(this.webhookUrl, eventData, this.webhookTimeoutMs).catch(() => {});
     }
   }
 
@@ -751,9 +769,7 @@ async function main() {
 
   let config;
   let configPath = null;
-  // File-backed cron configs must not supply the webhook URL; use WEBHOOK_URL
-  // (exported by the cron wrapper) so file bytes never reach fetch().
-  let webhookUrl = sanitizeWebhookUrl(process.env.WEBHOOK_URL);
+  let webhookUrl = null;
 
   if (cliArg.startsWith('@')) {
     configPath = cliArg.slice(1);
@@ -762,6 +778,16 @@ async function main() {
     } catch (err) {
       console.error(JSON.stringify({ error: `Invalid JSON in config file ${configPath}: ${err.message}` }));
       process.exit(1);
+    }
+    // File-backed cron configs must not supply the webhook URL; use WEBHOOK_URL
+    // (exported by the cron wrapper) so file bytes never reach fetch().
+    webhookUrl = sanitizeWebhookUrl(process.env.WEBHOOK_URL);
+    if (typeof config.webhookUrl === 'string' && config.webhookUrl.length > 0) {
+      if (webhookUrl) {
+        log('config file webhookUrl is ignored; using WEBHOOK_URL from the environment', 'warn');
+      } else {
+        log('config file webhookUrl is ignored and WEBHOOK_URL is unset; webhook delivery disabled. Export WEBHOOK_URL in the cron wrapper (new jobs do this automatically)', 'warn');
+      }
     }
   } else {
     let argvConfig;
@@ -772,9 +798,7 @@ async function main() {
       process.exit(1);
     }
     config = argvConfig;
-    if (!webhookUrl) {
-      webhookUrl = sanitizeWebhookUrl(argvConfig.webhookUrl);
-    }
+    webhookUrl = sanitizeWebhookUrl(argvConfig.webhookUrl) || sanitizeWebhookUrl(process.env.WEBHOOK_URL);
   }
 
   // Remember config path/job name when started from cron

--- a/skills/starknet-mini-pay/requirements.txt
+++ b/skills/starknet-mini-pay/requirements.txt
@@ -5,7 +5,7 @@ starknet-py>=0.6.0
 
 # QR Code generation
 qrcode[pil]>=7.4.2
-Pillow>=12.2.0
+Pillow>=12.3.0
 
 # Telegram Bot
 python-telegram-bot>=20.0

--- a/tools/ajv-cli/package-lock.json
+++ b/tools/ajv-cli/package-lock.json
@@ -170,9 +170,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/tools/ajv-cli/package.json
+++ b/tools/ajv-cli/package.json
@@ -9,7 +9,7 @@
   "overrides": {
     "fast-json-patch": "^3.1.1",
     "fast-uri": "^3.1.5",
-    "js-yaml": "^3.15.0",
+    "js-yaml": "^3.15.1",
     "brace-expansion": "^1.1.18"
   }
 }


### PR DESCRIPTION
## Summary
- Close the remaining Dependabot alert (`js-yaml` < 3.15.1 in `tools/ajv-cli`) and raise the Pillow floor to `>=12.3.0` for the Scorecard OSV findings.
- Fix CodeQL unused-code and trivial-conditional alerts in `resolve-smart.js` / `credentials.ts`.
- Harden skill-file downloads (GitHub host allowlist, skills-tree path check, streamed size limit, no redirect follow) and webhook POSTs (http(s)-only reconstructed URLs and primitive payloads) to address the `js/http-to-file-access` and `js/file-access-to-http` alerts.

## Breaking change: file-backed watcher webhooks
Existing cron jobs created before this PR stored `webhookUrl` in `~/.openclaw/cron/<job>.json`. That field is **ignored** so file bytes never reach `fetch()`. Delivery now requires `WEBHOOK_URL` in the environment (new jobs write this into the wrapper script). Recreate the cron job, or export `WEBHOOK_URL` in the existing `.sh` wrapper. The watcher logs a warning when a config file still contains `webhookUrl`.

CLI JSON `webhookUrl` still works and now takes precedence over a leftover `WEBHOOK_URL` env var.

Scorecard checks that need repo settings or process, not this diff: Branch-Protection, Code-Review, Fuzzing, and CII-Best-Practices. `PYSEC-2026-1325` (`ecdsa`) has no upstream patch and is not a declared Python dependency.

## Spec impact
No ABI or policy-schema change. File-backed watcher `webhookUrl` is ignored; existing cron wrappers must export `WEBHOOK_URL` or be recreated (see Breaking change above).

## Cross-repo impact
no cross-repo impact

## Test plan
- [x] `pnpm test` in `packages/create-starknet-agent` (84 tests)
- [x] `node --check` on the edited anonymous-wallet scripts
- [ ] Confirm Dependabot alert 82 and the CodeQL alerts above auto-close after this merges and scans rerun
- [ ] Confirm Scorecard Vulnerabilities drops the Pillow + js-yaml OSV IDs on the next scorecard run
- [ ] Recreate or wrap existing file-backed cron watchers so `WEBHOOK_URL` is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved `--from-env` setup messaging and credential handling, including private-key import in JSON mode.
  - Skill selection now reflects currently available skills.
  - Webhook event payloads now include event selectors.

- **Bug Fixes**
  - Strengthened skill downloads with trusted URL validation and content checks.
  - Improved webhook URL sanitization, configuration handling, and input validation.
  - Added clearer errors for invalid JSON and unsupported skill configurations.
  - Improved validation for wallet operations and swap parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
