### PR TITLE
fix(deps): dedupe browserslist to 4.28.8 to clear high-severity audit gate

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1996,11 +1996,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.6:
-    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.8:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2232,11 +2227,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.392:
-    resolution: {integrity: sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==}
-
-  electron-to-chromium@1.5.416:
-    resolution: {integrity: sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3388,10 +3380,6 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
-    engines: {node: '>=18'}
-
   node-releases@2.0.54:
     resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
@@ -4193,12 +4181,6 @@ packages:
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
-
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   update-browserslist-db@1.3.2:
     resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
@@ -5765,7 +5747,7 @@ snapshots:
 
   autoprefixer@10.5.4(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -5810,19 +5792,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.6:
-    dependencies:
-      baseline-browser-mapping: 2.11.20
-      caniuse-lite: 1.0.30001810
-      electron-to-chromium: 1.5.392
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.6)
-
   browserslist@4.28.8:
     dependencies:
       baseline-browser-mapping: 2.11.20
       caniuse-lite: 1.0.30001810
-      electron-to-chromium: 1.5.416
+      electron-to-chromium: 1.5.420
       node-releases: 2.0.54
       update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
@@ -6020,9 +5994,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.392: {}
-
-  electron-to-chromium@1.5.416: {}
+  electron-to-chromium@1.5.420: {}
 
   emoji-regex@8.0.0: {}
 
@@ -7731,8 +7703,6 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  node-releases@2.0.51: {}
-
   node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
@@ -8810,12 +8780,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
-
-  update-browserslist-db@1.2.3(browserslist@4.28.6):
-    dependencies:
-      browserslist: 4.28.6
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:


### PR DESCRIPTION
## Problem

CI has been red on `main` since two high-severity `browserslist` advisories were published. The `Enforce audit allowlist (high+)` step in the **Test** job blocks, which cascades into `All Checks Passed`:

```
audit-gate: BLOCK
- [high] 1153171 (browserslist) - Unbounded memory growth (no cache eviction) via distinct query results, leading to eventual OOM [not allowlisted]
- [high] 1153172 (browserslist) - Uncaught crash / prototype write via untrusted browserslist-stats.json custom stats (normalizeStats) [not allowlisted]
```

This is time-based, not caused by any particular commit — every push to `main` fails the same way. See [run 33594536872](https://github.com/keep-starknet-strange/starknet-agentic/actions/runs/33594536872).

## Root cause

The lockfile carried **two** `browserslist` copies:

| Version | Pulled in by | Status |
|---|---|---|
| `4.28.8` | `@babel/helper-compilation-targets` | patched |
| `4.28.6` | `autoprefixer@10.5.4` (`website/`) | **vulnerable** |

`autoprefixer@10.5.4` declares `browserslist: ^4.28.6`, so `4.28.8` satisfies it fine — the second copy was simply an undeduped pin, not a real constraint.

Dependabot opened its own security PR for this and gave up with `security_update_not_possible`, claiming `latest-resolvable-version: 4.28.6` ([run 33594547659](https://github.com/keep-starknet-strange/starknet-agentic/actions/runs/33594547659)). That's incorrect — `4.28.7` and `4.28.8` are both published and both satisfy `^4.28.6`; its resolver just didn't dedupe the transitive. Hence this manual fix.

## Change

`pnpm update browserslist -r` — lockfile only, no manifest changes. Collapses both copies onto `4.28.8`. The only other delta is the `electron-to-chromium` browser-version dataset (`1.5.416` → `1.5.420`), pulled in transitively.

No allowlist entry was added — the vulnerability is genuinely gone rather than suppressed.

## Verification

Ran locally, mirroring the Test job:

- `node scripts/security/audit-gate.mjs ... --failLevel high` → `audit-gate: PASS (0 findings at or above high)`
- Security script unit tests → 48 passed
- `pnpm run build` → all packages build
- `pnpm test` → 386 passed, 8 skipped
- `cd website && pnpm run build` → clean (this is the package that consumed the vulnerable copy)

## Note

A second Dependabot security run for `postcss-selector-parser` was in flight at the time of writing and may add a separate finding to the same gate. Worth a look after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)